### PR TITLE
fix: follow latest decorator proposal

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -227,7 +227,7 @@ export interface ParserState {
   currentChar: number;
   exportedNames: any;
   exportedBindings: any;
-  leadingDecorators: Decorator[] | void;
+  leadingDecorators: Decorator[];
 }
 
 /**

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,6 +1,6 @@
 import { Token, KeywordDescTable } from './token';
 import { Errors, report } from './errors';
-import { Node, Comment } from './estree';
+import { Node, Comment, Decorator } from './estree';
 import { nextToken } from './lexer/scan';
 
 /**
@@ -227,6 +227,7 @@ export interface ParserState {
   currentChar: number;
   exportedNames: any;
   exportedBindings: any;
+  leadingDecorators: Decorator[] | void;
 }
 
 /**

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -164,7 +164,8 @@ export const enum Errors {
   OptionalChainingNoTemplate,
   OptionalChainingNoSuper,
   OptionalChainingNoNew,
-  ImportMetaOutsideModule
+  ImportMetaOutsideModule,
+  InvalidLeadingDecorator
 }
 
 export const errorMessages: {
@@ -342,7 +343,8 @@ export const errorMessages: {
   [Errors.OptionalChainingNoTemplate]: 'Invalid tagged template on optional chain',
   [Errors.OptionalChainingNoSuper]: 'Invalid optional chain from super property',
   [Errors.OptionalChainingNoNew]: 'Invalid optional chain from new expression',
-  [Errors.ImportMetaOutsideModule]: 'Cannot use "import.meta" outside a module'
+  [Errors.ImportMetaOutsideModule]: 'Cannot use "import.meta" outside a module',
+  [Errors.InvalidLeadingDecorator]: 'Leading decorators must be attached to a class declaration'
 };
 
 export class ParseError extends SyntaxError {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -426,8 +426,6 @@ export function parseModuleItem(
       return parseExportDeclaration(parser, context, scope, start, line, column);
     case Token.ImportKeyword:
       return parseImportDeclaration(parser, context, scope, start, line, column);
-    case Token.Decorator:
-      return parseDecorators(parser, context) as ESTree.Decorator[];
     default:
       return parseStatementListItem(parser, context, scope, Origin.TopLevel, {}, start, line, column);
   }

--- a/test/parser/next/decorators.ts
+++ b/test/parser/next/decorators.ts
@@ -391,27 +391,26 @@ describe('Next - Decorators', () => {
       }
     ],
     [
-      `@bar export default
+      `export default @bar
           class Foo { }`,
       Context.OptionsNext | Context.Module | Context.Strict,
       {
         body: [
-          [
-            {
-              expression: {
-                name: 'bar',
-                type: 'Identifier'
-              },
-              type: 'Decorator'
-            }
-          ],
           {
             declaration: {
               body: {
                 body: [],
                 type: 'ClassBody'
               },
-              decorators: [],
+              decorators: [
+                {
+                  expression: {
+                    name: 'bar',
+                    type: 'Identifier'
+                  },
+                  type: 'Decorator'
+                }
+              ],
               id: {
                 name: 'Foo',
                 type: 'Identifier'
@@ -439,98 +438,97 @@ describe('Next - Decorators', () => {
       Context.OptionsNext | Context.Module | Context.Strict,
       {
         body: [
-          [
-            {
-              expression: {
-                arguments: [
-                  {
-                    properties: [
-                      {
-                        computed: false,
-                        key: {
-                          name: 'kind',
-                          type: 'Identifier'
-                        },
-                        kind: 'init',
-                        method: false,
-                        shorthand: false,
-                        type: 'Property',
-                        value: {
-                          type: 'Literal',
-                          value: 'initializer'
-                        }
-                      },
-                      {
-                        computed: false,
-                        key: {
-                          name: 'placement',
-                          type: 'Identifier'
-                        },
-                        kind: 'init',
-                        method: false,
-                        shorthand: false,
-                        type: 'Property',
-                        value: {
-                          type: 'Literal',
-                          value: 'own'
-                        }
-                      },
-                      {
-                        computed: false,
-                        key: {
-                          name: 'initializer',
-                          type: 'Identifier'
-                        },
-                        kind: 'init',
-                        method: true,
-                        shorthand: false,
-                        type: 'Property',
-                        value: {
-                          async: false,
-                          body: {
-                            body: [
-                              {
-                                expression: {
-                                  left: {
-                                    name: 'self',
-                                    type: 'Identifier'
-                                  },
-                                  operator: '=',
-                                  right: {
-                                    type: 'ThisExpression'
-                                  },
-                                  type: 'AssignmentExpression'
-                                },
-                                type: 'ExpressionStatement'
-                              }
-                            ],
-                            type: 'BlockStatement'
-                          },
-                          generator: false,
-                          id: null,
-                          params: [],
-                          type: 'FunctionExpression'
-                        }
-                      }
-                    ],
-                    type: 'ObjectExpression'
-                  }
-                ],
-                callee: {
-                  name: 'pushElement',
-                  type: 'Identifier'
-                },
-                type: 'CallExpression'
-              },
-              type: 'Decorator'
-            }
-          ],
           {
             body: {
               body: [],
               type: 'ClassBody'
             },
-            decorators: [],
+            decorators: [
+              {
+                expression: {
+                  arguments: [
+                    {
+                      properties: [
+                        {
+                          computed: false,
+                          key: {
+                            name: 'kind',
+                            type: 'Identifier'
+                          },
+                          kind: 'init',
+                          method: false,
+                          shorthand: false,
+                          type: 'Property',
+                          value: {
+                            type: 'Literal',
+                            value: 'initializer'
+                          }
+                        },
+                        {
+                          computed: false,
+                          key: {
+                            name: 'placement',
+                            type: 'Identifier'
+                          },
+                          kind: 'init',
+                          method: false,
+                          shorthand: false,
+                          type: 'Property',
+                          value: {
+                            type: 'Literal',
+                            value: 'own'
+                          }
+                        },
+                        {
+                          computed: false,
+                          key: {
+                            name: 'initializer',
+                            type: 'Identifier'
+                          },
+                          kind: 'init',
+                          method: true,
+                          shorthand: false,
+                          type: 'Property',
+                          value: {
+                            async: false,
+                            body: {
+                              body: [
+                                {
+                                  expression: {
+                                    left: {
+                                      name: 'self',
+                                      type: 'Identifier'
+                                    },
+                                    operator: '=',
+                                    right: {
+                                      type: 'ThisExpression'
+                                    },
+                                    type: 'AssignmentExpression'
+                                  },
+                                  type: 'ExpressionStatement'
+                                }
+                              ],
+                              type: 'BlockStatement'
+                            },
+                            generator: false,
+                            id: null,
+                            params: [],
+                            type: 'FunctionExpression'
+                          }
+                        }
+                      ],
+                      type: 'ObjectExpression'
+                    }
+                  ],
+                  callee: {
+                    name: 'pushElement',
+                    type: 'Identifier'
+                  },
+                  type: 'CallExpression'
+                },
+                type: 'Decorator'
+              }
+            ],
             id: {
               name: 'A',
               type: 'Identifier'

--- a/test/parser/next/decorators.ts
+++ b/test/parser/next/decorators.ts
@@ -2852,6 +2852,194 @@ describe('Next - Decorators', () => {
           }
         ]
       }
+    ],
+    [
+      '@a(@b class C {}) @d(@e() class F {}) class G {}',
+      Context.OptionsNext,
+      {
+        type: 'Program',
+        sourceType: 'script',
+        body: [
+          {
+            type: 'ClassDeclaration',
+            id: {
+              type: 'Identifier',
+              name: 'G'
+            },
+            superClass: null,
+            decorators: [
+              {
+                type: 'Decorator',
+                expression: {
+                  type: 'CallExpression',
+                  callee: {
+                    type: 'Identifier',
+                    name: 'a'
+                  },
+                  arguments: [
+                    {
+                      type: 'ClassExpression',
+                      id: {
+                        type: 'Identifier',
+                        name: 'C'
+                      },
+                      superClass: null,
+                      decorators: [
+                        {
+                          type: 'Decorator',
+                          expression: {
+                            type: 'Identifier',
+                            name: 'b'
+                          }
+                        }
+                      ],
+                      body: {
+                        type: 'ClassBody',
+                        body: []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                type: 'Decorator',
+                expression: {
+                  type: 'CallExpression',
+                  callee: {
+                    type: 'Identifier',
+                    name: 'd'
+                  },
+                  arguments: [
+                    {
+                      type: 'ClassExpression',
+                      id: {
+                        type: 'Identifier',
+                        name: 'F'
+                      },
+                      superClass: null,
+                      decorators: [
+                        {
+                          type: 'Decorator',
+                          expression: {
+                            type: 'CallExpression',
+                            callee: {
+                              type: 'Identifier',
+                              name: 'e'
+                            },
+                            arguments: []
+                          }
+                        }
+                      ],
+                      body: {
+                        type: 'ClassBody',
+                        body: []
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            body: {
+              type: 'ClassBody',
+              body: []
+            }
+          }
+        ]
+      }
+    ],
+    [
+      '@a(@b class C {}) @d(@e() class F {}) class G {}',
+      Context.OptionsNext | Context.Module,
+      {
+        type: 'Program',
+        sourceType: 'module',
+        body: [
+          {
+            type: 'ClassDeclaration',
+            id: {
+              type: 'Identifier',
+              name: 'G'
+            },
+            superClass: null,
+            decorators: [
+              {
+                type: 'Decorator',
+                expression: {
+                  type: 'CallExpression',
+                  callee: {
+                    type: 'Identifier',
+                    name: 'a'
+                  },
+                  arguments: [
+                    {
+                      type: 'ClassExpression',
+                      id: {
+                        type: 'Identifier',
+                        name: 'C'
+                      },
+                      superClass: null,
+                      decorators: [
+                        {
+                          type: 'Decorator',
+                          expression: {
+                            type: 'Identifier',
+                            name: 'b'
+                          }
+                        }
+                      ],
+                      body: {
+                        type: 'ClassBody',
+                        body: []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                type: 'Decorator',
+                expression: {
+                  type: 'CallExpression',
+                  callee: {
+                    type: 'Identifier',
+                    name: 'd'
+                  },
+                  arguments: [
+                    {
+                      type: 'ClassExpression',
+                      id: {
+                        type: 'Identifier',
+                        name: 'F'
+                      },
+                      superClass: null,
+                      decorators: [
+                        {
+                          type: 'Decorator',
+                          expression: {
+                            type: 'CallExpression',
+                            callee: {
+                              type: 'Identifier',
+                              name: 'e'
+                            },
+                            arguments: []
+                          }
+                        }
+                      ],
+                      body: {
+                        type: 'ClassBody',
+                        body: []
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            body: {
+              type: 'ClassBody',
+              body: []
+            }
+          }
+        ]
+      }
     ]
   ]);
 });

--- a/test/parser/next/decorators.ts
+++ b/test/parser/next/decorators.ts
@@ -79,7 +79,17 @@ describe('Next - Decorators', () => {
     ['class Foo {  @a; m(){}}', Context.OptionsNext],
     ['class Foo { @abc constructor(){} }', Context.OptionsNext],
     ['class A { @foo && bar method() {}  }', Context.OptionsNext],
-    ['class A { @foo && bar; method() {}  }', Context.OptionsNext]
+    ['class A { @foo && bar; method() {}  }', Context.OptionsNext],
+    ['@bar export const foo = 1;', Context.OptionsNext | Context.Module],
+    ['@bar export {Foo};', Context.OptionsNext | Context.Module],
+    ['@bar export * from "./foo";', Context.OptionsNext | Context.Module],
+    ['@bar export default function foo() {}', Context.OptionsNext | Context.Module],
+    ['@bar const foo = 1;', Context.OptionsNext],
+    ['@bar function foo() {}', Context.OptionsNext],
+    ['(@bar const foo = 1);', Context.OptionsNext],
+    ['(@bar function foo() {})', Context.OptionsNext],
+    ['@bar;', Context.OptionsNext],
+    ['@bar();', Context.OptionsNext]
   ]);
 
   pass('Next - Decorators (pass)', [
@@ -356,6 +366,41 @@ describe('Next - Decorators', () => {
       }
     ],
     [
+      `@bar export default
+          class Foo { }`,
+      Context.OptionsNext | Context.Module | Context.Strict,
+      {
+        body: [
+          {
+            declaration: {
+              body: {
+                body: [],
+                type: 'ClassBody'
+              },
+              decorators: [
+                {
+                  expression: {
+                    name: 'bar',
+                    type: 'Identifier'
+                  },
+                  type: 'Decorator'
+                }
+              ],
+              id: {
+                name: 'Foo',
+                type: 'Identifier'
+              },
+              superClass: null,
+              type: 'ClassDeclaration'
+            },
+            type: 'ExportDefaultDeclaration'
+          }
+        ],
+        sourceType: 'module',
+        type: 'Program'
+      }
+    ],
+    [
       `export default
           @bar class Foo { }`,
       Context.OptionsNext | Context.Module | Context.Strict,
@@ -403,6 +448,48 @@ describe('Next - Decorators', () => {
                 type: 'ClassBody'
               },
               decorators: [
+                {
+                  expression: {
+                    name: 'bar',
+                    type: 'Identifier'
+                  },
+                  type: 'Decorator'
+                }
+              ],
+              id: {
+                name: 'Foo',
+                type: 'Identifier'
+              },
+              superClass: null,
+              type: 'ClassDeclaration'
+            },
+            type: 'ExportDefaultDeclaration'
+          }
+        ],
+        sourceType: 'module',
+        type: 'Program'
+      }
+    ],
+    [
+      `@lo export default @bar
+          class Foo { }`,
+      Context.OptionsNext | Context.Module | Context.Strict,
+      {
+        body: [
+          {
+            declaration: {
+              body: {
+                body: [],
+                type: 'ClassBody'
+              },
+              decorators: [
+                {
+                  expression: {
+                    name: 'lo',
+                    type: 'Identifier'
+                  },
+                  type: 'Decorator'
+                },
                 {
                   expression: {
                     name: 'bar',
@@ -965,6 +1052,135 @@ describe('Next - Decorators', () => {
                 }
               }
             ]
+          }
+        ]
+      }
+    ],
+    [
+      `@foo('bar')
+  class Foo {}`,
+      Context.OptionsNext | Context.Module,
+      {
+        type: 'Program',
+        sourceType: 'module',
+        body: [
+          {
+            type: 'ClassDeclaration',
+            id: {
+              type: 'Identifier',
+              name: 'Foo'
+            },
+            superClass: null,
+            body: {
+              type: 'ClassBody',
+              body: []
+            },
+            decorators: [
+              {
+                type: 'Decorator',
+                expression: {
+                  type: 'CallExpression',
+                  callee: {
+                    type: 'Identifier',
+                    name: 'foo'
+                  },
+                  arguments: [
+                    {
+                      type: 'Literal',
+                      value: 'bar'
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    [
+      `(@foo('bar')
+  class Foo {})`,
+      Context.OptionsNext,
+      {
+        type: 'Program',
+        sourceType: 'script',
+        body: [
+          {
+            type: 'ExpressionStatement',
+            expression: {
+              type: 'ClassExpression',
+              id: {
+                type: 'Identifier',
+                name: 'Foo'
+              },
+              superClass: null,
+              decorators: [
+                {
+                  type: 'Decorator',
+                  expression: {
+                    type: 'CallExpression',
+                    callee: {
+                      type: 'Identifier',
+                      name: 'foo'
+                    },
+                    arguments: [
+                      {
+                        type: 'Literal',
+                        value: 'bar'
+                      }
+                    ]
+                  }
+                }
+              ],
+              body: {
+                type: 'ClassBody',
+                body: []
+              }
+            }
+          }
+        ]
+      }
+    ],
+    [
+      `(@foo('bar')
+  class Foo {})`,
+      Context.OptionsNext | Context.Module,
+      {
+        type: 'Program',
+        sourceType: 'module',
+        body: [
+          {
+            type: 'ExpressionStatement',
+            expression: {
+              type: 'ClassExpression',
+              id: {
+                type: 'Identifier',
+                name: 'Foo'
+              },
+              superClass: null,
+              decorators: [
+                {
+                  type: 'Decorator',
+                  expression: {
+                    type: 'CallExpression',
+                    callee: {
+                      type: 'Identifier',
+                      name: 'foo'
+                    },
+                    arguments: [
+                      {
+                        type: 'Literal',
+                        value: 'bar'
+                      }
+                    ]
+                  }
+                }
+              ],
+              body: {
+                type: 'ClassBody',
+                body: []
+              }
+            }
           }
         ]
       }


### PR DESCRIPTION
closes #105

-----
Move to new decorator proposal broke the old code `@dec export class A {}`. Need to improve parseExportDeclaration to support decorator before export keyword.