### PR TITLE
Fix escaped async keyword and escaped dot property

### DIFF
--- a/src/lexer/identifier.ts
+++ b/src/lexer/identifier.ts
@@ -85,13 +85,20 @@ export function scanIdentifierSlowCase(
     }
 
     if (context & Context.Strict) {
-      return token === Token.StaticKeyword
-        ? Token.EscapedFutureReserved
-        : (token & Token.FutureReserved) === Token.FutureReserved
-        ? Token.EscapedFutureReserved
-        : (token & Token.Reserved) === Token.Reserved
-        ? Token.EscapedReserved
-        : Token.AnyIdentifier;
+      if (token === Token.StaticKeyword) {
+        return Token.EscapedFutureReserved;
+      }
+      if ((token & Token.FutureReserved) === Token.FutureReserved) {
+        return Token.EscapedFutureReserved;
+      }
+      if ((token & Token.Reserved) === Token.Reserved) {
+        if (context & Context.AllowEscapedKeyword && (context & Context.InGlobal) === 0) {
+          return token;
+        } else {
+          return Token.EscapedReserved;
+        }
+      }
+      return Token.AnyIdentifier;
     }
     if (
       context & Context.AllowEscapedKeyword &&

--- a/src/lexer/identifier.ts
+++ b/src/lexer/identifier.ts
@@ -76,14 +76,22 @@ export function scanIdentifierSlowCase(
     if (token === void 0) return Token.Identifier;
     if (!hasEscape) return token;
 
+    if (token === Token.AwaitKeyword) {
+      // await is only reserved word in async functions or modules
+      if ((context & (Context.Module | Context.InAwaitContext)) === 0) {
+        return token;
+      }
+      return Token.EscapedReserved;
+    }
+
     if (context & Context.Strict) {
-      return token === Token.AwaitKeyword && (context & (Context.Module | Context.InAwaitContext)) === 0
-        ? token
-        : token === Token.StaticKeyword
+      return token === Token.StaticKeyword
         ? Token.EscapedFutureReserved
         : (token & Token.FutureReserved) === Token.FutureReserved
         ? Token.EscapedFutureReserved
-        : Token.EscapedReserved;
+        : (token & Token.Reserved) === Token.Reserved
+        ? Token.EscapedReserved
+        : Token.AnyIdentifier;
     }
     if (
       context & Context.AllowEscapedKeyword &&
@@ -99,13 +107,17 @@ export function scanIdentifierSlowCase(
         : token;
     }
 
-    return token === Token.AsyncKeyword && context & Context.AllowEscapedKeyword
-      ? Token.AnyIdentifier
-      : (token & Token.FutureReserved) === Token.FutureReserved
-      ? token
-      : token === Token.AwaitKeyword && (context & Context.InAwaitContext) === 0
-      ? token
-      : Token.EscapedReserved;
+    // async is not reserved; it can be used as a variable name
+    // or statement label without restriction
+    if (token === Token.AsyncKeyword) {
+      // Escaped "async" such as \u0061sync can only be identifier
+      // not as "async" keyword
+      return Token.AnyIdentifier;
+    }
+    if ((token & Token.FutureReserved) === Token.FutureReserved) {
+      return token;
+    }
+    return Token.EscapedReserved;
   }
   return Token.Identifier;
 }

--- a/src/token.ts
+++ b/src/token.ts
@@ -162,7 +162,7 @@ export const enum Token {
   /* Contextual keywords */
   AsKeyword          = 110 | Contextual | IsExpressionStart,
   AsyncKeyword       = 111 | Contextual | IsIdentifier | IsExpressionStart,
-  AwaitKeyword       = 112 | Contextual | IsExpressionStart | IsIdentifier,
+  AwaitKeyword       = 112 | Contextual | IsExpressionStart | IsIdentifier, // await is only reserved word in async functions or modules
   ConstructorKeyword = 113 | Contextual,
   GetKeyword         = 114 | Contextual,
   SetKeyword         = 115 | Contextual,

--- a/test/lexer/identifiers.ts
+++ b/test/lexer/identifiers.ts
@@ -90,9 +90,11 @@ describe('Lexer - Identifiers', () => {
     [Context.None, Token.LetKeyword, 'let', 'let'],
     [Context.None, Token.PublicKeyword, 'public', 'public'],
 
+    // Async is not reserved keyword
+    [Context.None, Token.AnyIdentifier, '\\u0061sync', 'async'],
+    [Context.Strict, Token.AnyIdentifier, '\\u0061sync', 'async'],
+
     // Escaped Keywords
-    [Context.None, Token.EscapedReserved, '\\u0061sync', 'async'],
-    [Context.Strict, Token.EscapedReserved, '\\u0061sync', 'async'],
     [Context.None, Token.EscapedReserved, 'br\\u0065ak', 'break'],
     [Context.None, Token.Identifier, 'Br\\u0065ak', 'Break'],
     [Context.Strict, Token.EscapedFutureReserved, 'int\\u0065rface', 'interface'],

--- a/test/parser/miscellaneous/escaped-keyword.ts
+++ b/test/parser/miscellaneous/escaped-keyword.ts
@@ -89,11 +89,21 @@ describe('Miscellaneous - Escaped keywords', () => {
     `async function a() {
       \\u0061sync
       p => {}
-    }`
+    }`,
+    `obj.bre\\u0061k = 42;`,
+    `for (\\u0061sync of [7]);`
   ]) {
     it(`${arg}`, () => {
       t.doesNotThrow(() => {
         parseSource(`${arg}`, undefined, Context.None);
+      });
+    });
+  }
+
+  for (const arg of [`obj.bre\\u0061k = 42;`, `for (\\u0061sync of [7]);`]) {
+    it(`${arg}`, () => {
+      t.doesNotThrow(() => {
+        parseSource(`${arg}`, undefined, Context.Strict | Context.Module);
       });
     });
   }


### PR DESCRIPTION
fix: async is not reserved word, and some fix on reserved words
fix: dot property should allow escaped keyword in strict mode
closes #221, #224