### PR TITLE
Fix parsing of nested class with constructor

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -8204,6 +8204,8 @@ export function parseClassBody(
 
   consume(parser, context | Context.AllowRegExp, Token.LeftBrace);
   context = (context | Context.DisallowIn) ^ Context.DisallowIn;
+
+  let hasConstr = parser.flags & Flags.HasConstructor;
   parser.flags = (parser.flags | Flags.HasConstructor) ^ Flags.HasConstructor;
 
   const body: (ESTree.MethodDefinition | ESTree.PropertyDefinition | ESTree.StaticBlock)[] = [];
@@ -8245,6 +8247,7 @@ export function parseClassBody(
     );
   }
   consume(parser, origin & Origin.Declaration ? context | Context.AllowRegExp : context, Token.RightBrace);
+  parser.flags = (parser.flags & ~Flags.HasConstructor) | hasConstr;
 
   return finishNode(parser, context, tokenPos, linePos, colPos, {
     type: 'ClassBody',

--- a/test/parser/expressions/class.ts
+++ b/test/parser/expressions/class.ts
@@ -310,7 +310,20 @@ describe('Expressions - Class', () => {
     'static constructor() {}',
     'static get constructor() {}',
     'static set constructor(_) {}',
-    'static *constructor() {}'
+    'static *constructor() {}',
+    `method() {
+       new class { constructor() {} }
+     }
+     constructor() {}`,
+    `method() {
+       new class {
+         method() {
+           new class { constructor() {} }
+         }
+         constructor() {}
+       }
+     }
+     constructor() {}`,
   ]) {
     it(`class C {${arg}}`, () => {
       t.doesNotThrow(() => {
@@ -799,7 +812,9 @@ describe('Expressions - Class', () => {
     ['(class A { static prototype() {} })', Context.None],
     ['(class A { static *get [x](){} })', Context.None],
     ['(class A { static *set [x](y){}})', Context.None],
-    ['async function f(foo = class y extends (await f) {}){}', Context.None]
+    ['async function f(foo = class y extends (await f) {}){}', Context.None],
+    ['new class { constructor() {} start() { new class { constructor() {}}} constructor() {}}', Context.None],
+    ['new class { constructor() {} start() { new class { } } constructor() {}}', Context.None]
   ]);
 
   for (const arg of [
@@ -12788,6 +12803,121 @@ describe('Expressions - Class', () => {
         ],
         sourceType: 'module',
         type: 'Program'
+      }
+    ],
+    [
+      `new class {
+        start() {
+          new class {
+            constructor() {}
+          }
+        }
+        constructor() {}
+      }`,
+      Context.None,
+      {
+        body: [
+          {
+            type: "ExpressionStatement",
+            expression: {
+              type: "NewExpression",
+              callee: {
+                type: "ClassExpression",
+                id: null,
+                superClass: null,
+                body: {
+                  type: "ClassBody",
+                  body: [
+                    {
+                      type: "MethodDefinition",
+                      kind: "method",
+                      static: false,
+                      computed: false,
+                      key: {
+                        type: "Identifier",
+                        name: "start"
+                      },
+                      value: {
+                        type: "FunctionExpression",
+                        params: [],
+                        body: {
+                          type: "BlockStatement",
+                          body: [
+                            {
+                              type: "ExpressionStatement",
+                              expression: {
+                                type: "NewExpression",
+                                callee: {
+                                  type: "ClassExpression",
+                                  id: null,
+                                  superClass: null,
+                                  body: {
+                                    type: "ClassBody",
+                                    body: [
+                                      {
+                                        type: "MethodDefinition",
+                                        kind: "constructor",
+                                        static: false,
+                                        computed: false,
+                                        key: {
+                                          type: "Identifier",
+                                          name: "constructor"
+                                        },
+                                        value: {
+                                          type: "FunctionExpression",
+                                          params: [],
+                                          body: {
+                                            type: "BlockStatement",
+                                            body: []
+                                          },
+                                          async: false,
+                                          generator: false,
+                                          id: null
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                arguments: []
+                              }
+                            }
+                          ]
+                        },
+                        async: false,
+                        generator: false,
+                        id: null
+                      }
+                    },
+                    {
+                      type: "MethodDefinition",
+                      kind: "constructor",
+                      static: false,
+                      computed: false,
+                      key: {
+                        type: "Identifier",
+                        name: "constructor"
+                      },
+                      value: {
+                        type: "FunctionExpression",
+                        params: [],
+                        body: {
+                          type: "BlockStatement",
+                          body: []
+                        },
+                        async: false,
+                        generator: false,
+                        id: null
+                      }
+                    }
+                  ]
+                }
+              },
+              arguments: []
+            }
+          }
+        ],
+        type: "Program",
+        sourceType: "script"
       }
     ]
   ]);


### PR DESCRIPTION
Fixes the issue described below by remembering the HasConstructor flag and restoring it after parsing the class body.

---

Meriyah fails to parse the following code:

```
new class {
  start() {
    new class {
      constructor() {}
    }
  }

  constructor() {}          
}
```

Seems that the position of the outer constructor is what causes the problem cause when the outer constructor is above the start method Meriyah can parse it.

This snippet succeeds

```
new class {
  constructor() {}          

  start() {
    new class {
      constructor() {}
    }
  }
}
```