### PR TITLE
fix(parser): fix annexB behaviour (webcompat) of catch param

### DIFF
--- a/scripts/run-test262.ts
+++ b/scripts/run-test262.ts
@@ -14,24 +14,7 @@ function loadList(filename: string) {
 }
 
 const unsupportedFeatures = new Set(loadList('unsupported-features.txt'));
-const whitelist = [
-  ...loadList('whitelist.txt'),
-  // Can't construct these regexps on Node.js v16
-  ...(process.version.startsWith('v16.')
-    ? [
-        'built-ins/RegExp/named-groups/non-unicode-property-names-valid.js (default)',
-        'built-ins/RegExp/named-groups/non-unicode-property-names-valid.js (strict mode)',
-        'built-ins/RegExp/property-escapes/generated/Script_-_Kawi.js (default)',
-        'built-ins/RegExp/property-escapes/generated/Script_-_Kawi.js (strict mode)',
-        'built-ins/RegExp/property-escapes/generated/Script_-_Nag_Mundari.js (default)',
-        'built-ins/RegExp/property-escapes/generated/Script_-_Nag_Mundari.js (strict mode)',
-        'built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Kawi.js (default)',
-        'built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Kawi.js (strict mode)',
-        'built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Nag_Mundari.js (default)',
-        'built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Nag_Mundari.js (strict mode)'
-      ]
-    : [])
-];
+const whitelist = loadList('whitelist.txt');
 
 function parse(src: string, { sourceType }: { sourceType: 'module' | 'script' }) {
   return (sourceType === 'module' ? parseModule : parseScript)(src, { webcompat: true, lexical: true, next: true });

--- a/src/common.ts
+++ b/src/common.ts
@@ -724,12 +724,8 @@ export function addVarName(
         currentScope.scopeError = recordScopeError(parser, Errors.DuplicateBinding, name);
       }
     }
-    if (value & (BindingKind.CatchIdentifier | BindingKind.CatchPattern)) {
-      if (
-        (value & BindingKind.CatchIdentifier) === 0 ||
-        (context & Context.OptionsWebCompat) === 0 ||
-        context & Context.Strict
-      ) {
+    if (value & BindingKind.CatchIdentifierOrPattern) {
+      if ((context & Context.OptionsWebCompat) === 0 || (value & BindingKind.CatchIdentifier) === 0) {
         report(parser, Errors.DuplicateBinding, name);
       }
     }

--- a/src/common.ts
+++ b/src/common.ts
@@ -724,10 +724,11 @@ export function addVarName(
         currentScope.scopeError = recordScopeError(parser, Errors.DuplicateBinding, name);
       }
     }
-    if (value & BindingKind.CatchIdentifierOrPattern) {
-      if ((context & Context.OptionsWebCompat) === 0 || (value & BindingKind.CatchIdentifier) === 0) {
-        report(parser, Errors.DuplicateBinding, name);
-      }
+    if (
+      value & BindingKind.CatchPattern ||
+      (value & BindingKind.CatchIdentifier && (context & Context.OptionsWebCompat) === 0)
+    ) {
+      report(parser, Errors.DuplicateBinding, name);
     }
 
     currentScope['#' + name] = kind;

--- a/test/test262-parser-tests/whitelist.txt
+++ b/test/test262-parser-tests/whitelist.txt
@@ -1,8 +1,3 @@
-annexB/language/statements/try/catch-redeclared-for-in-var.js (strict mode)
-annexB/language/statements/try/catch-redeclared-for-of-var.js (strict mode)
-annexB/language/statements/try/catch-redeclared-for-var.js (strict mode)
-annexB/language/statements/try/catch-redeclared-var-statement-captured.js (strict mode)
-annexB/language/statements/try/catch-redeclared-var-statement.js (strict mode)
 language/block-scope/syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-function.js (default)
 language/block-scope/syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-function.js (strict mode)
 language/block-scope/syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-generator.js (default)


### PR DESCRIPTION
ECMA B.3.4 syntax error if catch param occurs in var declared names of catch block, unless catch param is binding identifier