### PR TITLE
Remove unused `isArrow` from `classifyIdentifier`

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -830,12 +830,11 @@ export function isValidIdentifier(context: Context, t: Token): boolean {
 export function classifyIdentifier(
   parser: ParserState,
   context: Context,
-  t: Token,
-  isArrow: 0 | 1
+  t: Token
 ): any {
   if ((t & Token.IsEvalOrArguments) === Token.IsEvalOrArguments) {
     if (context & Context.Strict) report(parser, Errors.StrictEvalArguments);
-    if (isArrow) parser.flags |= Flags.StrictEvalArguments;
+    parser.flags |= Flags.StrictEvalArguments;
   }
 
   if (!isValidIdentifier(context, t)) report(parser, Errors.Unexpected);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1067,7 +1067,7 @@ export function parseAsyncArrowOrAsyncFunctionDeclaration(
     );
   } else {
     if (parser.token === Token.Arrow) {
-      classifyIdentifier(parser, context, token, /* isArrow */ 1);
+      classifyIdentifier(parser, context, token);
       expr = parseArrowFromIdentifier(parser, context, parser.tokenValue, expr, 0, 1, 0, start, line, column);
     }
 
@@ -3561,7 +3561,7 @@ export function parseAsyncExpression(
   }
 
   if (parser.token === Token.Arrow) {
-    classifyIdentifier(parser, context, token, /* isArrow */ 1);
+    classifyIdentifier(parser, context, token);
     if (inNew) report(parser, Errors.InvalidAsyncArrow);
     return parseArrowFromIdentifier(parser, context, parser.tokenValue, expr, inNew, canAssign, 0, start, line, column);
   }
@@ -4229,7 +4229,7 @@ export function parsePrimaryExpression(
 
     if (parser.token === Token.Arrow) {
       if (!isLHS) report(parser, Errors.Unexpected);
-      classifyIdentifier(parser, context, token, /* isArrow */ 1);
+      classifyIdentifier(parser, context, token);
       return parseArrowFromIdentifier(parser, context, tokenValue, expr, inNew, canAssign, 0, start, line, column);
     }
 


### PR DESCRIPTION
I don't really understand what is that for, but found it's always `1`, and rollup is able to remove it during #264.