### PR TITLE
feat(parser): add onInsertedSemicolon option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ This is the available options:
   // Allows comment extraction. Accepts either a function or array
   onComment: []
 
+  // Allows detection of automatic semicolon insertion. Accepts a callback function that will be passed the charater offset where the semicolon was inserted
+  onInsertedSemicolon: (pos) => {}
+
   // Allows token extraction. Accepts either a function or array
   onToken: []
 
@@ -115,12 +118,19 @@ If an array is supplied, comments/tokens will be pushed to the array, the item i
 If a function callback is supplied, the signature must be
 
 ```ts
-function onComment(type: string, value: string, start: number, end: number, loc: SourceLocation): void {}
+declare function onComment(type: string, value: string, start: number, end: number, loc: SourceLocation): void;
 
-function onToken(token: string, start: number, end: number, loc: SourceLocation): void {}
+declare function onToken(token: string, start: number, end: number, loc: SourceLocation): void;
 ```
 
 Note the `start/end/loc` information are provided to the function callback regardless of the settings on ranges and loc flags. onComment callback has one extra argument `value: string` for the body string of the comment.
+
+### onInsertedSemicolon
+If a function callback is supplied, the signature must be
+
+```ts
+declare function onInsertedSemicolon(position: number): void;
+```
 
 ## Example usage
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -174,6 +174,11 @@ export const enum ScopeKind {
 export type OnComment = void | Comment[] | ((type: string, value: string, start: number, end: number, loc: SourceLocation) => any);
 
 /**
+ * The type of the `onInsertedSemicolon` option.
+ */
+export type OnInsertedSemicolon = void | ((pos: number) => any);
+
+/**
  * The type of the `onToken` option.
  */
 export type OnToken = void | Token[] | ((token: string, start: number, end: number, loc: SourceLocation) => any);
@@ -214,6 +219,7 @@ export interface ParserState {
   end: number;
   token: Token;
   onComment: any;
+  onInsertedSemicolon: any;
   onToken: any;
   tokenValue: any;
   tokenRaw: string;
@@ -247,7 +253,11 @@ export function matchOrInsertSemicolon(parser: ParserState, context: Context, sp
   ) {
     report(parser, Errors.UnexpectedToken, KeywordDescTable[parser.token & Token.Type]);
   }
-  consumeOpt(parser, context, Token.Semicolon);
+
+  if (!consumeOpt(parser, context, Token.Semicolon)) {
+    // Automatic semicolon insertion has occurred
+    parser.onInsertedSemicolon?.(parser.startPos);
+  }
 }
 
 export function isValidStrictMode(parser: ParserState, index: number, tokenPos: number, tokenValue: string): 0 | 1 {

--- a/test/parser/miscellaneous/onInsertedSemicolon.ts
+++ b/test/parser/miscellaneous/onInsertedSemicolon.ts
@@ -1,0 +1,14 @@
+import * as t from 'assert';
+import { parseScript } from '../../../src/meriyah';
+
+describe('Miscellaneous - oninsertedSemicolon', () => {
+  it('invokes the callback when automatic semicolon insertion occurs', () => {
+    const semicolons: number[] = [];
+    const lines = ['"use strict"', 'self.a;', 'self.b'];
+    const input = lines.join('\n');
+    parseScript(input, {
+      onInsertedSemicolon: (pos) => semicolons.push(pos)
+    });
+    t.deepEqual(semicolons, [lines[0].length, input.length]);
+  });
+});


### PR DESCRIPTION
Adds support for the `onInsertedSemicolon` callback option, matching the base behavior of the `acorn` option of the same name. This option is used by `webpack` to identify when replacing the text of a node with a parenthesized expression would run afoul of a difference in runtime behavior if automatic semicolon insertion occurred.

Motivating example:
```js
console.log('hi!') // ASI occurs here
foo() // ASI occurs here
console.log(foo.name)
```

If webpack replaces `foo` with the imported expression `(0,some_module.foo)`, the resulting code has the runtime behavior of

```js
console.log('hi!')(0,some_module.foo)() // tried to call the result of `console.log`, TypeError
console.log((0,some_module.foo).name) // Correct code
```

On the other hand, if webpack tries to always insert a semicolon, we instead have

```js
console.log('hi') // ASI not needed
;(0,some_module.foo)() // Correct code
console.log(;(0,some_module.foo).name) // Syntax error
```

Ultimately this is an issue because webpack doesn't perform all transforms on the AST layer and run the code through a printer for performance reasons.

The lack of this option is the one difference in behavior between `acorn` and `meriyah` that would potentially impact using `meriyah` in `webpack` for a 20-30% AST parse performance boost.

Adds a basic unit test for the feature.