### PR TITLE
fix: fix wrong cooked value in TemplateElement, fix wrong loc and range in various template nodes

### DIFF
--- a/src/estree.ts
+++ b/src/estree.ts
@@ -732,7 +732,7 @@ export interface TemplateElement extends _Node {
   type: 'TemplateElement';
   value: {
     raw: string;
-    cooked: string;
+    cooked: string | null;
   };
   tail: boolean;
 }

--- a/test/parser/expressions/object.ts
+++ b/test/parser/expressions/object.ts
@@ -4505,9 +4505,9 @@ describe('Expressions - Object', () => {
                         quasis: [
                           {
                             type: 'TemplateElement',
-                            start: 20,
-                            end: 23,
-                            range: [20, 23],
+                            start: 21,
+                            end: 22,
+                            range: [21, 22],
                             value: {
                               raw: 'c',
                               cooked: 'c'
@@ -4589,9 +4589,9 @@ describe('Expressions - Object', () => {
                         quasis: [
                           {
                             type: 'TemplateElement',
-                            start: 46,
-                            end: 49,
-                            range: [46, 49],
+                            start: 47,
+                            end: 47,
+                            range: [47, 47],
                             value: {
                               raw: '',
                               cooked: ''
@@ -4600,9 +4600,9 @@ describe('Expressions - Object', () => {
                           },
                           {
                             type: 'TemplateElement',
-                            start: 50,
-                            end: 53,
-                            range: [50, 53],
+                            start: 51,
+                            end: 52,
+                            range: [51, 52],
                             value: {
                               raw: 'e',
                               cooked: 'e'

--- a/test/parser/expressions/object.ts
+++ b/test/parser/expressions/object.ts
@@ -4505,9 +4505,9 @@ describe('Expressions - Object', () => {
                         quasis: [
                           {
                             type: 'TemplateElement',
-                            start: 23,
+                            start: 20,
                             end: 23,
-                            range: [23, 23],
+                            range: [20, 23],
                             value: {
                               raw: 'c',
                               cooked: 'c'
@@ -4590,8 +4590,8 @@ describe('Expressions - Object', () => {
                           {
                             type: 'TemplateElement',
                             start: 46,
-                            end: 46,
-                            range: [46, 46],
+                            end: 49,
+                            range: [46, 49],
                             value: {
                               raw: '',
                               cooked: ''
@@ -4601,8 +4601,8 @@ describe('Expressions - Object', () => {
                           {
                             type: 'TemplateElement',
                             start: 50,
-                            end: 50,
-                            range: [50, 50],
+                            end: 53,
+                            range: [50, 53],
                             value: {
                               raw: 'e',
                               cooked: 'e'

--- a/test/parser/expressions/template.ts
+++ b/test/parser/expressions/template.ts
@@ -3470,6 +3470,207 @@ describe('Expressions - Template', () => {
           }
         ]
       }
+    ],
+    [
+      'tagA`a`\ntagB`b`',
+      Context.None | Context.OptionsRanges | Context.OptionsLoc,
+      {
+        type: 'Program',
+        sourceType: 'script',
+        body: [
+          {
+            type: 'ExpressionStatement',
+            expression: {
+              type: 'TaggedTemplateExpression',
+              tag: {
+                type: 'Identifier',
+                name: 'tagA',
+                start: 0,
+                end: 4,
+                range: [0, 4],
+                loc: {
+                  start: {
+                    line: 1,
+                    column: 0
+                  },
+                  end: {
+                    line: 1,
+                    column: 4
+                  }
+                }
+              },
+              quasi: {
+                type: 'TemplateLiteral',
+                expressions: [],
+                quasis: [
+                  {
+                    type: 'TemplateElement',
+                    value: {
+                      cooked: 'a',
+                      raw: 'a'
+                    },
+                    tail: true,
+                    start: 4,
+                    end: 7,
+                    range: [4, 7],
+                    loc: {
+                      start: {
+                        line: 1,
+                        column: 4
+                      },
+                      end: {
+                        line: 1,
+                        column: 7
+                      }
+                    }
+                  }
+                ],
+                start: 4,
+                end: 7,
+                range: [4, 7],
+                loc: {
+                  start: {
+                    line: 1,
+                    column: 4
+                  },
+                  end: {
+                    line: 1,
+                    column: 7
+                  }
+                }
+              },
+              start: 0,
+              end: 7,
+              range: [0, 7],
+              loc: {
+                start: {
+                  line: 1,
+                  column: 0
+                },
+                end: {
+                  line: 1,
+                  column: 7
+                }
+              }
+            },
+            start: 0,
+            end: 7,
+            range: [0, 7],
+            loc: {
+              start: {
+                line: 1,
+                column: 0
+              },
+              end: {
+                line: 1,
+                column: 7
+              }
+            }
+          },
+          {
+            type: 'ExpressionStatement',
+            expression: {
+              type: 'TaggedTemplateExpression',
+              tag: {
+                type: 'Identifier',
+                name: 'tagB',
+                start: 8,
+                end: 12,
+                range: [8, 12],
+                loc: {
+                  start: {
+                    line: 2,
+                    column: 0
+                  },
+                  end: {
+                    line: 2,
+                    column: 4
+                  }
+                }
+              },
+              quasi: {
+                type: 'TemplateLiteral',
+                expressions: [],
+                quasis: [
+                  {
+                    type: 'TemplateElement',
+                    value: {
+                      cooked: 'b',
+                      raw: 'b'
+                    },
+                    tail: true,
+                    start: 12,
+                    end: 15,
+                    range: [12, 15],
+                    loc: {
+                      start: {
+                        line: 2,
+                        column: 4
+                      },
+                      end: {
+                        line: 2,
+                        column: 7
+                      }
+                    }
+                  }
+                ],
+                start: 12,
+                end: 15,
+                range: [12, 15],
+                loc: {
+                  start: {
+                    line: 2,
+                    column: 4
+                  },
+                  end: {
+                    line: 2,
+                    column: 7
+                  }
+                }
+              },
+              start: 8,
+              end: 15,
+              range: [8, 15],
+              loc: {
+                start: {
+                  line: 2,
+                  column: 0
+                },
+                end: {
+                  line: 2,
+                  column: 7
+                }
+              }
+            },
+            start: 8,
+            end: 15,
+            range: [8, 15],
+            loc: {
+              start: {
+                line: 2,
+                column: 0
+              },
+              end: {
+                line: 2,
+                column: 7
+              }
+            }
+          }
+        ],
+        start: 0,
+        end: 15,
+        range: [0, 15],
+        loc: {
+          start: {
+            line: 1,
+            column: 0
+          },
+          end: {
+            line: 2,
+            column: 7
+          }
+        }
+      }
     ]
   ]);
 });

--- a/test/parser/expressions/template.ts
+++ b/test/parser/expressions/template.ts
@@ -3510,17 +3510,17 @@ describe('Expressions - Template', () => {
                       raw: 'a'
                     },
                     tail: true,
-                    start: 4,
-                    end: 7,
-                    range: [4, 7],
+                    start: 5,
+                    end: 6,
+                    range: [5, 6],
                     loc: {
                       start: {
                         line: 1,
-                        column: 4
+                        column: 5
                       },
                       end: {
                         line: 1,
-                        column: 7
+                        column: 6
                       }
                     }
                   }
@@ -3599,17 +3599,17 @@ describe('Expressions - Template', () => {
                       raw: 'b'
                     },
                     tail: true,
-                    start: 12,
-                    end: 15,
-                    range: [12, 15],
+                    start: 13,
+                    end: 14,
+                    range: [13, 14],
                     loc: {
                       start: {
                         line: 2,
-                        column: 4
+                        column: 5
                       },
                       end: {
                         line: 2,
-                        column: 7
+                        column: 6
                       }
                     }
                   }


### PR DESCRIPTION
closes #109, #108

-----

The range/loc in TemplateElement was wrong, because we need to move parser to nextToken before finalise it.
This PR doesn't address null "cooked" value, as indicated in estree spec. I merely added the typing into our estree types.