### PR TITLE
feat: support import attributes with "assert" keyword

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2536,7 +2536,10 @@ function parseImportDeclaration(
   };
 
   if (context & Context.OptionsNext) {
-    node.attributes = parser.getToken() === Token.WithKeyword ? parseImportAttributes(parser, context, specifiers) : [];
+    node.attributes =
+      parser.getToken() === Token.WithKeyword || parser.getToken() === Token.Assert
+        ? parseImportAttributes(parser, context, specifiers)
+        : [];
   }
 
   matchOrInsertSemicolon(parser, context | Context.AllowRegExp);
@@ -2971,7 +2974,10 @@ function parseExportDeclaration(
       };
 
       if (context & Context.OptionsNext) {
-        node.attributes = parser.getToken() === Token.WithKeyword ? parseImportAttributes(parser, context) : [];
+        node.attributes =
+          parser.getToken() === Token.WithKeyword || parser.getToken() === Token.Assert
+            ? parseImportAttributes(parser, context)
+            : [];
       }
 
       matchOrInsertSemicolon(parser, context | Context.AllowRegExp);
@@ -4498,7 +4504,7 @@ export function parseImportAttributes(
   context: Context,
   specifiers: ESTree.ImportDeclaration['specifiers'] = []
 ): ESTree.ImportAttribute[] {
-  consume(parser, context, Token.WithKeyword);
+  consume(parser, context, parser.getToken());
   consume(parser, context, Token.LeftBrace);
 
   const attributes: ESTree.ImportAttribute[] = [];

--- a/src/token.ts
+++ b/src/token.ts
@@ -197,6 +197,8 @@ export const enum Token {
 
   // JSX
   JSXText           = 138,
+
+  Assert = 139 | IsIdentifier,
 }
 
 export const KeywordDescTable = [
@@ -242,7 +244,7 @@ export const KeywordDescTable = [
 
   'BigIntLiteral', '??', '?.', 'WhiteSpace', 'Illegal', 'LineTerminator', 'PrivateField',
 
-  'Template', '@', 'target', 'meta', 'LineFeed', 'Escaped', 'JSXText'
+  'Template', '@', 'target', 'meta', 'LineFeed', 'Escaped', 'JSXText', 'assert'
 ];
 
 // Normal object is much faster than Object.create(null), even with typeof check to avoid Object.prototype interference
@@ -304,4 +306,5 @@ export const descKeywordTable: { [key: string]: Token } = Object.create(null, {
   arguments: { value: Token.Arguments },
   target: { value: Token.Target },
   meta: { value: Token.Meta },
+  assert: { value: Token.Assert },
 });

--- a/test/parser/next/import-attributes.ts
+++ b/test/parser/next/import-attributes.ts
@@ -354,6 +354,45 @@ describe('Next - Import Attributes', () => {
       }
     ],
     [
+      'import foo from "bar" assert { type: "json" };',
+      Context.Module | Context.Strict | Context.OptionsNext,
+      {
+        body: [
+          {
+            source: {
+              type: 'Literal',
+              value: 'bar'
+            },
+            specifiers: [
+              {
+                local: {
+                  name: 'foo',
+                  type: 'Identifier'
+                },
+                type: 'ImportDefaultSpecifier'
+              }
+            ],
+            type: 'ImportDeclaration',
+            attributes: [
+              {
+                key: {
+                  name: 'type',
+                  type: 'Identifier'
+                },
+                value: {
+                  type: 'Literal',
+                  value: 'json'
+                },
+                type: 'ImportAttribute'
+              }
+            ]
+          }
+        ],
+        sourceType: 'module',
+        type: 'Program'
+      }
+    ],
+    [
       'import foo from "bar" with { type: "json", "data-type": "json" };',
       Context.Module | Context.Strict | Context.OptionsNext,
       {


### PR DESCRIPTION
This PR adds support for the old `assert` keyword syntax (import-assertions). The resulting node is the same as with the `with` syntax, i.e., `ImportAttributes` are added to the `attributes` member instead of the `assertions` member.

```typescript
interface ImportDeclaration {
    attributes: [ ImportAttribute ];
}
```

References:
- [Import Attributes](https://github.com/estree/estree/blob/master/stage3/import-attributes.md)
- [Import Assertions](https://github.com/estree/estree/blob/master/stage3/import-assertions.md)
