### PR TITLE
chore: remove explicit binary mask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ node_modules
 /packages/*/.rpt2_cache
 package-lock.json
 yarn.lock
+bun.lockb
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/src/common.ts
+++ b/src/common.ts
@@ -28,15 +28,15 @@ export const enum Context {
   InIteration = 1 << 17,
   SuperProperty = 1 << 18,
   SuperCall = 1 << 19,
-  InYieldContext = 1 << 21,
-  InAwaitContext = 1 << 22,
-  InArgumentList = 1 << 23,
-  InConstructor = 1 << 24,
-  InMethod = 1 << 25,
-  AllowNewTarget = 1 << 26,
-  DisallowIn = 1 << 27,
-  AllowEscapedKeyword = 1 << 28,
-  OptionsUniqueKeyInPattern = 1 << 29
+  InYieldContext = 1 << 20,
+  InAwaitContext = 1 << 21,
+  InArgumentList = 1 << 22,
+  InConstructor = 1 << 23,
+  InMethod = 1 << 24,
+  AllowNewTarget = 1 << 25,
+  DisallowIn = 1 << 26,
+  AllowEscapedKeyword = 1 << 27,
+  OptionsUniqueKeyInPattern = 1 << 28
 }
 
 /**

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -7170,7 +7170,9 @@ export function parseArrowFunctionExpression(
 
   consume(parser, context | Context.AllowRegExp, Token.Arrow);
 
-  context = ((context | 0b0000000111100000000_0000_00000000) ^ 0b0000000111100000000_0000_00000000) | (isAsync << 22);
+  const modifierFlags = Context.InYieldContext | Context.InAwaitContext | Context.InArgumentList;
+
+  context = ((context | modifierFlags) ^ modifierFlags) | (isAsync ? Context.InAwaitContext : 0);
 
   const expression = parser.token !== Token.LeftBrace;
 
@@ -7194,15 +7196,9 @@ export function parseArrowFunctionExpression(
   } else {
     if (scope) scope = addChildScope(scope, ScopeKind.FunctionBody);
 
-    body = parseFunctionBody(
-      parser,
-      (context | 0b0001000000000000001_0000_00000000 | Context.InGlobal | Context.InClass) ^
-        (0b0001000000000000001_0000_00000000 | Context.InGlobal | Context.InClass),
-      scope,
-      Origin.Arrow,
-      void 0,
-      void 0
-    );
+    const modifierFlags = Context.InSwitch | Context.DisallowIn | Context.InGlobal | Context.InClass;
+
+    body = parseFunctionBody(parser, (context | modifierFlags) ^ modifierFlags, scope, Origin.Arrow, void 0, void 0);
 
     switch (parser.token) {
       case Token.LeftBracket:

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -5643,8 +5643,12 @@ export function parseMethodDefinition(
 
   context =
     ((context | modifierFlags) ^ modifierFlags) |
-    ((kind & 0b0000000000000000000_0000_01011000) << 18) |
-    0b0000110000001000000_0000_00000000;
+    (kind & PropertyKind.Generator ? Context.InYieldContext : 0) |
+    (kind & PropertyKind.Async ? Context.InAwaitContext : 0) |
+    (kind & PropertyKind.Constructor ? Context.InConstructor : 0) |
+    Context.SuperProperty |
+    Context.InMethod |
+    Context.AllowNewTarget;
 
   let scope = context & Context.OptionsLexical ? addChildScope(createScope(), ScopeKind.FunctionParams) : void 0;
 
@@ -8518,8 +8522,12 @@ export function parsePropertyDefinition(
 
     context =
       ((context | modifierFlags) ^ modifierFlags) |
-      ((state & 0b0000000000000000000_0000_01011000) << 18) |
-      0b0000110000001000000_0000_00000000;
+      (state & PropertyKind.Generator ? Context.InYieldContext : 0) |
+      (state & PropertyKind.Async ? Context.InAwaitContext : 0) |
+      (state & PropertyKind.Constructor ? Context.InConstructor : 0) |
+      Context.SuperProperty |
+      Context.InMethod |
+      Context.AllowNewTarget;
 
     value = parsePrimaryExpression(
       parser,


### PR DESCRIPTION
This removes the coupling with the Context and PropertyKind enum definition.
The old code means we cannot modify Context and PropertyKind definition freely.

Related to #274
