### PR TITLE
chore: remove option identifierPattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,6 @@ This is the available options:
   // Adds a source attribute in every node’s loc object when the locations option is `true`
   source: false;
 
-  // Distinguish Identifier from IdentifierPattern
-  identifierPattern: false;
-
    // Enable React JSX parsing
   jsx: false
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -35,9 +35,8 @@ export const enum Context {
   InMethod = 1 << 25,
   AllowNewTarget = 1 << 26,
   DisallowIn = 1 << 27,
-  OptionsIdentifierPattern = 1 << 28,
-  AllowEscapedKeyword = 1 << 29,
-  OptionsUniqueKeyInPattern = 1 << 30,
+  AllowEscapedKeyword = 1 << 28,
+  OptionsUniqueKeyInPattern = 1 << 29,
 }
 
 /**

--- a/test/parser/miscellaneous/api.ts
+++ b/test/parser/miscellaneous/api.ts
@@ -12,7 +12,6 @@ describe('Expressions - API', () => {
         module: true,
         preserveParens: true,
         jsx: true,
-        identifierPattern: true,
         lexical: true,
         source: 'bullshit'
       }),
@@ -38,7 +37,6 @@ describe('Expressions - API', () => {
               start: 0,
               end: 3,
               range: [0, 3],
-              pattern: false,
               type: 'Identifier'
             },
             loc: {


### PR DESCRIPTION
This option added a "pattern" flag to Identifer node, but this feature was rejected by ESTree, https://github.com/estree/estree/issues/196 KFlash prematurelly added this when reading it.
Since it's not in ESTree spec, nobody would never relied on it. In this sense, not a breaking change.