### PR TITLE
chore: remove specDeviation option which has never been passed to matchOrInsertSemicolon

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,6 @@ This is the available options:
 
    // Enable React JSX parsing
   jsx: false
-
-  // Allow edge cases that deviate from the spec
-  specDeviation: false
 }
 
 ```

--- a/src/common.ts
+++ b/src/common.ts
@@ -36,9 +36,8 @@ export const enum Context {
   AllowNewTarget = 1 << 26,
   DisallowIn = 1 << 27,
   OptionsIdentifierPattern = 1 << 28,
-  OptionsSpecDeviation = 1 << 29,
-  AllowEscapedKeyword = 1 << 30,
-  OptionsUniqueKeyInPattern = 1 << 31,
+  AllowEscapedKeyword = 1 << 29,
+  OptionsUniqueKeyInPattern = 1 << 30,
 }
 
 /**
@@ -244,12 +243,11 @@ export interface ParserState {
  * @param context Context masks
  */
 
-export function matchOrInsertSemicolon(parser: ParserState, context: Context, specDeviation?: number): void {
+export function matchOrInsertSemicolon(parser: ParserState, context: Context): void {
 
   if (
     (parser.flags & Flags.NewLine) === 0 &&
-    (parser.token & Token.IsAutoSemicolon) !== Token.IsAutoSemicolon &&
-    !specDeviation
+    (parser.token & Token.IsAutoSemicolon) !== Token.IsAutoSemicolon
   ) {
     report(parser, Errors.UnexpectedToken, KeywordDescTable[parser.token & Token.Type]);
   }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -226,8 +226,6 @@ export interface Options {
   identifierPattern?: boolean;
   // Enable React JSX parsing
   jsx?: boolean;
-  // Allow edge cases that deviate from the spec
-  specDeviation?: boolean;
   // Allows comment extraction. Accepts either a callback function or an array
   onComment?: OnComment;
   // Allows detection of automatic semicolon insertion. Accepts a callback function that will be passed the charater offset where the semicolon was inserted
@@ -261,7 +259,6 @@ export function parseSource(source: string, options: Options | void, context: Co
     if (options.impliedStrict) context |= Context.Strict;
     if (options.jsx) context |= Context.OptionsJSX;
     if (options.identifierPattern) context |= Context.OptionsIdentifierPattern;
-    if (options.specDeviation) context |= Context.OptionsSpecDeviation;
     if (options.source) sourceFile = options.source;
     // Accepts either a callback function to be invoked or an array to collect comments (as the node is constructed)
     if (options.onComment != null) {
@@ -1850,7 +1847,7 @@ export function parseDoWhileStatement(
   // ECMA-262, section 11.9
   // The previous token is ) and the inserted semicolon would then be parsed as the terminating semicolon of a do-while statement (13.7.2).
   // This cannot be implemented in matchOrInsertSemicolon() because it doesn't know
-  // this RightRaren is the end of a do-while statement.
+  // this RightParen is the end of a do-while statement.
   consumeOpt(parser, context | Context.AllowRegExp, Token.Semicolon);
   return finishNode(parser, context, start, line, column, {
     type: 'DoWhileStatement',

--- a/test/parser/miscellaneous/api.ts
+++ b/test/parser/miscellaneous/api.ts
@@ -9,7 +9,6 @@ describe('Expressions - API', () => {
         globalReturn: true,
         ranges: true,
         webcompat: true,
-        specDeviation: true,
         module: true,
         preserveParens: true,
         jsx: true,


### PR DESCRIPTION
Although it removes an option, this is not a breaking change as the option has no effect at all.