### PR TITLE
Allow HTML comments in modules contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ This is the available options:
   // The flag to allow return in the global scope
   globalReturn: false;
 
+  // Allow HTML comments when the module option is `true`
+  htmlCommentModule: false;
+
   // The flag to enable implied strict mode
   impliedStrict: false;
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -39,6 +39,7 @@ export const enum Context {
   OptionsSpecDeviation = 1 << 29,
   AllowEscapedKeyword = 1 << 30,
   OptionsUniqueKeyInPattern = 1 << 31,
+  OptionsHTMLCommentModule = 1 << 32,
 }
 
 /**

--- a/src/lexer/comments.ts
+++ b/src/lexer/comments.ts
@@ -48,7 +48,7 @@ export function skipSingleHTMLComment(
   line: number,
   column: number
 ): LexerState {
-  if (context & Context.Module) report(parser, Errors.Unexpected);
+  if (context & Context.Module && !(context & Context.OptionsHTMLCommentModule)) report(parser, Errors.Unexpected);
   return skipSingleLineComment(parser, source, state, type, start, line, column);
 }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -227,6 +227,8 @@ export interface Options {
   onToken?: OnToken;
   // Creates unique key for in ObjectPattern when key value are same
   uniqueKeyInPattern?: boolean;
+  // Allow HTML comments when the module option is `true`
+  htmlCommentModule?: boolean;
 }
 
 /**
@@ -242,6 +244,7 @@ export function parseSource(source: string, options: Options | void, context: Co
     if (options.loc) context |= Context.OptionsLoc;
     if (options.ranges) context |= Context.OptionsRanges;
     if (options.uniqueKeyInPattern) context |= Context.OptionsUniqueKeyInPattern;
+    if (options.htmlCommentModule) context |= Context.OptionsHTMLCommentModule;
     if (options.lexical) context |= Context.OptionsLexical;
     if (options.webcompat) context |= Context.OptionsWebCompat;
     if (options.directives) context |= Context.OptionsDirectives | Context.OptionsRaw;


### PR DESCRIPTION
This pull request will add the `htmlCommentModule` option that will allow HTML comments (`<!-- COMMENT -->`) when the module option is enabled. Although browsers forbid modules from having HTML comments in 
module sources, this will allow for more lenient parsing in cases where the source type being a module is unknown.