### PR TITLE
feat(lexer): support regexp v flag (unicodeSets)

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "prettier": "3.3.1",
     "rollup": "^4.18.0",
     "rollup-plugin-typescript2": "^0.36.0",
-    "semver": "^7.6.3",
     "source-map-support": "^0.5.21",
     "standard-changelog": "^6.0.0",
     "test262": "tc39/test262#880f8a5ba64d4e9df02e4c961e5abb9dec380f2b",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "prettier": "3.3.1",
     "rollup": "^4.18.0",
     "rollup-plugin-typescript2": "^0.36.0",
+    "semver": "^7.6.3",
     "source-map-support": "^0.5.21",
     "standard-changelog": "^6.0.0",
     "test262": "tc39/test262#880f8a5ba64d4e9df02e4c961e5abb9dec380f2b",

--- a/scripts/run-test262.ts
+++ b/scripts/run-test262.ts
@@ -1,7 +1,10 @@
 import { parseScript, parseModule } from '../src/meriyah';
 import * as path from 'path';
 import * as fs from 'fs';
+import * as semver from 'semver';
 import run = require('test262-parser-runner');
+
+const vFlagSupported = semver.gte(process.version.slice(1), '20.0.0');
 
 function loadList(filename: string) {
   const file = path.join(__dirname, '../test/test262-parser-tests', filename);
@@ -14,6 +17,9 @@ function loadList(filename: string) {
 }
 
 const unsupportedFeatures = new Set(loadList('unsupported-features.txt'));
+if (!vFlagSupported) {
+  unsupportedFeatures.add('regexp-v-flag');
+}
 const whitelist = loadList('whitelist.txt');
 
 function parse(src: string, { sourceType }: { sourceType: 'module' | 'script' }) {

--- a/scripts/run-test262.ts
+++ b/scripts/run-test262.ts
@@ -1,10 +1,15 @@
 import { parseScript, parseModule } from '../src/meriyah';
 import * as path from 'path';
 import * as fs from 'fs';
-import * as semver from 'semver';
 import run = require('test262-parser-runner');
 
-const vFlagSupported = semver.gte(process.version.slice(1), '20.0.0');
+const vFlagSupported = (() => {
+  try {
+    return new RegExp('', 'v').flags === 'v';
+  } catch {
+    return false;
+  }
+})();
 
 function loadList(filename: string) {
   const file = path.join(__dirname, '../test/test262-parser-tests', filename);

--- a/src/lexer/regexp.ts
+++ b/src/lexer/regexp.ts
@@ -12,14 +12,15 @@ enum RegexState {
 }
 
 enum RegexFlags {
-  Empty = 0b0000000,
-  IgnoreCase = 0b0000001,
-  Global = 0b0000010,
-  Multiline = 0b0000100,
-  Unicode = 0b0010000,
-  Sticky = 0b0001000,
-  DotAll = 0b0100000,
-  Indices = 0b1000000
+  Empty = 0b0000_0000,
+  IgnoreCase = 0b0000_0001,
+  Global = 0b0000_0010,
+  Multiline = 0b0000_0100,
+  Unicode = 0b0001_0000,
+  Sticky = 0b0000_1000,
+  DotAll = 0b0010_0000,
+  Indices = 0b0100_0000,
+  UnicodeSets = 0b1000_0000
 }
 
 /**
@@ -98,7 +99,14 @@ export function scanRegularExpression(parser: ParserState, context: Context): To
 
       case Chars.LowerU:
         if (mask & RegexFlags.Unicode) report(parser, Errors.DuplicateRegExpFlag, 'u');
+        if (mask & RegexFlags.UnicodeSets) report(parser, Errors.DuplicateRegExpFlag, 'vu');
         mask |= RegexFlags.Unicode;
+        break;
+
+      case Chars.LowerV:
+        if (mask & RegexFlags.Unicode) report(parser, Errors.DuplicateRegExpFlag, 'uv');
+        if (mask & RegexFlags.UnicodeSets) report(parser, Errors.DuplicateRegExpFlag, 'v');
+        mask |= RegexFlags.UnicodeSets;
         break;
 
       case Chars.LowerY:
@@ -150,8 +158,8 @@ function validate(parser: ParserState, pattern: string, flags: string): RegExp |
     return new RegExp(pattern, flags);
   } catch {
     try {
-      // Some JavaScript engine has not supported flag "d".
-      new RegExp(pattern, flags.replace('d', ''));
+      // Some JavaScript engine has not supported flag "v". They will fail.
+      new RegExp(pattern, flags);
       // Use null as tokenValue according to ESTree spec
       return null;
     } catch {

--- a/test/lexer/regexp.ts
+++ b/test/lexer/regexp.ts
@@ -1,11 +1,16 @@
 import * as t from 'assert';
-import * as semver from 'semver';
 import { Context } from '../../src/common';
 import { Token } from '../../src/token';
 import { create } from '../../src/parser';
 import { scanSingleToken } from '../../src/lexer/scan';
 
-const vFlagSupported = semver.gte(process.version.slice(1), '20.0.0');
+const vFlagSupported = (() => {
+  try {
+    return new RegExp('', 'v').flags === 'v';
+  } catch {
+    return false;
+  }
+})();
 
 describe('Lexer - Regular expressions', () => {
   const tokens: [Context, string, string, string][] = [

--- a/test/test262-parser-tests/unsupported-features.txt
+++ b/test/test262-parser-tests/unsupported-features.txt
@@ -2,7 +2,6 @@ explicit-resource-management
 regexp-modifiers
 import-assertions
 regexp-duplicate-named-groups
-regexp-v-flag
 arbitrary-module-namespace-names
 source-phase-imports
 source-phase-imports-module-source


### PR DESCRIPTION
Note meriyah uses JavaScrip runtime to validate regexp pattern, so the v flag only works in JS runtime that supports it. For nodejs, it's v20.0.0+.