### PR TITLE
fix for regexp test after do-while with semicolon

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1802,7 +1802,7 @@ export function parseDoWhileStatement(
   // The previous token is ) and the inserted semicolon would then be parsed as the terminating semicolon of a do-while statement (13.7.2).
   // This cannot be implemented in matchOrInsertSemicolon() because it doesn't know
   // this RightRaren is the end of a do-while statement.
-  consumeOpt(parser, context, Token.Semicolon);
+  consumeOpt(parser, context | Context.AllowRegExp, Token.Semicolon);
   return finishNode(parser, context, start, line, column, {
     type: 'DoWhileStatement',
     body,

--- a/test/parser/statements/do-while.ts
+++ b/test/parser/statements/do-while.ts
@@ -718,6 +718,55 @@ while(y)
           }
         ]
       }
+    ],
+    [
+      'do { } while (a); /^.*$/.test(b)',
+      Context.OptionsWebCompat,
+      {
+        type: 'Program',
+        sourceType: 'script',
+        body: [
+          {
+            type: 'DoWhileStatement',
+            body: {
+              type: 'BlockStatement',
+              body: []
+            },
+            test: {
+              type: 'Identifier',
+              name: 'a'
+            }
+          },
+          {
+            type: 'ExpressionStatement',
+            expression: {
+              type: 'CallExpression',
+              callee: {
+                type: 'MemberExpression',
+                object: {
+                  type: 'Literal',
+                  value: /^.*$/,
+                  regex: {
+                    pattern: '^.*$',
+                    flags: ''
+                  }
+                },
+                computed: false,
+                property: {
+                  type: 'Identifier',
+                  name: 'test'
+                }
+              },
+              arguments: [
+                {
+                  type: 'Identifier',
+                  name: 'b'
+                }
+              ]
+            }
+          }
+        ]
+      }
     ]
   ]);
 });


### PR DESCRIPTION
Fix for bug found when attempting to parse a regexp test immediately after a do-while loop terminated by a semicolon.