### PR TITLE
Add onToken - based on Cherow

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,11 @@ This is the available options:
   // The flag to enable implied strict mode
   impliedStrict: false;
 
-  // Allowes comment extraction. Accepts either a function or array
+  // Allows comment extraction. Accepts either a function or array
   onComment: []
+
+  // Allows token extraction. Accepts either a function or array
+  onToken: []
 
   // Enable non-standard parenthesized expression node
   preserveParens: false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "meriyah",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/common.ts
+++ b/src/common.ts
@@ -171,6 +171,11 @@ export const enum ScopeKind {
 export type OnComment = void | Comment[] | ((type: string, value: string, start?: number, end?: number) => any);
 
 /**
+ * The type of the `onToken` option.
+ */
+export type OnToken = void | Token[] | ((token: Token, start?: number, end?: number) => any);
+
+/**
  * Lexical scope interface
  */
 export interface ScopeState {
@@ -206,6 +211,7 @@ export interface ParserState {
   end: number;
   token: Token;
   onComment: any;
+  onToken: any;
   tokenValue: any;
   tokenRaw: string;
   tokenRegExp: void | {
@@ -768,6 +774,20 @@ export function pushComment(context: Context, array: any[]): any {
       comment.end = end;
     }
     array.push(comment);
+  };
+}
+
+export function pushToken(context: Context, array: any[]): any {
+  return function(token: string, start: number, end: number) {
+    const tokens: any = {
+      token
+    };
+
+    if (context & Context.OptionsLoc) {
+      tokens.start = start;
+      tokens.end = end;
+    }
+    array.push(tokens);
   };
 }
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -173,7 +173,7 @@ export type OnComment = void | Comment[] | ((type: string, value: string, start?
 /**
  * The type of the `onToken` option.
  */
-export type OnToken = void | Token[] | ((token: Token, start?: number, end?: number) => any);
+export type OnToken = void | Token[] | ((token: string, start?: number, end?: number) => any);
 
 /**
  * Lexical scope interface

--- a/src/lexer/common.ts
+++ b/src/lexer/common.ts
@@ -1,3 +1,4 @@
+import { Token } from '../token';
 import { Chars } from '../chars';
 import { ParserState, Flags } from '../common';
 import { unicodeLookup } from '../unicode';
@@ -129,4 +130,36 @@ export function fromCodePoint(codePoint: number): string {
  */
 export function toHex(code: number): number {
   return code < Chars.UpperA ? code - Chars.Zero : (code - Chars.UpperA + 10) & 0xf;
+}
+
+/**
+ * Converts a value to a hex value
+ *
+ * @param t Token
+ */
+export function convertTokenType(t: Token): string {
+  switch (t) {
+    case Token.NumericLiteral:
+      return 'NumericLiteral';
+    case Token.StringLiteral:
+      return 'StringLiteral';
+    case Token.RegularExpression:
+      return 'RegularExpressionLiteral';
+    case Token.FalseKeyword:
+    case Token.TrueKeyword:
+      return 'BooleanLiteral';
+    case Token.NullKeyword:
+      return 'NullLiteral';
+    case Token.RegularExpression:
+      return 'RegularExpression';
+    case Token.TemplateContinuation:
+    case Token.TemplateSpan:
+    case Token.Template:
+      return 'TemplateLiteral';
+    default:
+      if ((t & Token.IsIdentifier) === Token.IsIdentifier) return 'Identifier';
+      if ((t & Token.Keyword) === Token.Keyword) return 'Keyword';
+
+      return 'Punctuator';
+  }
 }

--- a/src/lexer/index.ts
+++ b/src/lexer/index.ts
@@ -15,7 +15,8 @@ export {
   consumeLineFeed,
   scanNewLine,
   LexerState,
-  NumberKind
+  NumberKind,
+  convertTokenType
 } from './common';
 export { CharTypes, CharFlags, isIdentifierStart, isIdentifierPart } from './charClassifier';
 export {

--- a/src/lexer/scan.ts
+++ b/src/lexer/scan.ts
@@ -183,7 +183,8 @@ export function nextToken(parser: ParserState, context: Context): void {
   parser.startColumn = parser.column;
   parser.startLine = parser.line;
   parser.token = scanSingleToken(parser, context, LexerState.None);
-  if (parser.onToken) parser.onToken(convertTokenType(parser.token), parser.startPos, parser.index);
+  if (parser.onToken && parser.token !== Token.EOF)
+    parser.onToken(convertTokenType(parser.token), parser.startPos, parser.index);
 }
 
 export function scanSingleToken(parser: ParserState, context: Context, state: LexerState): Token {

--- a/src/lexer/scan.ts
+++ b/src/lexer/scan.ts
@@ -22,7 +22,8 @@ import {
   scanPrivateName,
   fromCodePoint,
   consumeLineFeed,
-  scanNewLine
+  scanNewLine,
+  convertTokenType
 } from './';
 
 /*
@@ -182,6 +183,7 @@ export function nextToken(parser: ParserState, context: Context): void {
   parser.startColumn = parser.column;
   parser.startLine = parser.line;
   parser.token = scanSingleToken(parser, context, LexerState.None);
+  if (parser.onToken) parser.onToken(convertTokenType(parser.token), parser.startPos, parser.index);
 }
 
 export function scanSingleToken(parser: ParserState, context: Context, state: LexerState): Token {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -216,9 +216,9 @@ export interface Options {
   jsx?: boolean;
   // Allow edge cases that deviate from the spec
   specDeviation?: boolean;
-  // Allowes comment extraction. Accepts either a a callback function or an array
+  // Allows comment extraction. Accepts either a a callback function or an array
   onComment?: OnComment;
-  // Allowes token extraction. Accepts either a a callback function or an array
+  // Allows token extraction. Accepts either a a callback function or an array
   onToken?: OnToken;
 }
 

--- a/test/parser/miscellaneous/onComment.ts
+++ b/test/parser/miscellaneous/onComment.ts
@@ -1,7 +1,7 @@
 import * as t from 'assert';
 import { parseScript } from '../../../src/meriyah';
 
-describe('Expressions - API', () => {
+describe('Miscellaneous - onComment', () => {
   it('should extract single line comment', () => {
     t.deepEqual(
       parseScript('// Single line comment', {

--- a/test/parser/miscellaneous/onToken.ts
+++ b/test/parser/miscellaneous/onToken.ts
@@ -1,0 +1,39 @@
+import * as t from 'assert';
+import { parseScript } from '../../../src/meriyah';
+import { Token } from 'token';
+
+describe('Miscellaneous - onToken', () => {
+  it('tokenize braces using array', () => {
+    let tokens: Token[] = [];
+    parseScript('{}', {
+      onToken: tokens,
+      loc: true
+    });
+    t.deepEqual(tokens, [
+      {
+        end: 1,
+        start: 0,
+        token: 'Punctuator'
+      },
+      {
+        end: 2,
+        start: 1,
+        token: 'Punctuator'
+      }
+    ]);
+  });
+
+  it('tokenize boolean using function', () => {
+    let called = false;
+    parseScript('false', {
+      onToken: function(token: string, start?: number, end?: number) {
+        t.deepEqual(token, 'BooleanLiteral');
+        t.deepEqual(start, 0);
+        t.deepEqual(end, 5);
+        called = true;
+      },
+      loc: true
+    });
+    t.deepEqual(called, true);
+  });
+});

--- a/test/parser/miscellaneous/onToken.ts
+++ b/test/parser/miscellaneous/onToken.ts
@@ -1,10 +1,10 @@
 import * as t from 'assert';
 import { parseScript } from '../../../src/meriyah';
-import { Token } from 'token';
+import { Token } from '../../../src/token';
 
 describe('Miscellaneous - onToken', () => {
   it('tokenize braces using array', () => {
-    let tokens: Token[] = [];
+    const tokens: Token[] = [];
     parseScript('{}', {
       onToken: tokens,
       loc: true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
     "stripInternal": true,
     "target": "es2018",
     "typeRoots": ["./node_modules/@types"],
-    "types": ["node"]
+    "types": ["node", "mocha"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
Add onToken callback function based on the same feature in [Cherow](https://github.com/cherow/cherow). This will allow comment attachment using tools like [estraverse](https://github.com/estools/estraverse), like Acorn and Esprima do.