### PR TITLE
Ensure that types are exported

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "unpkg": "dist/meriyah.umd.min.js",
   "exports": {
     "import": "./dist/meriyah.esm.mjs",
-    "require": "./dist/meriyah.cjs"
+    "require": "./dist/meriyah.cjs",
+    "types": "./dist/src/meriyah.d.ts"
   },
   "types": "dist/src/meriyah.d.ts",
   "typings": "dist/src/meriyah.d.ts",


### PR DESCRIPTION
Fix for the following problem:

```
Could not find a declaration file for module 'meriyah'. '/path/to/node_modules/meriyah/dist/meriyah.esm.mjs' implicitly has an 'any' type.
  There are types at '/path/to/node_modules/meriyah/dist/src/meriyah.d.ts', but this result could not be resolved when respecting package.json "exports". The 'meriyah' library may need to update its package.json or typings.

import { parseScript } from 'meriyah';
```