### PR TITLE
fix(parser): "static" can be used as an identifier in ClassElement

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -8281,7 +8281,12 @@ function parseClassElementList(
 
     switch (token) {
       case Token.StaticKeyword:
-        if (!isStatic && parser.token !== Token.LeftParen) {
+        if (
+          !isStatic &&
+          parser.token !== Token.LeftParen &&
+          (parser.token & Token.IsAutoSemicolon) !== Token.IsAutoSemicolon &&
+          parser.token !== Token.Assign
+        ) {
           return parseClassElementList(
             parser,
             context,

--- a/test/parser/expressions/class.ts
+++ b/test/parser/expressions/class.ts
@@ -12681,6 +12681,114 @@ describe('Expressions - Class', () => {
         sourceType: 'script',
         type: 'Program'
       }
+    ],
+    [
+      `class A { static }`,
+      Context.OptionsNext | Context.Module,
+      {
+        body: [
+          {
+            body: {
+              body: [
+                {
+                  computed: false,
+                  decorators: [],
+                  key: {
+                    name: 'static',
+                    type: 'Identifier'
+                  },
+                  static: false,
+                  type: 'PropertyDefinition',
+                  value: null
+                }
+              ],
+              type: 'ClassBody'
+            },
+            decorators: [],
+            id: {
+              name: 'A',
+              type: 'Identifier'
+            },
+            superClass: null,
+            type: 'ClassDeclaration'
+          }
+        ],
+        sourceType: 'module',
+        type: 'Program'
+      }
+    ],
+    [
+      `class A { static; }`,
+      Context.OptionsNext | Context.Module,
+      {
+        body: [
+          {
+            body: {
+              body: [
+                {
+                  computed: false,
+                  decorators: [],
+                  key: {
+                    name: 'static',
+                    type: 'Identifier'
+                  },
+                  static: false,
+                  type: 'PropertyDefinition',
+                  value: null
+                }
+              ],
+              type: 'ClassBody'
+            },
+            decorators: [],
+            id: {
+              name: 'A',
+              type: 'Identifier'
+            },
+            superClass: null,
+            type: 'ClassDeclaration'
+          }
+        ],
+        sourceType: 'module',
+        type: 'Program'
+      }
+    ],
+    [
+      `class A { static = 1 }`,
+      Context.OptionsNext | Context.Module,
+      {
+        body: [
+          {
+            body: {
+              body: [
+                {
+                  computed: false,
+                  decorators: [],
+                  key: {
+                    name: 'static',
+                    type: 'Identifier'
+                  },
+                  static: false,
+                  type: 'PropertyDefinition',
+                  value: {
+                    type: 'Literal',
+                    value: 1
+                  }
+                }
+              ],
+              type: 'ClassBody'
+            },
+            decorators: [],
+            id: {
+              name: 'A',
+              type: 'Identifier'
+            },
+            superClass: null,
+            type: 'ClassDeclaration'
+          }
+        ],
+        sourceType: 'module',
+        type: 'Program'
+      }
     ]
   ]);
 });


### PR DESCRIPTION
closes #231

Not 100% sure about the implementation.

The spec didn't tell me exact steps. https://262.ecma-international.org/13.0/#sec-static-semantics-isstatic

I tried to use an allowed-list (~~whitelist~~), but there are few conditions like `static "str-id" = 1;` `static *generator()`, I am not confident to cover them all.

So I extended the current blocked-list (~~blacklist~~) for the logic.