### PR TITLE
fix: rename CoalesceExpression

### DIFF
--- a/src/estree.ts
+++ b/src/estree.ts
@@ -30,7 +30,6 @@ export type ArgumentExpression =
   | SpreadElement
   | BinaryExpression
   | LogicalExpression
-  | CoalesceExpression
   | SequenceExpression;
 
 export type CommentType = 'Line' | 'Block' | 'HTMLOpen' | 'HTMLClose';
@@ -104,7 +103,6 @@ export type Node =
   | LabeledStatement
   | Literal
   | LogicalExpression
-  | CoalesceExpression
   | MemberExpression
   | MetaProperty
   | MethodDefinition
@@ -161,7 +159,6 @@ export type Expression =
   | JSXOpeningFragment
   | JSXSpreadChild
   | LogicalExpression
-  | CoalesceExpression
   | NewExpression
   | RestElement
   | SequenceExpression
@@ -620,13 +617,6 @@ export interface Literal extends _Node {
   type: 'Literal';
   value: boolean | number | string | null;
   raw?: string;
-}
-
-export interface CoalesceExpression extends _Node {
-  type: 'CoalesceExpression';
-  operator: string;
-  left: Expression;
-  right: Expression;
 }
 
 export interface LogicalExpression extends _Node {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3416,7 +3416,7 @@ export function parseBinaryExpression(
     nextToken(parser, context | Context.AllowRegExp);
 
     left = finishNode(parser, context, start, line, column, {
-      type: t & Token.IsLogical ? 'LogicalExpression' : t & Token.IsCoalesc ? 'CoalesceExpression' : 'BinaryExpression',
+      type: t & Token.IsLogical || t & Token.IsCoalesc ? 'LogicalExpression' : 'BinaryExpression',
       left,
       right: parseBinaryExpression(
         parser,

--- a/test/parser/miscellaneous/api.ts
+++ b/test/parser/miscellaneous/api.ts
@@ -273,7 +273,7 @@ describe('Expressions - API', () => {
           {
             type: 'ExpressionStatement',
             expression: {
-              type: 'CoalesceExpression',
+              type: 'LogicalExpression',
               left: {
                 type: 'Identifier',
                 name: 'a',

--- a/test/parser/next/nullCoalescing.ts
+++ b/test/parser/next/nullCoalescing.ts
@@ -156,7 +156,7 @@ describe('Next - Nullish Coalescing', () => {
                   type: 'Literal',
                   value: 3
                 },
-                type: 'CoalesceExpression'
+                type: 'LogicalExpression'
               },
               property: {
                 name: 'x',
@@ -187,7 +187,7 @@ describe('Next - Nullish Coalescing', () => {
                 type: 'Literal',
                 value: 3
               },
-              type: 'CoalesceExpression'
+              type: 'LogicalExpression'
             },
             type: 'ExpressionStatement'
           }
@@ -212,7 +212,7 @@ describe('Next - Nullish Coalescing', () => {
                 type: 'Literal',
                 value: 3
               },
-              type: 'CoalesceExpression'
+              type: 'LogicalExpression'
             },
             type: 'ExpressionStatement'
           }
@@ -245,7 +245,7 @@ describe('Next - Nullish Coalescing', () => {
                 type: 'Literal',
                 value: 3
               },
-              type: 'CoalesceExpression'
+              type: 'LogicalExpression'
             },
             type: 'ExpressionStatement'
           }
@@ -278,7 +278,7 @@ describe('Next - Nullish Coalescing', () => {
                 type: 'Literal',
                 value: 3
               },
-              type: 'CoalesceExpression'
+              type: 'LogicalExpression'
             },
             type: 'ExpressionStatement'
           }
@@ -311,7 +311,7 @@ describe('Next - Nullish Coalescing', () => {
                 },
                 type: 'LogicalExpression'
               },
-              type: 'CoalesceExpression'
+              type: 'LogicalExpression'
             },
             type: 'ExpressionStatement'
           }
@@ -339,14 +339,14 @@ describe('Next - Nullish Coalescing', () => {
                   name: 'b',
                   type: 'Identifier'
                 },
-                type: 'CoalesceExpression'
+                type: 'LogicalExpression'
               },
               operator: '??',
               right: {
                 name: 'c',
                 type: 'Identifier'
               },
-              type: 'CoalesceExpression'
+              type: 'LogicalExpression'
             },
             type: 'ExpressionStatement'
           }
@@ -371,7 +371,7 @@ describe('Next - Nullish Coalescing', () => {
                 type: 'Literal',
                 value: 1
               },
-              type: 'CoalesceExpression'
+              type: 'LogicalExpression'
             },
             type: 'ExpressionStatement'
           }
@@ -397,14 +397,14 @@ describe('Next - Nullish Coalescing', () => {
                   name: 'b',
                   type: 'Identifier'
                 },
-                type: 'CoalesceExpression'
+                type: 'LogicalExpression'
               },
               operator: '??',
               right: {
                 name: 'c',
                 type: 'Identifier'
               },
-              type: 'CoalesceExpression'
+              type: 'LogicalExpression'
             },
             type: 'ExpressionStatement'
           }
@@ -437,7 +437,7 @@ describe('Next - Nullish Coalescing', () => {
                 },
                 type: 'LogicalExpression'
               },
-              type: 'CoalesceExpression'
+              type: 'LogicalExpression'
             },
             type: 'ExpressionStatement'
           }
@@ -470,7 +470,7 @@ describe('Next - Nullish Coalescing', () => {
                 name: 'c',
                 type: 'Identifier'
               },
-              type: 'CoalesceExpression'
+              type: 'LogicalExpression'
             },
             type: 'ExpressionStatement'
           }
@@ -503,7 +503,7 @@ describe('Next - Nullish Coalescing', () => {
                 name: 'c',
                 type: 'Identifier'
               },
-              type: 'CoalesceExpression'
+              type: 'LogicalExpression'
             },
             type: 'ExpressionStatement'
           }


### PR DESCRIPTION
The Estree spec extends the LogicalExpression node type by adding
the '??' operator value to it:
https://github.com/estree/estree/blob/master/es2020.md#logicalexpression