### PR TITLE
chore: fix eslint related dependencies

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-      - run: npm i --legacy-peer-deps
+      - run: npm i
       - run: npm run lint
 
   test:
@@ -41,5 +41,5 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm i --legacy-peer-deps
+      - run: npm i
       - run: npm test

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,19 +1,18 @@
-import { fixupPluginRules } from '@eslint/compat';
 import eslintJs from '@eslint/js';
 import eslintPluginN from 'eslint-plugin-n';
 import tseslint from 'typescript-eslint';
-import eslintPluginImport from 'eslint-plugin-import';
+import eslintPluginImportX from 'eslint-plugin-import-x';
 
 export default [
   eslintJs.configs.recommended,
   ...tseslint.configs.recommended,
   {
-    plugins: { import: fixupPluginRules(eslintPluginImport) },
-    settings: eslintPluginImport.configs.typescript.settings,
+    plugins: { 'import-x': eslintPluginImportX },
+    settings: eslintPluginImportX.configs.typescript.settings,
     rules: {
-      ...eslintPluginImport.configs.errors.rules,
-      ...eslintPluginImport.configs.warnings.rules,
-      ...eslintPluginImport.configs.typescript.rules,
+      ...eslintPluginImportX.configs.errors.rules,
+      ...eslintPluginImportX.configs.warnings.rules,
+      ...eslintPluginImportX.configs.typescript.rules,
       '@typescript-eslint/no-use-before-define': [2, { functions: false }], // https://github.com/eslint/eslint/issues/11903
       '@typescript-eslint/indent': 0,
       'prefer-const': ['error', { destructuring: 'all' }],
@@ -24,6 +23,7 @@ export default [
       '@typescript-eslint/class-name-casing': 0,
       '@typescript-eslint/camelcase': 0,
       '@typescript-eslint/no-var-requires': 0,
+      '@typescript-eslint/no-require-imports': 0,
       'no-fallthrough': 0
     }
   },
@@ -34,8 +34,8 @@ export default [
   {
     files: ['bench/**/*'],
     rules: {
-      'import/no-unresolved': 0,
-      'import/namespace': 0
+      'import-x/no-unresolved': 0,
+      'import-x/namespace': 0
     }
   },
   {
@@ -49,11 +49,11 @@ export default [
   {
     files: ['eslint.config.mjs'],
     rules: {
-      'import/no-unresolved': 0,
-      'import/namespace': 0,
-      'import/default': 0,
-      'import/no-named-as-default': 0,
-      'import/no-named-as-default-member': 0
+      'import-x/no-unresolved': 0,
+      'import-x/namespace': 0,
+      'import-x/default': 0,
+      'import-x/no-named-as-default': 0,
+      'import-x/no-named-as-default-member': 0
     }
   },
   {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "prepare": "husky"
   },
   "devDependencies": {
-    "@eslint/compat": "^1.0.3",
     "@eslint/js": "^9.4.0",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-terser": "^0.4.4",
@@ -94,10 +93,11 @@
     "@unicode/unicode-15.1.0": "^1.5.2",
     "coveralls": "^3.1.1",
     "cross-env": "^7.0.3",
-    "eslint": "^9.4.0",
-    "eslint-plugin-import": "^2.29.1",
+    "eslint": "^9.7.0",
+    "eslint-plugin-import-x": "^3.0.1",
     "eslint-plugin-n": "^17.8.1",
     "husky": "^9.0.11",
+    "lint-staged": "^15.2.7",
     "mocha": "^10.4.0",
     "nyc": "^15.1.0",
     "prettier": "3.3.1",
@@ -110,7 +110,7 @@
     "tsconfig-paths": "^4.2.0",
     "tslib": "^2.6.3",
     "typescript": "^4.7.4",
-    "typescript-eslint": "^7.12.0",
+    "typescript-eslint": "rc-v8",
     "unexpected": "^13.2.1"
   },
   "engines": {

--- a/src/lexer/regexp.ts
+++ b/src/lexer/regexp.ts
@@ -143,13 +143,13 @@ export function scanRegularExpression(parser: ParserState, context: Context): To
 function validate(parser: ParserState, pattern: string, flags: string): RegExp | null | Token {
   try {
     return new RegExp(pattern, flags);
-  } catch (e) {
+  } catch {
     try {
       // Some JavaScript engine has not supported flag "d".
       new RegExp(pattern, flags.replace('d', ''));
       // Use null as tokenValue according to ESTree spec
       return null;
-    } catch (e) {
+    } catch {
       report(parser, Errors.UnterminatedRegExp);
     }
   }

--- a/test/lexer/numbers.ts
+++ b/test/lexer/numbers.ts
@@ -32,7 +32,7 @@ describe('Lexer - Numberic literals', () => {
     [Context.None, Token.NumericLiteral, '4.0', 4],
     [Context.None, Token.NumericLiteral, '0.0', 0],
     [Context.OptionsRaw, Token.NumericLiteral, '456.345', 456.345],
-    // eslint-disable-next-line @typescript-eslint/no-loss-of-precision -- FIXME
+    // eslint-disable-next-line no-loss-of-precision -- FIXME
     [Context.None, Token.NumericLiteral, '1234567890.0987654321', 1234567890.0987654321],
 
     // Numeric literals with exponent


### PR DESCRIPTION
Make codebase installable with npm

- Migrate `eslint-plugin-import` to `eslint-plugin-import-x`
- Update `typescript-eslint` to v8