### PR TITLE
Fix issue with import located in a sequence

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2700,7 +2700,7 @@ function parseImportCallDeclaration(
   line: number,
   column: number
 ): ESTree.ExpressionStatement {
-  let expr = parseImportExpression(parser, context, /* inGroup */ 0, start, line, column);
+  let expr: ESTree.Expression = parseImportExpression(parser, context, /* inGroup */ 0, start, line, column);
 
   /** MemberExpression :
    *   1. PrimaryExpression
@@ -2722,6 +2722,10 @@ function parseImportCallDeclaration(
    */
 
   expr = parseMemberOrUpdateExpression(parser, context, expr, 0, 0, start, line, column);
+
+  if (parser.token === Token.Comma) {
+    expr = parseSequenceExpression(parser, context, 0, start, line, column, expr);
+  }
 
   /**
    * ExpressionStatement[Yield, Await]:

--- a/test/parser/expressions/import_call.ts
+++ b/test/parser/expressions/import_call.ts
@@ -111,6 +111,8 @@ describe('Next - ImportCall', () => {
     'let Layout = () => import("../foo/bar/zoo.js")',
     '"use strict"; import("test.js");',
     'function loadImport(file) { return import(`test/${file}.js`); }',
+    'function loadImport(file) { return import(file).then(() => {}), console.log("Done."); }',
+    'function loadImport(file) { import(file).then(() => {}), console.log("Done."); }',
     '() => { import(x) }',
     '(import(y=x))',
     '{import(y=x)}',
@@ -250,6 +252,95 @@ describe('Next - ImportCall', () => {
               type: 'Identifier'
             },
             params: [],
+            type: 'FunctionDeclaration'
+          }
+        ],
+        sourceType: 'script',
+        type: 'Program'
+      }
+    ],
+    [
+      'function loadImport(file) { import(file).then(() => {}), console.log("Done."); }',
+      Context.OptionsNext,
+      {
+        body: [
+          {
+            async: false,
+            body: {
+              body: [
+                {
+                  expression: {
+                    expressions: [
+                      {
+                        arguments: [
+                          {
+                            async: false,
+                            body: {
+                              body: [],
+                              type: 'BlockStatement'
+                            },
+                            expression: false,
+                            params: [],
+                            type: 'ArrowFunctionExpression'
+                          }
+                        ],
+                        callee: {
+                          computed: false,
+                          object: {
+                            source: {
+                              name: 'file',
+                              type: 'Identifier'
+                            },
+                            type: 'ImportExpression'
+                          },
+                          property: {
+                            name: 'then',
+                            type: 'Identifier'
+                          },
+                          type: 'MemberExpression'
+                        },
+                        type: 'CallExpression'
+                      },
+                      {
+                        arguments: [
+                          {
+                            type: 'Literal',
+                            value: 'Done.'
+                          }
+                        ],
+                        callee: {
+                          computed: false,
+                          object: {
+                            name: 'console',
+                            type: 'Identifier'
+                          },
+                          property: {
+                            name: 'log',
+                            type: 'Identifier'
+                          },
+                          type: 'MemberExpression'
+                        },
+                        type: 'CallExpression'
+                      }
+                    ],
+                    type: 'SequenceExpression'
+                  },
+                  type: 'ExpressionStatement'
+                }
+              ],
+              type: 'BlockStatement'
+            },
+            generator: false,
+            id: {
+              name: 'loadImport',
+              type: 'Identifier'
+            },
+            params: [
+              {
+                name: 'file',
+                type: 'Identifier'
+              }
+            ],
             type: 'FunctionDeclaration'
           }
         ],


### PR DESCRIPTION
The PR fixes an error with the following construct:
```js
function() {
   import('some.js').then(e => e || {}), (this.some = !0);
}
```