### PR TITLE
Fix template strings with octal or hex values

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3929,7 +3929,7 @@ export function parseMemberOrUpdateExpression(
 
         parser.assignable = AssignmentKind.Assignable;
 
-        const property = parsePropertyOrPrivatePropertyName(parser, context);
+        const property = parsePropertyOrPrivatePropertyName(parser, context | Context.TaggedTemplate);
 
         expr = finishNode(parser, context, start, line, column, {
           type: 'MemberExpression',
@@ -4287,7 +4287,7 @@ export function parsePrimaryExpression(
     case Token.LeftParen:
       return parseParenthesizedExpression(
         parser,
-        context,
+        context | Context.TaggedTemplate,
         canAssign,
         BindingKind.ArgumentList,
         Origin.None,
@@ -4663,7 +4663,7 @@ export function parseArguments(
   const args: (ESTree.Expression | ESTree.SpreadElement)[] = [];
 
   if (parser.token === Token.RightParen) {
-    nextToken(parser, context);
+    nextToken(parser, context | Context.TaggedTemplate);
     return args;
   }
 

--- a/test/parser/expressions/template.ts
+++ b/test/parser/expressions/template.ts
@@ -338,7 +338,15 @@ describe('Expressions - Template', () => {
     'test`\\18`;',
     '(`\n`)',
     '(`\r`)',
-    'new nestedNewOperatorFunction`1``2``3``array`'
+    'new nestedNewOperatorFunction`1``2``3``array`',
+    "tag()`'\\00a0'`;",
+    "(tag = () => {})`'\\00a0'`",
+    "(() => {})`'\\00a0'`",
+    "(function tag() { return () => {}; })()`'\\00a0'`",
+    "(function() { return () => {}; })()`'\\00a0'`",
+    "(function tag() {})`'\\00a0'`",
+    "(function() {})`'\\00a0'`",
+    'String.raw`{\rtf1adeflang1025ansiansicpg1252\\uc1`;'
   ]) {
     it(`${arg}`, () => {
       t.doesNotThrow(() => {
@@ -4032,6 +4040,134 @@ describe('Expressions - Template', () => {
             column: 0
           }
         }
+      }
+    ],
+    [
+      "tag()`'\\00a0'`;",
+      Context.None,
+      {
+        body: [
+          {
+            expression: {
+              quasi: {
+                expressions: [],
+                quasis: [
+                  {
+                    tail: true,
+                    type: 'TemplateElement',
+                    value: {
+                      cooked: undefined,
+                      raw: "'\\00a0'"
+                    }
+                  }
+                ],
+                type: 'TemplateLiteral'
+              },
+              tag: {
+                arguments: [],
+                callee: {
+                  name: 'tag',
+                  type: 'Identifier'
+                },
+                type: 'CallExpression'
+              },
+              type: 'TaggedTemplateExpression'
+            },
+            type: 'ExpressionStatement'
+          }
+        ],
+        sourceType: 'script',
+        type: 'Program'
+      }
+    ],
+    [
+      "(tag = () => {})`'\\00a0'`",
+      Context.None,
+      {
+        body: [
+          {
+            expression: {
+              quasi: {
+                expressions: [],
+                quasis: [
+                  {
+                    tail: true,
+                    type: 'TemplateElement',
+                    value: {
+                      cooked: undefined,
+                      raw: "'\\00a0'"
+                    }
+                  }
+                ],
+                type: 'TemplateLiteral'
+              },
+              tag: {
+                left: {
+                  name: 'tag',
+                  type: 'Identifier'
+                },
+                operator: '=',
+                right: {
+                  async: false,
+                  body: {
+                    body: [],
+                    type: 'BlockStatement'
+                  },
+                  expression: false,
+                  params: [],
+                  type: 'ArrowFunctionExpression'
+                },
+                type: 'AssignmentExpression'
+              },
+              type: 'TaggedTemplateExpression'
+            },
+            type: 'ExpressionStatement'
+          }
+        ],
+        sourceType: 'script',
+        type: 'Program'
+      }
+    ],
+    [
+      'String.raw`{\rtf1adeflang1025ansiansicpg1252\\uc1`;',
+      Context.None,
+      {
+        body: [
+          {
+            expression: {
+              quasi: {
+                expressions: [],
+                quasis: [
+                  {
+                    tail: true,
+                    type: 'TemplateElement',
+                    value: {
+                      cooked: undefined,
+                      raw: '{\rtf1adeflang1025ansiansicpg1252\\uc1'
+                    }
+                  }
+                ],
+                type: 'TemplateLiteral'
+              },
+              tag: {
+                computed: false,
+                object: {
+                  name: 'String',
+                  type: 'Identifier'
+                },
+                property: {
+                  name: 'raw',
+                  type: 'Identifier'
+                },
+                type: 'MemberExpression'
+              },
+              type: 'TaggedTemplateExpression'
+            },
+            type: 'ExpressionStatement'
+          }
+        ],
+        sourceType: 'script',
+        type: 'Program'
       }
     ]
   ]);


### PR DESCRIPTION
The PR fixes these two corner cases with template strings:

```js
1. tag()`template string with octal or hex value`
2. String.raw`template string with octal or hex value`
```