### PR TITLE
chore: reduce dist files to esm, cjs, and umd

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22, 20, 18, 16]
+        node-version: [22, 20, 18]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 - No backtracking
 - Low memory usage
 - Very well tested (~99 000 unit tests with full code coverage)
-- Lightweight - ~90 KB minified
+- Lightweight - ~130 KB minified
 
 ## ESNext features
 

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "unexpected": "^13.2.1"
   },
   "engines": {
-    "node": ">=10.4.0"
+    "node": ">=18.0.0"
   },
   "lint-staged": {
     "*.{ts,mts,cts,js,mjs,cjs}": "eslint --fix",

--- a/package.json
+++ b/package.json
@@ -3,17 +3,16 @@
   "version": "5.0.0",
   "description": "A 100% compliant, self-hosted javascript parser with high focus on both performance and stability",
   "main": "dist/meriyah.cjs",
-  "module": "dist/meriyah.esm.js",
-  "jsnext:main": "dist/meriyah.esm.js",
+  "module": "dist/meriyah.min.mjs",
   "browser": "dist/meriyah.umd.min.js",
   "unpkg": "dist/meriyah.umd.min.js",
-  "exports": {
-    "import": "./dist/meriyah.esm.mjs",
-    "require": "./dist/meriyah.cjs",
-    "types": "./dist/src/meriyah.d.ts"
-  },
   "types": "dist/src/meriyah.d.ts",
   "typings": "dist/src/meriyah.d.ts",
+  "exports": {
+    "types": "./dist/src/meriyah.d.ts",
+    "import": "./dist/meriyah.min.mjs",
+    "require": "./dist/meriyah.cjs"
+  },
   "license": "ISC",
   "homepage": "https://github.com/meriyah/meriyah",
   "repository": {
@@ -31,6 +30,10 @@
     {
       "name": "Chunpeng Huo",
       "url": "https://github.com/3cp"
+    },
+    {
+      "name": "Fisker Cheung",
+      "url": "https://github.com/fisker"
     }
   ],
   "keywords": [
@@ -51,7 +54,6 @@
   ],
   "files": [
     "dist",
-    "src",
     "README.md",
     "CHANGELOG.md",
     "LICENSE.md"

--- a/package.json
+++ b/package.json
@@ -30,10 +30,6 @@
     {
       "name": "Chunpeng Huo",
       "url": "https://github.com/3cp"
-    },
-    {
-      "name": "Fisker Cheung",
-      "url": "https://github.com/fisker"
     }
   ],
   "keywords": [


### PR DESCRIPTION
BREAKING CHANGE: only distribute following files:
dist/meriyah.cjs
dist/meriyah.mjs
dist/meriyah.min.mjs
dist/meriyah.umd.js
dist/meriyah.umd.min.js
All transpiled with target: "ES2021"