### PR TITLE
fix(parser): precedence of `<=` and `>=` operators

### DIFF
--- a/src/token.ts
+++ b/src/token.ts
@@ -106,8 +106,8 @@ export const enum Token {
   StrictNotEqual     = 61 | IsBinaryOp | 7 << PrecStart, // !==
   LooseEqual         = 62 | IsBinaryOp | 7 << PrecStart, // ==
   LooseNotEqual      = 63 | IsBinaryOp | 7 << PrecStart, // !=
-  LessThanOrEqual    = 64 | IsBinaryOp | 7 << PrecStart, // <=
-  GreaterThanOrEqual = 65 | IsBinaryOp | 7 << PrecStart, // >=
+  LessThanOrEqual    = 64 | IsBinaryOp | 8 << PrecStart, // <=
+  GreaterThanOrEqual = 65 | IsBinaryOp | 8 << PrecStart, // >=
   LessThan           = 66 | IsBinaryOp | IsExpressionStart | 8 << PrecStart, // <
   GreaterThan        = 67 | IsBinaryOp | 8 << PrecStart, // >
   ShiftLeft          = 68 | IsBinaryOp | 9 << PrecStart, // <<

--- a/test/parser/expressions/logical.ts
+++ b/test/parser/expressions/logical.ts
@@ -393,6 +393,113 @@ describe('Expressions - Logical', () => {
       }
     ],
     [
+      'a == b <= c',
+      Context.None,
+      {
+        type: 'Program',
+        sourceType: 'script',
+        body: [
+          {
+            type: 'ExpressionStatement',
+            expression: {
+              type: 'BinaryExpression',
+              left: {
+                type: 'Identifier',
+                name: 'a'
+              },
+              right: {
+                type: 'BinaryExpression',
+                left: {
+                  type: 'Identifier',
+                  name: 'b'
+                },
+                right: {
+                  type: 'Identifier',
+                  name: 'c'
+                },
+                operator: '<='
+              },
+              operator: '=='
+            }
+          }
+        ]
+      }
+    ],
+    [
+      'a == b >= c',
+      Context.None,
+      {
+        type: 'Program',
+        sourceType: 'script',
+        body: [
+          {
+            type: 'ExpressionStatement',
+            expression: {
+              type: 'BinaryExpression',
+              left: {
+                type: 'Identifier',
+                name: 'a'
+              },
+              right: {
+                type: 'BinaryExpression',
+                left: {
+                  type: 'Identifier',
+                  name: 'b'
+                },
+                right: {
+                  type: 'Identifier',
+                  name: 'c'
+                },
+                operator: '>='
+              },
+              operator: '=='
+            }
+          }
+        ]
+      }
+    ],
+    [
+      'a >= b !== c >= d',
+      Context.None,
+      {
+        type: 'Program',
+        sourceType: 'script',
+        body: [
+          {
+            type: 'ExpressionStatement',
+            expression: {
+              type: 'BinaryExpression',
+              left: {
+                type: 'BinaryExpression',
+                left: {
+                  type: 'Identifier',
+                  name: 'a'
+                },
+                right: {
+                  type: 'Identifier',
+                  name: 'b'
+                },
+                operator: '>='
+              },
+              right: {
+                type: 'BinaryExpression',
+                left: {
+                  type: 'Identifier',
+                  name: 'c'
+                },
+                right: {
+                  type: 'Identifier',
+                  name: 'd'
+                },
+                operator: '>='
+              },
+              operator: '!=='
+            }
+          }
+        ]
+      }
+    ],
+    [
       'a << b < c',
       Context.None,
       {


### PR DESCRIPTION
Fixes invalid precedence of `<=` and `>=` operators

According to [mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence#table) `<=` and `>=` operators have precedence same as `<` and `>` and greater than equal operators.

At the moment expression `a >= b !== c >= d` parsed as `((a >= b) !== c) >= d`, but expected `(a >= b) !== (c >= d)`.