### PR TITLE
chore: show proper error "Expected 'from'"

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2559,10 +2559,7 @@ function parseImportNamespaceSpecifier(
 function parseModuleSpecifier(parser: ParserState, context: Context): ESTree.Literal {
   // ModuleSpecifier :
   //   StringLiteral
-  if (!consumeOpt(parser, context, Token.FromKeyword)) {
-    report(parser, Errors.UnexpectedToken, KeywordDescTable[parser.token & Token.Type]);
-  }
-
+  consume(parser, context, Token.FromKeyword);
   if (parser.token !== Token.StringLiteral) report(parser, Errors.InvalidExportImportSource, 'Import');
 
   return parseLiteral(parser, context);

--- a/test/parser/module/import.ts
+++ b/test/parser/module/import.ts
@@ -28,7 +28,6 @@ describe('Module - Import', () => {
     'import {} from;',
     "import {,} from 'a';",
     'import from;',
-    "import from 'foo';",
     "import { foo as !d } from 'foo';",
     "import { foo as 123 } from 'foo';",
     "import { foo as [123] } from 'foo';",
@@ -192,6 +191,21 @@ describe('Module - Import', () => {
       t.throws(() => {
         parseSource(`${arg}`, undefined, Context.Strict | Context.Module);
       });
+    });
+  }
+
+  for (const arg of [
+    'import from "foo";',
+    'import a "foo";',
+    'import * as a "foo";',
+    'import { a } "foo";',
+    'import b, { a } "foo";',
+    'import { default as a, b } "foo";'
+  ]) {
+    it(`${arg}`, () => {
+      t.throws(() => {
+        parseSource(`${arg}`, undefined, Context.Strict | Context.Module);
+      }, /Expected 'from'$/);
     });
   }
 


### PR DESCRIPTION
There is an existing method does report better error.

```js
export function consume(parser: ParserState, context: Context, t: Token): void {
  if (parser.token !== t) report(parser, Errors.ExpectedToken, KeywordDescTable[t & Token.Type]);
  nextToken(parser, context);
}
```