### PR TITLE
feat(parser): Add support for class static initialization block

### DIFF
--- a/src/estree.ts
+++ b/src/estree.ts
@@ -117,6 +117,7 @@ export type Node =
   | ReturnStatement
   | SequenceExpression
   | SpreadElement
+  | StaticBlock
   | Super
   | SwitchCase
   | SwitchStatement
@@ -274,6 +275,10 @@ interface MethodDefinitionBase extends _Node {
   decorators?: Decorator[];
 }
 
+export interface BlockStatementBase extends _Node {
+  body: Statement[];
+}
+
 export interface ArrayExpression extends _Node {
   type: 'ArrayExpression';
   elements: (Expression | SpreadElement | null)[];
@@ -321,9 +326,8 @@ export interface BinaryExpression extends _Node {
   right: Expression;
 }
 
-export interface BlockStatement extends _Node {
+export interface BlockStatement extends BlockStatementBase {
   type: 'BlockStatement';
-  body: Statement[];
 }
 
 export interface BreakStatement extends _Node {
@@ -354,9 +358,13 @@ export interface CatchClause extends _Node {
   body: BlockStatement;
 }
 
+export interface StaticBlock extends BlockStatementBase {
+  type: 'StaticBlock';
+}
+
 export interface ClassBody extends _Node {
   type: 'ClassBody';
-  body: (ClassElement | PropertyDefinition)[];
+  body: (ClassElement | PropertyDefinition | StaticBlock)[];
 }
 
 export interface PropertyDefinition extends _Node {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -8337,7 +8337,7 @@ function parseClassElementList(
     key = parsePrivateIdentifier(parser, context | Context.InClass, tokenPos, linePos, colPos);
   } else if (context & Context.OptionsNext && (parser.token & Token.IsClassField) === Token.IsClassField) {
     kind |= PropertyKind.ClassField;
-  } else if (context & Context.OptionsNext && isStatic && token === Token.LeftBrace) {
+  } else if (isStatic && token === Token.LeftBrace) {
     return parseStaticBlock(parser, context, scope, tokenPos, linePos, colPos);
   } else if (token === Token.EscapedFutureReserved) {
     key = parseIdentifier(parser, context, 0);

--- a/test/parser/next/static-block.ts
+++ b/test/parser/next/static-block.ts
@@ -1,0 +1,149 @@
+import { Context } from '../../../src/common';
+import { pass, fail } from '../../test-utils';
+
+describe('Next - Class static initialization block', () => {
+  fail('Next - Class static initialization block (fail)', [
+    ['class A { static {} }', Context.OptionsWebCompat],
+    ['class A { static {} }', Context.None],
+    ['class A { static { super() } }', Context.OptionsNext],
+    ['class A {}; class B extends A { static { super() } }', Context.OptionsNext],
+    ['class A { static async {} }', Context.OptionsNext],
+    ['class A { async static {} }', Context.OptionsNext]
+  ]);
+
+  pass('Next - Class static initialization block (pass)', [
+    [
+      `class A { static {} }`,
+      Context.OptionsNext,
+      {
+        body: [
+          {
+            body: {
+              body: [
+                {
+                  body: [],
+                  type: 'StaticBlock'
+                }
+              ],
+              type: 'ClassBody'
+            },
+            decorators: [],
+            id: {
+              name: 'A',
+              type: 'Identifier'
+            },
+            superClass: null,
+            type: 'ClassDeclaration'
+          }
+        ],
+        sourceType: 'script',
+        type: 'Program'
+      }
+    ],
+    [
+      `class A { static { this.a } }`,
+      Context.OptionsNext,
+      {
+        body: [
+          {
+            body: {
+              body: [
+                {
+                  body: [
+                    {
+                      expression: {
+                        computed: false,
+                        object: {
+                          type: 'ThisExpression'
+                        },
+                        property: {
+                          name: 'a',
+                          type: 'Identifier'
+                        },
+                        type: 'MemberExpression'
+                      },
+                      type: 'ExpressionStatement'
+                    }
+                  ],
+                  type: 'StaticBlock'
+                }
+              ],
+              type: 'ClassBody'
+            },
+            decorators: [],
+            id: {
+              name: 'A',
+              type: 'Identifier'
+            },
+            superClass: null,
+            type: 'ClassDeclaration'
+          }
+        ],
+        sourceType: 'script',
+        type: 'Program'
+      }
+    ],
+    [
+      `class A {}; class B extends A { static { super.a } }`,
+      Context.OptionsNext,
+      {
+        body: [
+          {
+            body: {
+              body: [],
+              type: 'ClassBody'
+            },
+            decorators: [],
+            id: {
+              name: 'A',
+              type: 'Identifier'
+            },
+            superClass: null,
+            type: 'ClassDeclaration'
+          },
+          {
+            type: 'EmptyStatement'
+          },
+          {
+            body: {
+              body: [
+                {
+                  body: [
+                    {
+                      expression: {
+                        computed: false,
+                        object: {
+                          type: 'Super'
+                        },
+                        property: {
+                          name: 'a',
+                          type: 'Identifier'
+                        },
+                        type: 'MemberExpression'
+                      },
+                      type: 'ExpressionStatement'
+                    }
+                  ],
+                  type: 'StaticBlock'
+                }
+              ],
+              type: 'ClassBody'
+            },
+            decorators: [],
+            id: {
+              name: 'B',
+              type: 'Identifier'
+            },
+            superClass: {
+              name: 'A',
+              type: 'Identifier'
+            },
+            type: 'ClassDeclaration'
+          }
+        ],
+        sourceType: 'script',
+        type: 'Program'
+      }
+    ]
+  ]);
+});

--- a/test/parser/statements/static-block.ts
+++ b/test/parser/statements/static-block.ts
@@ -3,18 +3,16 @@ import { pass, fail } from '../../test-utils';
 
 describe('Next - Class static initialization block', () => {
   fail('Next - Class static initialization block (fail)', [
-    ['class A { static {} }', Context.OptionsWebCompat],
-    ['class A { static {} }', Context.None],
-    ['class A { static { super() } }', Context.OptionsNext],
-    ['class A {}; class B extends A { static { super() } }', Context.OptionsNext],
-    ['class A { static async {} }', Context.OptionsNext],
-    ['class A { async static {} }', Context.OptionsNext]
+    ['class A { static { super() } }', Context.None],
+    ['class A {}; class B extends A { static { super() } }', Context.None],
+    ['class A { static async {} }', Context.None],
+    ['class A { async static {} }', Context.None]
   ]);
 
   pass('Next - Class static initialization block (pass)', [
     [
       `class A { static {} }`,
-      Context.OptionsNext,
+      Context.None,
       {
         body: [
           {
@@ -27,7 +25,6 @@ describe('Next - Class static initialization block', () => {
               ],
               type: 'ClassBody'
             },
-            decorators: [],
             id: {
               name: 'A',
               type: 'Identifier'
@@ -42,7 +39,7 @@ describe('Next - Class static initialization block', () => {
     ],
     [
       `class A { static { this.a } }`,
-      Context.OptionsNext,
+      Context.None,
       {
         body: [
           {
@@ -70,7 +67,6 @@ describe('Next - Class static initialization block', () => {
               ],
               type: 'ClassBody'
             },
-            decorators: [],
             id: {
               name: 'A',
               type: 'Identifier'
@@ -85,7 +81,7 @@ describe('Next - Class static initialization block', () => {
     ],
     [
       `class A {}; class B extends A { static { super.a } }`,
-      Context.OptionsNext,
+      Context.None,
       {
         body: [
           {
@@ -93,7 +89,6 @@ describe('Next - Class static initialization block', () => {
               body: [],
               type: 'ClassBody'
             },
-            decorators: [],
             id: {
               name: 'A',
               type: 'Identifier'
@@ -129,7 +124,6 @@ describe('Next - Class static initialization block', () => {
               ],
               type: 'ClassBody'
             },
-            decorators: [],
             id: {
               name: 'B',
               type: 'Identifier'


### PR DESCRIPTION
Attempts to fix #194 and one point from #214.

    extend interface ClassBody {
      body: [ MethodDefinition | PropertyDefinition | StaticBlock ];
    }

    interface StaticBlock <: BlockStatement {
      type: "StaticBlock";
    }

Proposal: https://github.com/tc39/proposal-class-static-block
MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Class_static_initialization_blocks
V8 examples: https://v8.dev/features/class-static-initializer-blocks
ESTree: https://github.com/estree/estree/blob/master/es2022.md#staticblock
