### PR TITLE
Fix tracking of parser location regardless of line-ending format

### DIFF
--- a/src/lexer/comments.ts
+++ b/src/lexer/comments.ts
@@ -67,7 +67,6 @@ export function skipMultiLineComment(parser: ParserState, state: LexerState): Le
   const { index } = parser;
   while (parser.index < parser.end) {
     while (parser.currentChar === Chars.Asterisk) {
-      state &= ~LexerState.LastIsCR;
       if (advanceChar(parser) === Chars.Slash) {
         advanceChar(parser);
         if (parser.onComment)

--- a/src/lexer/common.ts
+++ b/src/lexer/common.ts
@@ -6,7 +6,6 @@ import { report, Errors } from '../errors';
 export const enum LexerState {
   None = 0,
   NewLine = 1 << 0,
-  //LastIsCR = 1 << 2 // no longer care about CR's
 }
 
 export const enum NumberKind {
@@ -42,28 +41,6 @@ export function advanceChar(parser: ParserState): number {
   }
   return parser.currentChar;
 }
-//export function advanceChar(parser: ParserState): number {
-//  parser.column++;
-//  return advanceAndLawrenceDolTheCRLF(parser);
-//}
-//
-//export function advanceAndLawrenceDolTheCRLF(parser: ParserState) {
-//  parser.currentChar = parser.source.charCodeAt(++parser.index);
-//  if (parser.index < parser.end) {
-//    const cur = parser.currentChar;
-//    const nxt = parser.source.charCodeAt(parser.index + 1);
-//    if (
-//      (cur == Chars.CarriageReturn && nxt == Chars.LineFeed) ||
-//      (cur == Chars.LineFeed && nxt == Chars.CarriageReturn)
-//    ) {
-//      parser.currentChar = Chars.LineFeed;
-//      parser.index++;
-//    } else if (cur === Chars.CarriageReturn) {
-//      parser.currentChar = Chars.LineFeed;
-//    }
-//  }
-//  return parser.currentChar;
-//}
 
 /**
  * Consumes multi unit code point
@@ -94,21 +71,6 @@ export function consumeLineBreak(parser) {
   parser.line++;
   parser.currentChar = advanceChar(parser); // important to use advanceChar() so CR/LF are handled consistently; also, col was just reset to 0, so correct for advanceChar() to do column++.
 }
-//export function consumeLineFeed(parser: ParserState, state: LexerState): void {
-//  advanceAndLawrenceDolTheCRLF(parser);
-//  parser.flags |= Flags.NewLine;
-//  if ((state & LexerState.LastIsCR) === 0) {
-//    parser.column = 0;
-//    parser.line++;
-//  }
-//}
-//
-//export function consumeLineBreak(parser: ParserState): void {
-//  parser.flags |= Flags.NewLine;
-//  parser.column = 0;
-//  parser.line++;
-//  advanceAndLawrenceDolTheCRLF(parser);
-//}
 
 // ECMA-262 11.2 White Space
 export function isExoticECMAScriptWhitespace(code: number): boolean {

--- a/src/lexer/common.ts
+++ b/src/lexer/common.ts
@@ -65,7 +65,7 @@ export function consumeMultiUnitCodePoint(parser: ParserState, hi: number): 0 | 
 /**
  * Use to consume a line feed instead of `consumeLineBreak`.
  */
-export function consumeLineBreak(parser) {
+export function consumeLineBreak(parser: ParserState): void {
   parser.flags |= Flags.NewLine;
   parser.column = 0;
   parser.line++;

--- a/src/lexer/common.ts
+++ b/src/lexer/common.ts
@@ -6,7 +6,7 @@ import { report, Errors } from '../errors';
 export const enum LexerState {
   None = 0,
   NewLine = 1 << 0,
-  LastIsCR = 1 << 2
+  //LastIsCR = 1 << 2 // no longer care about CR's
 }
 
 export const enum NumberKind {
@@ -28,26 +28,42 @@ export const enum NumberKind {
  */
 export function advanceChar(parser: ParserState): number {
   parser.column++;
-  return advanceAndLawrenceDolTheCRLF(parser);
-}
-
-export function advanceAndLawrenceDolTheCRLF(parser: ParserState) {
   parser.currentChar = parser.source.charCodeAt(++parser.index);
-  if (parser.index < parser.end) {
-    const cur = parser.currentChar;
-    const nxt = parser.source.charCodeAt(parser.index + 1);
-    if (
-      (cur == Chars.CarriageReturn && nxt == Chars.LineFeed) ||
-      (cur == Chars.LineFeed && nxt == Chars.CarriageReturn)
-    ) {
-      parser.currentChar = Chars.LineFeed;
-      parser.index++;
-    } else if (cur === Chars.CarriageReturn) {
-      parser.currentChar = Chars.LineFeed;
-    }
+
+  if(parser.index < parser.end) {
+      const cur = parser.currentChar;
+      const nxt = parser.source.charCodeAt(parser.index + 1);
+      if((cur == Chars.CarriageReturn && nxt == Chars.LineFeed) || (cur == Chars.LineFeed && nxt == Chars.CarriageReturn)) {
+          parser.currentChar = Chars.LineFeed;
+          parser.index++;
+      } else if(cur == Chars.CarriageReturn) {
+          parser.currentChar = Chars.LineFeed;
+      }
   }
   return parser.currentChar;
 }
+//export function advanceChar(parser: ParserState): number {
+//  parser.column++;
+//  return advanceAndLawrenceDolTheCRLF(parser);
+//}
+//
+//export function advanceAndLawrenceDolTheCRLF(parser: ParserState) {
+//  parser.currentChar = parser.source.charCodeAt(++parser.index);
+//  if (parser.index < parser.end) {
+//    const cur = parser.currentChar;
+//    const nxt = parser.source.charCodeAt(parser.index + 1);
+//    if (
+//      (cur == Chars.CarriageReturn && nxt == Chars.LineFeed) ||
+//      (cur == Chars.LineFeed && nxt == Chars.CarriageReturn)
+//    ) {
+//      parser.currentChar = Chars.LineFeed;
+//      parser.index++;
+//    } else if (cur === Chars.CarriageReturn) {
+//      parser.currentChar = Chars.LineFeed;
+//    }
+//  }
+//  return parser.currentChar;
+//}
 
 /**
  * Consumes multi unit code point
@@ -72,21 +88,27 @@ export function consumeMultiUnitCodePoint(parser: ParserState, hi: number): 0 | 
 /**
  * Use to consume a line feed instead of `consumeLineBreak`.
  */
-export function consumeLineFeed(parser: ParserState, state: LexerState): void {
-  advanceAndLawrenceDolTheCRLF(parser);
-  parser.flags |= Flags.NewLine;
-  if ((state & LexerState.LastIsCR) === 0) {
-    parser.column = 0;
-    parser.line++;
-  }
-}
-
-export function consumeLineBreak(parser: ParserState): void {
-  parser.flags |= Flags.NewLine;
+export function consumeLineBreak(parser) {
+  parser.flags |= 1;
   parser.column = 0;
   parser.line++;
-  advanceAndLawrenceDolTheCRLF(parser);
+  parser.currentChar = advanceChar(parser); // important to use advanceChar() so CR/LF are handled consistently; also, col was just reset to 0, so correct for advanceChar() to do column++.
 }
+//export function consumeLineFeed(parser: ParserState, state: LexerState): void {
+//  advanceAndLawrenceDolTheCRLF(parser);
+//  parser.flags |= Flags.NewLine;
+//  if ((state & LexerState.LastIsCR) === 0) {
+//    parser.column = 0;
+//    parser.line++;
+//  }
+//}
+//
+//export function consumeLineBreak(parser: ParserState): void {
+//  parser.flags |= Flags.NewLine;
+//  parser.column = 0;
+//  parser.line++;
+//  advanceAndLawrenceDolTheCRLF(parser);
+//}
 
 // ECMA-262 11.2 White Space
 export function isExoticECMAScriptWhitespace(code: number): boolean {

--- a/src/lexer/common.ts
+++ b/src/lexer/common.ts
@@ -66,7 +66,7 @@ export function consumeMultiUnitCodePoint(parser: ParserState, hi: number): 0 | 
  * Use to consume a line feed instead of `consumeLineBreak`.
  */
 export function consumeLineBreak(parser) {
-  parser.flags |= 1;
+  parser.flags |= Flags.NewLine;
   parser.column = 0;
   parser.line++;
   parser.currentChar = advanceChar(parser); // important to use advanceChar() so CR/LF are handled consistently; also, col was just reset to 0, so correct for advanceChar() to do column++.

--- a/src/lexer/common.ts
+++ b/src/lexer/common.ts
@@ -32,10 +32,10 @@ export function advanceChar(parser: ParserState): number {
   if(parser.index < parser.end) {
       const cur = parser.currentChar;
       const nxt = parser.source.charCodeAt(parser.index + 1);
-      if((cur == Chars.CarriageReturn && nxt == Chars.LineFeed) || (cur == Chars.LineFeed && nxt == Chars.CarriageReturn)) {
+      if((cur === Chars.CarriageReturn && nxt === Chars.LineFeed) || (cur === Chars.LineFeed && nxt === Chars.CarriageReturn)) {
           parser.currentChar = Chars.LineFeed;
           parser.index++;
-      } else if(cur == Chars.CarriageReturn) {
+      } else if(cur === Chars.CarriageReturn) {
           parser.currentChar = Chars.LineFeed;
       }
   }

--- a/src/lexer/common.ts
+++ b/src/lexer/common.ts
@@ -32,14 +32,18 @@ export function advanceChar(parser: ParserState): number {
   if(parser.index < parser.end) {
       const cur = parser.currentChar;
       const nxt = parser.source.charCodeAt(parser.index + 1);
-      if((cur === Chars.CarriageReturn && nxt === Chars.LineFeed) || (cur === Chars.LineFeed && nxt === Chars.CarriageReturn)) {
+      if(isLineBreakPair(cur,nxt)) {
           parser.currentChar = Chars.LineFeed;
-          parser.index++;
+          parser.index++; // skip the second char of the line-break sequence
       } else if(cur === Chars.CarriageReturn) {
-          parser.currentChar = Chars.LineFeed;
+          parser.currentChar = Chars.LineFeed; // treat lone CR as if it were LF
       }
   }
   return parser.currentChar;
+}
+
+function isLineBreakPair(cur,nxt) {
+    return (cur === Chars.CarriageReturn && nxt === Chars.LineFeed) || (cur === Chars.LineFeed && nxt === Chars.CarriageReturn);
 }
 
 /**

--- a/src/lexer/index.ts
+++ b/src/lexer/index.ts
@@ -12,7 +12,6 @@ export {
   isExoticECMAScriptWhitespace,
   fromCodePoint,
   toHex,
-  //consumeLineFeed,
   consumeLineBreak,
   LexerState,
   NumberKind

--- a/src/lexer/index.ts
+++ b/src/lexer/index.ts
@@ -12,7 +12,7 @@ export {
   isExoticECMAScriptWhitespace,
   fromCodePoint,
   toHex,
-  consumeLineFeed,
+  //consumeLineFeed,
   consumeLineBreak,
   LexerState,
   NumberKind

--- a/src/lexer/scan.ts
+++ b/src/lexer/scan.ts
@@ -21,7 +21,7 @@ import {
   scanIdentifierSlowCase,
   scanPrivateName,
   fromCodePoint,
-  consumeLineFeed,
+  //consumeLineFeed,
   consumeLineBreak
 } from './';
 
@@ -534,14 +534,20 @@ export function scanSingleToken(parser: ParserState, context: Context, state: Le
           break;
 
         case Token.CarriageReturn:
+        case Token.LineFeed:
           consumeLineBreak(parser);
           state |= LexerState.NewLine;
           break;
 
-        case Token.LineFeed:
-          consumeLineFeed(parser, state);
-          state = (state & ~LexerState.LastIsCR) | LexerState.NewLine;
-          break;
+        // Now we only handle "line breaks", regardless of whether indicated by CR, CRLF, LF, or LFCR.
+        //case Token.CarriageReturn:
+        //  consumeLineBreak(parser);
+        //  state |= LexerState.NewLine;
+        //  break;
+        //case Token.LineFeed:
+        //  consumeLineFeed(parser, state);
+        //  state = (state & ~LexerState.LastIsCR) | LexerState.NewLine;
+        //  break;
 
         default:
         // unreachable

--- a/src/lexer/scan.ts
+++ b/src/lexer/scan.ts
@@ -33,8 +33,7 @@ import {
  * StringLiteral:    34, 39: '"', `'`
  * NumericLiteral:   48, 49..57: '0'..'9'
  * WhiteSpace:       9, 11, 12, 32: '\t', '\v', '\f', ' '
- * LineFeed:         10: '\n'
- * CarriageReturn:   13: '\r'
+ * LineBreak:        10, 13: '\n', '\r'
  * Template:         96: '`'
  */
 
@@ -49,10 +48,10 @@ export const TokenLookup = [
   /*   7 - Bell               */ Token.Illegal,
   /*   8 - Backspace          */ Token.Illegal,
   /*   9 - Horizontal Tab     */ Token.WhiteSpace,
-  /*  10 - Line Feed          */ Token.LineFeed,
+  /*  10 - Line Feed          */ Token.LineBreak,
   /*  11 - Vertical Tab       */ Token.WhiteSpace,
   /*  12 - Form Feed          */ Token.WhiteSpace,
-  /*  13 - Carriage Return    */ Token.CarriageReturn,
+  /*  13 - Carriage Return    */ Token.LineBreak,
   /*  14 - Shift Out          */ Token.Illegal,
   /*  15 - Shift In           */ Token.Illegal,
   /*  16 - Data Line Escape   */ Token.Illegal,
@@ -532,8 +531,7 @@ export function scanSingleToken(parser: ParserState, context: Context, state: Le
           advanceChar(parser);
           break;
 
-        case Token.CarriageReturn:
-        case Token.LineFeed:
+        case Token.LineBreak:
           consumeLineBreak(parser);
           state |= LexerState.NewLine;
           break;

--- a/src/lexer/scan.ts
+++ b/src/lexer/scan.ts
@@ -21,7 +21,6 @@ import {
   scanIdentifierSlowCase,
   scanPrivateName,
   fromCodePoint,
-  //consumeLineFeed,
   consumeLineBreak
 } from './';
 
@@ -538,16 +537,6 @@ export function scanSingleToken(parser: ParserState, context: Context, state: Le
           consumeLineBreak(parser);
           state |= LexerState.NewLine;
           break;
-
-        // Now we only handle "line breaks", regardless of whether indicated by CR, CRLF, LF, or LFCR.
-        //case Token.CarriageReturn:
-        //  consumeLineBreak(parser);
-        //  state |= LexerState.NewLine;
-        //  break;
-        //case Token.LineFeed:
-        //  consumeLineFeed(parser, state);
-        //  state = (state & ~LexerState.LastIsCR) | LexerState.NewLine;
-        //  break;
 
         default:
         // unreachable

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -69,7 +69,7 @@ export function create(source: string, sourceFile: string | void, onComment: OnC
     /**
      * Beginning of current line
      */
-    line: 1,
+    line: 0, // Without initializing to 0 I consistently get the line out by +1; but this surprises me.
 
     /**
      * Beginning of current column


### PR DESCRIPTION
Abstract the handling of a line break to be agnostic of whether the sequence is any of CR,CRLF, LF, or LFCR.