### PR TITLE
fix(lexer): \8 \9 are acceptable in web compatibility mode

### DIFF
--- a/src/lexer/string.ts
+++ b/src/lexer/string.ts
@@ -162,11 +162,6 @@ export function parseEscape(parser: ParserState, context: Context, first: number
       return code;
     }
 
-    // `8`, `9` (invalid escapes)
-    case Chars.Eight:
-    case Chars.Nine:
-      return Escape.EightOrNine;
-
     // HexEscapeSequence
     // \x HexDigit HexDigit
     case Chars.LowerX: {
@@ -214,6 +209,11 @@ export function parseEscape(parser: ParserState, context: Context, first: number
         return (toHex(ch) << 12) | (toHex(ch2) << 8) | (toHex(ch3) << 4) | toHex(ch4);
       }
     }
+
+    // `8`, `9` (invalid escapes)
+    case Chars.Eight:
+    case Chars.Nine:
+      if ((context & Context.OptionsWebCompat) === 0) return Escape.EightOrNine;
 
     default:
       return first;

--- a/test/lexer/strings.ts
+++ b/test/lexer/strings.ts
@@ -131,7 +131,12 @@ describe('Lexer - String', () => {
     [Context.None, Token.StringLiteral, '"\\302"', 'Â'],
     [Context.None, Token.StringLiteral, '"\\000"', '\u0000'],
     [Context.None, Token.StringLiteral, '"\\104"', 'D'],
-    [Context.None, Token.StringLiteral, '"\\221"', '']
+    [Context.None, Token.StringLiteral, '"\\221"', ''],
+
+    // \8 \9 are acceptable in web compatibility mode
+    [Context.OptionsWebCompat, Token.StringLiteral, '"\\8"', '8'],
+    [Context.OptionsWebCompat, Token.StringLiteral, '"\\9"', '9'],
+    [Context.OptionsWebCompat, Token.StringLiteral, '"\\9999"', '9999']
   ];
 
   for (const [ctx, token, op, value] of tokens) {

--- a/test/parser/miscellaneous/failure.ts
+++ b/test/parser/miscellaneous/failure.ts
@@ -838,8 +838,6 @@ describe('Miscellaneous - Failure', () => {
     '"use strict";\n"\\011"',
     '"use strict"; "\\08"',
     '"use strict"; "\\09"',
-    '"use strict"; "\\8"',
-    '"use strict"; "\\9"',
     'await ~123',
     'async () => class await {}',
     '{_ => {}/123/g;}',

--- a/test/parser/miscellaneous/literals.ts
+++ b/test/parser/miscellaneous/literals.ts
@@ -38,7 +38,6 @@ describe('Miscellaneous - Literal', () => {
     "'use strict'; ('\\123')",
     "('\\x')",
     '(")',
-    "('\\9')",
     '\\0009',
     '("\\u{FFFFFFF}")',
     "'",

--- a/test/test262-parser-tests/parser-tests.ts
+++ b/test/test262-parser-tests/parser-tests.ts
@@ -45,7 +45,12 @@ const expectations = {
     'e3fbcf63d7e43ead.js',
     '15a6123f6b825c38.js',
     '147fa078a7436e0e.js',
-    'fd2a45941e114896.js'
+    'fd2a45941e114896.js',
+    // https://github.com/tc39/test262-parser-tests/issues/25
+    '0d5e450f1da8a92a.js',
+    '748656edbfb2d0bb.js',
+    '79f882da06f88c9f.js',
+    '92b6af54adef3624.js'
   ],
   early: [
     'eeb5ffaafa815bb2.js',


### PR DESCRIPTION
closes #137