### PR TITLE
fix(parser): class property definition needs to be separated

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -8562,11 +8562,10 @@ export function parsePropertyDefinition(
       );
 
       value = parseAssignmentExpression(parser, context | Context.InClass, 0, 0, tokenPos, linePos, colPos, value);
-      if (parser.token === Token.Comma) {
-        value = parseSequenceExpression(parser, context, 0, start, line, column, value as any);
-      }
     }
   }
+
+  matchOrInsertSemicolon(parser, context);
 
   return finishNode(parser, context, start, line, column, {
     type: 'PropertyDefinition',

--- a/test/parser/expressions/super.ts
+++ b/test/parser/expressions/super.ts
@@ -3769,7 +3769,7 @@ describe('Expressions - Super', () => {
                 {
                   computed: false,
                   decorators: [],
-                  end: 39,
+                  end: 40,
                   key: {
                     end: 21,
                     name: 'a',
@@ -3777,7 +3777,7 @@ describe('Expressions - Super', () => {
                     start: 20,
                     type: 'Identifier'
                   },
-                  range: [20, 39],
+                  range: [20, 40],
                   start: 20,
                   static: false,
                   type: 'PropertyDefinition',
@@ -3971,7 +3971,7 @@ describe('Expressions - Super', () => {
                 {
                   computed: false,
                   decorators: [],
-                  end: 51,
+                  end: 52,
                   key: {
                     end: 21,
                     name: 'a',
@@ -3979,7 +3979,7 @@ describe('Expressions - Super', () => {
                     start: 20,
                     type: 'Identifier'
                   },
-                  range: [20, 51],
+                  range: [20, 52],
                   start: 20,
                   static: false,
                   type: 'PropertyDefinition',
@@ -4185,7 +4185,7 @@ describe('Expressions - Super', () => {
                 {
                   computed: false,
                   decorators: [],
-                  end: 75,
+                  end: 76,
                   key: {
                     end: 37,
                     name: 'properties',
@@ -4193,7 +4193,7 @@ describe('Expressions - Super', () => {
                     start: 27,
                     type: 'Identifier'
                   },
-                  range: [27, 75],
+                  range: [27, 76],
                   start: 27,
                   static: true,
                   type: 'PropertyDefinition',

--- a/test/parser/next/decorators.ts
+++ b/test/parser/next/decorators.ts
@@ -154,9 +154,9 @@ describe('Next - Decorators', () => {
                     }
                   ],
                   start: 15,
-                  end: 23,
-                  range: [15, 23],
-                  loc: { start: { line: 1, column: 15 }, end: { line: 1, column: 23 } }
+                  end: 24,
+                  range: [15, 24],
+                  loc: { start: { line: 1, column: 15 }, end: { line: 1, column: 24 } }
                 }
               ],
               start: 8,

--- a/test/parser/next/private_methods.ts
+++ b/test/parser/next/private_methods.ts
@@ -7,6 +7,10 @@ describe('Next - Private methods', () => {
   fail('Private methods (fail)', [
     ['class A { #a }', Context.OptionsWebCompat],
     ['class A { #a }', Context.None],
+    ['class A { #a b() {} }', Context.OptionsNext],
+    ['class A { #a b }', Context.OptionsNext],
+    ['class A { #a #b }', Context.OptionsNext],
+    ['class A { a #b }', Context.OptionsNext],
     ['a = { #ab() {} }', Context.OptionsNext],
     ['class A { [{#ab() {}}]() {} }', Context.OptionsNext],
     ['class A{ # a() {}}', Context.OptionsNext],
@@ -235,7 +239,6 @@ describe('Next - Private methods', () => {
     'var C = class { static async m() { return 42; } #℘_; ℘(value) { this.#℘_ = value; return this.#℘; }}',
     'var C = class { static async m() { return 42; } static * #$(value) { yield * value; }  static * #_(value) {  yield * value; } }',
     'var C = class { static m() { return 42; } static #$ = 1; static #_ = 1; static _() { return this.#_; } }',
-    'var C = class { var C = class { [obj1] = 42; [obj2] = 43; [obj3] = 44; } }',
     'var C = class { static m() { return 42; } static #$ = 1; static #_ = 1; static _() { return this.#_; } }',
     '{ class C { #a() { class B { #a() {  } } new B; } } new C; }',
     `{
@@ -398,8 +401,8 @@ describe('Next - Private methods', () => {
                   computed: false,
                   static: false,
                   start: 10,
-                  end: 12,
-                  range: [10, 12]
+                  end: 13,
+                  range: [10, 13]
                 },
                 {
                   type: 'PropertyDefinition',
@@ -415,8 +418,8 @@ describe('Next - Private methods', () => {
                   computed: false,
                   static: false,
                   start: 14,
-                  end: 16,
-                  range: [14, 16]
+                  end: 17,
+                  range: [14, 17]
                 }
               ],
               start: 8,
@@ -488,8 +491,8 @@ describe('Next - Private methods', () => {
                   computed: false,
                   static: false,
                   start: 10,
-                  end: 23,
-                  range: [10, 23]
+                  end: 24,
+                  range: [10, 24]
                 }
               ],
               start: 8,
@@ -561,8 +564,8 @@ describe('Next - Private methods', () => {
                   computed: false,
                   static: false,
                   start: 10,
-                  end: 28,
-                  range: [10, 28]
+                  end: 29,
+                  range: [10, 29]
                 }
               ],
               start: 8,
@@ -614,8 +617,8 @@ describe('Next - Private methods', () => {
                   computed: false,
                   static: false,
                   start: 10,
-                  end: 16,
-                  range: [10, 16]
+                  end: 17,
+                  range: [10, 17]
                 }
               ],
               start: 8,

--- a/test/parser/next/public-fields.ts
+++ b/test/parser/next/public-fields.ts
@@ -22,7 +22,12 @@ describe('Next - Public fields', () => {
       Context.OptionsWebCompat | Context.OptionsNext
     ],
     ['class A { a, b }', Context.None],
-    ['class A { a, b }', Context.OptionsNext]
+    ['class A { a, b }', Context.OptionsNext],
+    ['class A { a b }', Context.None],
+    ['class A { a b }', Context.OptionsNext],
+    ['class A { a b() {} }', Context.OptionsNext],
+    ['class A { a = 1, 2 }', Context.OptionsNext],
+    ['class A { a = 1, b = 2 }', Context.OptionsNext]
   ]);
 
   for (const arg of [
@@ -64,6 +69,7 @@ describe('Next - Public fields', () => {
 
   for (const arg of [
     'a = 0;',
+    'a = (1, 2)',
     'a = 0; b;',
     'a = 0; b(){}',
     'a = 0; *b(){}',
@@ -290,8 +296,8 @@ describe('Next - Public fields', () => {
                   computed: false,
                   static: false,
                   start: 12,
-                  end: 17,
-                  range: [12, 17]
+                  end: 18,
+                  range: [12, 18]
                 }
               ],
               start: 10,
@@ -343,8 +349,8 @@ describe('Next - Public fields', () => {
                   computed: false,
                   static: false,
                   start: 10,
-                  end: 13,
-                  range: [10, 13]
+                  end: 14,
+                  range: [10, 14]
                 }
               ],
               start: 8,
@@ -577,8 +583,8 @@ describe('Next - Public fields', () => {
                   computed: true,
                   static: false,
                   start: 16,
-                  end: 24,
-                  range: [16, 24]
+                  end: 25,
+                  range: [16, 25]
                 },
                 {
                   type: 'PropertyDefinition',
@@ -600,8 +606,8 @@ describe('Next - Public fields', () => {
                   computed: true,
                   static: false,
                   start: 26,
-                  end: 39,
-                  range: [26, 39]
+                  end: 40,
+                  range: [26, 40]
                 },
                 {
                   type: 'PropertyDefinition',
@@ -617,8 +623,8 @@ describe('Next - Public fields', () => {
                   computed: true,
                   static: false,
                   start: 41,
-                  end: 60,
-                  range: [41, 60]
+                  end: 61,
+                  range: [41, 61]
                 }
               ],
               start: 8,
@@ -781,8 +787,8 @@ describe('Next - Public fields', () => {
                   computed: true,
                   static: false,
                   start: 10,
-                  end: 19,
-                  range: [10, 19]
+                  end: 20,
+                  range: [10, 20]
                 },
                 {
                   type: 'PropertyDefinition',
@@ -798,8 +804,8 @@ describe('Next - Public fields', () => {
                   computed: false,
                   static: false,
                   start: 21,
-                  end: 22,
-                  range: [21, 22]
+                  end: 23,
+                  range: [21, 23]
                 }
               ],
               start: 8,
@@ -1345,8 +1351,8 @@ describe('Next - Public fields', () => {
                   computed: false,
                   static: false,
                   start: 22,
-                  end: 25,
-                  range: [22, 25]
+                  end: 26,
+                  range: [22, 26]
                 },
                 {
                   type: 'PropertyDefinition',
@@ -1362,8 +1368,8 @@ describe('Next - Public fields', () => {
                   computed: false,
                   static: false,
                   start: 27,
-                  end: 30,
-                  range: [27, 30]
+                  end: 31,
+                  range: [27, 31]
                 },
                 {
                   type: 'PropertyDefinition',
@@ -1385,8 +1391,8 @@ describe('Next - Public fields', () => {
                   computed: false,
                   static: false,
                   start: 32,
-                  end: 40,
-                  range: [32, 40]
+                  end: 41,
+                  range: [32, 41]
                 },
                 {
                   type: 'PropertyDefinition',
@@ -1408,8 +1414,8 @@ describe('Next - Public fields', () => {
                   computed: false,
                   static: false,
                   start: 43,
-                  end: 51,
-                  range: [43, 51]
+                  end: 52,
+                  range: [43, 52]
                 }
               ],
               start: 8,
@@ -1461,8 +1467,8 @@ describe('Next - Public fields', () => {
                   computed: false,
                   static: false,
                   start: 10,
-                  end: 13,
-                  range: [10, 13]
+                  end: 14,
+                  range: [10, 14]
                 }
               ],
               start: 8,


### PR DESCRIPTION
A property definition needs to end with semicolon, newline, or implicit semicolon.

`class A { a b }` is invalid, needs `class A { a; b }` or `"class A { a\nb}"`.

closes #233