### PR TITLE
Fix order of VariableDeclarator properties

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2115,8 +2115,8 @@ function parseVariableDeclaration(
 
   return finishNode(parser, context, tokenPos, linePos, colPos, {
     type: 'VariableDeclarator',
-    init,
-    id
+    id,
+    init
   });
 }
 


### PR DESCRIPTION
The "id" property should come before "init". This is useful for Estree iterators that don't preset traversal order of Node keys.