### PR TITLE
fix(parser): fix jsx parsing on '< / >'

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -393,7 +393,7 @@ export function validateBindingIdentifier(
   // The BoundNames of LexicalDeclaration and ForDeclaration must not
   // contain 'let'. (CatchParameter is the only lexical binding form
   // without this restriction.)
-  if (kind & (BindingKind.Let | BindingKind.Const) && (t & Token.LetKeyword) === Token.LetKeyword) {
+  if (kind & (BindingKind.Let | BindingKind.Const) && (t & Token.Type) === (Token.LetKeyword & Token.Type)) {
     report(parser, Errors.InvalidLetConstBinding);
   }
 

--- a/src/lexer/scan.ts
+++ b/src/lexer/scan.ts
@@ -256,9 +256,9 @@ export function scanSingleToken(parser: ParserState, context: Context, state: Le
           state = (state & ~LexerState.LastIsCR) | LexerState.NewLine;
           break;
 
-        // `<`, `<=`, `<<`, `<<=`, `</`, `<!--`
+        // `<`, `<=`, `<<`, `<<=`, `<!--`
         case Token.LessThan: {
-          let ch = advanceChar(parser);
+          const ch = advanceChar(parser);
           if (parser.index < parser.end) {
             if (ch === Chars.LessThan) {
               if (parser.index < parser.end && advanceChar(parser) === Chars.EqualSign) {
@@ -296,18 +296,6 @@ export function scanSingleToken(parser: ParserState, context: Context, state: Le
                 continue;
               }
               return Token.LessThan;
-            }
-            if (ch === Chars.Slash) {
-              if ((context & Context.OptionsJSX) === 0) return Token.LessThan;
-              const index = parser.index + 1;
-
-              // Check that it's not a comment start.
-              if (index < parser.end) {
-                ch = source.charCodeAt(index);
-                if (ch === Chars.Asterisk || ch === Chars.Slash) return Token.LessThan;
-              }
-              advanceChar(parser);
-              return Token.JSXClose;
             }
           }
           return Token.LessThan;

--- a/src/token.ts
+++ b/src/token.ts
@@ -62,142 +62,140 @@ export const enum Token {
   QuestionMark = 22, // ?
   SingleQuote  = 23, // '
   DoubleQuote  = 24, // "
-  JSXClose     = 25, // </
-  JSXAutoClose = 26, // />
 
   /* Update operators */
-  Increment = 27 | IsUpdateOp, // ++
-  Decrement = 28 | IsUpdateOp, // --
+  Increment = 25 | IsUpdateOp, // ++
+  Decrement = 26 | IsUpdateOp, // --
 
   /* Assign operators */
-  Assign                  = 29 | IsAssignOp | IsClassField, // =
-  ShiftLeftAssign         = 30 | IsAssignOp, // <<=
-  ShiftRightAssign        = 31 | IsAssignOp, // >>=
-  LogicalShiftRightAssign = 32 | IsAssignOp, // >>>=
-  ExponentiateAssign      = 33 | IsAssignOp, // **=
-  AddAssign               = 34 | IsAssignOp, // +=
-  SubtractAssign          = 35 | IsAssignOp, // -=
-  MultiplyAssign          = 36 | IsAssignOp, // *=
-  DivideAssign            = 37 | IsAssignOp | IsExpressionStart, // /=
-  ModuloAssign            = 38 | IsAssignOp, // %=
-  BitwiseXorAssign        = 39 | IsAssignOp, // ^=
-  BitwiseOrAssign         = 40 | IsAssignOp, // |=
-  BitwiseAndAssign        = 41 | IsAssignOp, // &=
-  LogicalOrAssign         = 42 | IsAssignOp, // ||=
-  LogicalAndAssign        = 43 | IsAssignOp, // &&=
-  CoalesceAssign          = 44 | IsAssignOp, // ??=
+  Assign                  = 27 | IsAssignOp | IsClassField, // =
+  ShiftLeftAssign         = 28 | IsAssignOp, // <<=
+  ShiftRightAssign        = 29 | IsAssignOp, // >>=
+  LogicalShiftRightAssign = 30 | IsAssignOp, // >>>=
+  ExponentiateAssign      = 31 | IsAssignOp, // **=
+  AddAssign               = 32 | IsAssignOp, // +=
+  SubtractAssign          = 33 | IsAssignOp, // -=
+  MultiplyAssign          = 34 | IsAssignOp, // *=
+  DivideAssign            = 35 | IsAssignOp | IsExpressionStart, // /=
+  ModuloAssign            = 36 | IsAssignOp, // %=
+  BitwiseXorAssign        = 37 | IsAssignOp, // ^=
+  BitwiseOrAssign         = 38 | IsAssignOp, // |=
+  BitwiseAndAssign        = 39 | IsAssignOp, // &=
+  LogicalOrAssign         = 40 | IsAssignOp, // ||=
+  LogicalAndAssign        = 41 | IsAssignOp, // &&=
+  CoalesceAssign          = 42 | IsAssignOp, // ??=
 
   /* Unary/binary operators */
-  TypeofKeyword      = 45 | IsUnaryOp | Reserved,
-  DeleteKeyword      = 46 | IsUnaryOp | Reserved,
-  VoidKeyword        = 47 | IsUnaryOp | Reserved,
-  Negate             = 48 | IsUnaryOp, // !
-  Complement         = 49 | IsUnaryOp, // ~
-  Add                = 50 | IsUnaryOp | IsBinaryOp | 10 << PrecStart, // +
-  Subtract           = 51 | IsUnaryOp | IsBinaryOp | 10 << PrecStart, // -
-  InKeyword          = 52 | IsBinaryOp | 8 << PrecStart | Reserved | IsInOrOf,
-  InstanceofKeyword  = 53 | IsBinaryOp | 8 << PrecStart | Reserved,
-  Multiply           = 54 | IsBinaryOp | 11 << PrecStart, // *
-  Modulo             = 55 | IsBinaryOp | 11 << PrecStart, // %
-  Divide             = 56 | IsBinaryOp | IsExpressionStart | 11 << PrecStart, // /
-  Exponentiate       = 57 | IsBinaryOp | 12 << PrecStart, // **
-  LogicalAnd         = 58 | IsBinaryOp | IsLogical | 3 << PrecStart, // &&
-  LogicalOr          = 59 | IsBinaryOp | IsLogical | 2 << PrecStart, // ||
-  StrictEqual        = 60 | IsBinaryOp | 7 << PrecStart, // ===
-  StrictNotEqual     = 61 | IsBinaryOp | 7 << PrecStart, // !==
-  LooseEqual         = 62 | IsBinaryOp | 7 << PrecStart, // ==
-  LooseNotEqual      = 63 | IsBinaryOp | 7 << PrecStart, // !=
-  LessThanOrEqual    = 64 | IsBinaryOp | 8 << PrecStart, // <=
-  GreaterThanOrEqual = 65 | IsBinaryOp | 8 << PrecStart, // >=
-  LessThan           = 66 | IsBinaryOp | IsExpressionStart | 8 << PrecStart, // <
-  GreaterThan        = 67 | IsBinaryOp | 8 << PrecStart, // >
-  ShiftLeft          = 68 | IsBinaryOp | 9 << PrecStart, // <<
-  ShiftRight         = 69 | IsBinaryOp | 9 << PrecStart, // >>
-  LogicalShiftRight  = 70 | IsBinaryOp | 9 << PrecStart, // >>>
-  BitwiseAnd         = 71 | IsBinaryOp | 6 << PrecStart, // &
-  BitwiseOr          = 72 | IsBinaryOp | 4 << PrecStart, // |
-  BitwiseXor         = 73 | IsBinaryOp | 5 << PrecStart, // ^
+  TypeofKeyword      = 43 | IsUnaryOp | Reserved,
+  DeleteKeyword      = 44 | IsUnaryOp | Reserved,
+  VoidKeyword        = 45 | IsUnaryOp | Reserved,
+  Negate             = 46 | IsUnaryOp, // !
+  Complement         = 47 | IsUnaryOp, // ~
+  Add                = 48 | IsUnaryOp | IsBinaryOp | 10 << PrecStart, // +
+  Subtract           = 49 | IsUnaryOp | IsBinaryOp | 10 << PrecStart, // -
+  InKeyword          = 50 | IsBinaryOp | 8 << PrecStart | Reserved | IsInOrOf,
+  InstanceofKeyword  = 51 | IsBinaryOp | 8 << PrecStart | Reserved,
+  Multiply           = 52 | IsBinaryOp | 11 << PrecStart, // *
+  Modulo             = 53 | IsBinaryOp | 11 << PrecStart, // %
+  Divide             = 54 | IsBinaryOp | IsExpressionStart | 11 << PrecStart, // /
+  Exponentiate       = 55 | IsBinaryOp | 12 << PrecStart, // **
+  LogicalAnd         = 56 | IsBinaryOp | IsLogical | 3 << PrecStart, // &&
+  LogicalOr          = 57 | IsBinaryOp | IsLogical | 2 << PrecStart, // ||
+  StrictEqual        = 58 | IsBinaryOp | 7 << PrecStart, // ===
+  StrictNotEqual     = 59 | IsBinaryOp | 7 << PrecStart, // !==
+  LooseEqual         = 60 | IsBinaryOp | 7 << PrecStart, // ==
+  LooseNotEqual      = 61 | IsBinaryOp | 7 << PrecStart, // !=
+  LessThanOrEqual    = 62 | IsBinaryOp | 8 << PrecStart, // <=
+  GreaterThanOrEqual = 63 | IsBinaryOp | 8 << PrecStart, // >=
+  LessThan           = 64 | IsBinaryOp | IsExpressionStart | 8 << PrecStart, // <
+  GreaterThan        = 65 | IsBinaryOp | 8 << PrecStart, // >
+  ShiftLeft          = 66 | IsBinaryOp | 9 << PrecStart, // <<
+  ShiftRight         = 67 | IsBinaryOp | 9 << PrecStart, // >>
+  LogicalShiftRight  = 68 | IsBinaryOp | 9 << PrecStart, // >>>
+  BitwiseAnd         = 69 | IsBinaryOp | 6 << PrecStart, // &
+  BitwiseOr          = 70 | IsBinaryOp | 4 << PrecStart, // |
+  BitwiseXor         = 71 | IsBinaryOp | 5 << PrecStart, // ^
 
   /* Variable declaration kinds */
-  VarKeyword   = 74 | IsExpressionStart | Reserved,
-  LetKeyword   = 75 | IsExpressionStart | FutureReserved | IsIdentifier,
-  ConstKeyword = 76 | IsExpressionStart | Reserved,
+  VarKeyword   = 72 | IsExpressionStart | Reserved,
+  LetKeyword   = 73 | IsExpressionStart | FutureReserved | IsIdentifier,
+  ConstKeyword = 74 | IsExpressionStart | Reserved,
 
   /* Other reserved words */
-  BreakKeyword    = 77 | Reserved,
-  CaseKeyword     = 78 | Reserved,
-  CatchKeyword    = 79 | Reserved,
-  ClassKeyword    = 80 | IsExpressionStart | Reserved,
-  ContinueKeyword = 81 | Reserved,
-  DebuggerKeyword = 82 | Reserved,
-  DefaultKeyword  = 83 | Reserved,
-  DoKeyword       = 84 | Reserved,
-  ElseKeyword     = 85 | Reserved,
-  ExportKeyword   = 86 | Reserved,
-  ExtendsKeyword  = 87 | Reserved,
-  FinallyKeyword  = 88 | Reserved,
-  ForKeyword      = 89 | Reserved,
-  FunctionKeyword = 90 | IsExpressionStart | Reserved,
-  IfKeyword       = 91 | Reserved,
-  ImportKeyword   = 92 | IsExpressionStart | Reserved,
-  NewKeyword      = 93 | IsExpressionStart | Reserved,
-  ReturnKeyword   = 94 | Reserved,
-  SuperKeyword    = 95 | IsExpressionStart | Reserved,
-  SwitchKeyword   = 96 | IsExpressionStart | Reserved,
-  ThisKeyword     = 97 | IsExpressionStart | Reserved,
-  ThrowKeyword    = 98 | IsExpressionStart | Reserved,
-  TryKeyword      = 99 | Reserved,
-  WhileKeyword    = 100 | Reserved,
-  WithKeyword     = 101 | Reserved,
+  BreakKeyword    = 75 | Reserved,
+  CaseKeyword     = 76 | Reserved,
+  CatchKeyword    = 77 | Reserved,
+  ClassKeyword    = 78 | IsExpressionStart | Reserved,
+  ContinueKeyword = 79 | Reserved,
+  DebuggerKeyword = 80 | Reserved,
+  DefaultKeyword  = 81 | Reserved,
+  DoKeyword       = 82 | Reserved,
+  ElseKeyword     = 83 | Reserved,
+  ExportKeyword   = 84 | Reserved,
+  ExtendsKeyword  = 85 | Reserved,
+  FinallyKeyword  = 86 | Reserved,
+  ForKeyword      = 87 | Reserved,
+  FunctionKeyword = 88 | IsExpressionStart | Reserved,
+  IfKeyword       = 89 | Reserved,
+  ImportKeyword   = 90 | IsExpressionStart | Reserved,
+  NewKeyword      = 91 | IsExpressionStart | Reserved,
+  ReturnKeyword   = 92 | Reserved,
+  SuperKeyword    = 93 | IsExpressionStart | Reserved,
+  SwitchKeyword   = 94 | IsExpressionStart | Reserved,
+  ThisKeyword     = 95 | IsExpressionStart | Reserved,
+  ThrowKeyword    = 96 | IsExpressionStart | Reserved,
+  TryKeyword      = 97 | Reserved,
+  WhileKeyword    = 98 | Reserved,
+  WithKeyword     = 99 | Reserved,
 
   /* Strict mode reserved words */
-  ImplementsKeyword = 102 | FutureReserved,
-  InterfaceKeyword  = 103 | FutureReserved,
-  PackageKeyword    = 104 | FutureReserved,
-  PrivateKeyword    = 105 | FutureReserved,
-  ProtectedKeyword  = 106 | FutureReserved,
-  PublicKeyword     = 107 | FutureReserved,
-  StaticKeyword     = 108 | FutureReserved,
-  YieldKeyword      = 109 | FutureReserved | IsExpressionStart | IsIdentifier,
+  ImplementsKeyword = 100 | FutureReserved,
+  InterfaceKeyword  = 101 | FutureReserved,
+  PackageKeyword    = 102 | FutureReserved,
+  PrivateKeyword    = 103 | FutureReserved,
+  ProtectedKeyword  = 104 | FutureReserved,
+  PublicKeyword     = 105 | FutureReserved,
+  StaticKeyword     = 106 | FutureReserved,
+  YieldKeyword      = 107 | FutureReserved | IsExpressionStart | IsIdentifier,
 
   /* Contextual keywords */
-  AsKeyword          = 110 | Contextual | IsExpressionStart,
-  AsyncKeyword       = 111 | Contextual | IsIdentifier | IsExpressionStart,
-  AwaitKeyword       = 112 | Contextual | IsExpressionStart | IsIdentifier, // await is only reserved word in async functions or modules
-  ConstructorKeyword = 113 | Contextual,
-  GetKeyword         = 114 | Contextual,
-  SetKeyword         = 115 | Contextual,
-  FromKeyword        = 116 | Contextual,
-  OfKeyword          = 117 | Contextual | IsInOrOf,
-  EnumKeyword        = 118 | Reserved | IsExpressionStart,
+  AsKeyword          = 108 | Contextual | IsExpressionStart,
+  AsyncKeyword       = 109 | Contextual | IsIdentifier | IsExpressionStart,
+  AwaitKeyword       = 110 | Contextual | IsExpressionStart | IsIdentifier, // await is only reserved word in async functions or modules
+  ConstructorKeyword = 111 | Contextual,
+  GetKeyword         = 112 | Contextual,
+  SetKeyword         = 113 | Contextual,
+  FromKeyword        = 114 | Contextual,
+  OfKeyword          = 115 | Contextual | IsInOrOf,
+  EnumKeyword        = 116 | Reserved | IsExpressionStart,
 
-  Eval               = 119 | IsEvalOrArguments,
-  Arguments          = 120 | IsEvalOrArguments,
+  Eval               = 117 | IsEvalOrArguments,
+  Arguments          = 118 | IsEvalOrArguments,
 
-  EscapedReserved       = 121 | IsEscaped,
-  EscapedFutureReserved = 122 | IsEscaped,
-  AnyIdentifier      = 123 | IsIdentifier,
+  EscapedReserved       = 119 | IsEscaped,
+  EscapedFutureReserved = 120 | IsEscaped,
+  AnyIdentifier      = 121 | IsIdentifier,
 
   // Stage #3 proposals
-  PrivateIdentifier  = 124,
-  BigIntLiteral      = 125 | IsExpressionStart | IsStringOrNumber,
-  Coalesce           = 126 | IsBinaryOp | IsCoalesc | 1 << PrecStart, // ??
-  QuestionMarkPeriod = 127 | IsMemberOrCallExpression, // ?.
+  PrivateIdentifier  = 122,
+  BigIntLiteral      = 123 | IsExpressionStart | IsStringOrNumber,
+  Coalesce           = 124 | IsBinaryOp | IsCoalesc | 1 << PrecStart, // ??
+  QuestionMarkPeriod = 125 | IsMemberOrCallExpression, // ?.
 
   // Others
-  WhiteSpace        = 128,
-  Illegal           = 129,
-  CarriageReturn    = 130,
-  PrivateField      = 131,
-  Template          = 132,
-  Decorator         = 133,
-  Target            = 134 | IsIdentifier,
-  Meta              = 135 | IsIdentifier,
-  LineFeed          = 136,
-  EscapedIdentifier = 137 | IsEscaped,
+  WhiteSpace        = 126,
+  Illegal           = 127,
+  CarriageReturn    = 128,
+  PrivateField      = 129,
+  Template          = 130,
+  Decorator         = 131,
+  Target            = 132 | IsIdentifier,
+  Meta              = 133 | IsIdentifier,
+  LineFeed          = 134,
+  EscapedIdentifier = 135 | IsEscaped,
 
   // JSX
-  JSXText           = 138,
+  JSXText           = 136,
 }
 
 export const KeywordDescTable = [
@@ -211,7 +209,7 @@ export const KeywordDescTable = [
   'template continuation', 'template tail',
 
   /* Punctuators */
-  '=>', '(', '{', '.', '...', '}', ')', ';', ',', '[', ']', ':', '?', '\'', '"', '</', '/>',
+  '=>', '(', '{', '.', '...', '}', ')', ';', ',', '[', ']', ':', '?', '\'', '"',
 
   /* Update operators */
   '++', '--',

--- a/test/parser/miscellaneous/onToken.ts
+++ b/test/parser/miscellaneous/onToken.ts
@@ -146,14 +146,16 @@ describe('Miscellaneous - onToken', () => {
       { token: 'Identifier', start: 24, end: 27, value: 'a-b' },
       { token: 'Punctuator', start: 27, end: 28, value: '>' },
       { token: 'Punctuator', start: 28, end: 33, value: 'hello' },
-      { token: 'Punctuator', start: 33, end: 35, value: '</' },
+      { token: 'Punctuator', start: 33, end: 34, value: '<' },
+      { token: 'Punctuator', start: 34, end: 35, value: '/' },
       { token: 'Identifier', start: 35, end: 38, value: 'a-b' },
       { token: 'Punctuator', start: 38, end: 39, value: '>' },
       { token: 'Punctuator', start: 39, end: 40, value: '<' },
       { token: 'Identifier', start: 40, end: 41, value: 'c' },
       { token: 'Punctuator', start: 42, end: 43, value: '/' },
       { token: 'Punctuator', start: 43, end: 44, value: '>' },
-      { token: 'Punctuator', start: 44, end: 46, value: '</' },
+      { token: 'Punctuator', start: 44, end: 45, value: '<' },
+      { token: 'Punctuator', start: 45, end: 46, value: '/' },
       { token: 'Identifier', start: 46, end: 49, value: 'div' },
       { token: 'Punctuator', start: 49, end: 50, value: '>' },
       { token: 'Punctuator', start: 50, end: 51, value: ';' }
@@ -189,14 +191,16 @@ describe('Miscellaneous - onToken', () => {
       { token: 'Identifier', start: 21, end: 24, value: 'a-b' },
       { token: 'Punctuator', start: 24, end: 25, value: '>' },
       { token: 'Punctuator', start: 25, end: 30, value: 'hello' },
-      { token: 'Punctuator', start: 30, end: 32, value: '</' },
+      { token: 'Punctuator', start: 30, end: 31, value: '<' },
+      { token: 'Punctuator', start: 31, end: 32, value: '/' },
       { token: 'Identifier', start: 32, end: 35, value: 'a-b' },
       { token: 'Punctuator', start: 35, end: 36, value: '>' },
       { token: 'Punctuator', start: 36, end: 37, value: '<' },
       { token: 'Identifier', start: 37, end: 38, value: 'c' },
       { token: 'Punctuator', start: 39, end: 40, value: '/' },
       { token: 'Punctuator', start: 40, end: 41, value: '>' },
-      { token: 'Punctuator', start: 41, end: 43, value: '</' },
+      { token: 'Punctuator', start: 41, end: 42, value: '<' },
+      { token: 'Punctuator', start: 42, end: 43, value: '/' },
       { token: 'Punctuator', start: 43, end: 44, value: '>' },
       { token: 'Punctuator', start: 44, end: 45, value: ';' }
     ]);
@@ -220,9 +224,35 @@ describe('Miscellaneous - onToken', () => {
       { token: 'Punctuator', start: 0, end: 1, value: '<' },
       { token: 'Identifier', start: 2, end: 3, value: 'a' },
       { token: 'Punctuator', start: 3, end: 4, value: '>' },
-      { token: 'Punctuator', start: 4, end: 7, value: '< /' },
+      { token: 'Punctuator', start: 4, end: 5, value: '<' },
+      { token: 'Punctuator', start: 6, end: 7, value: '/' },
       { token: 'Identifier', start: 7, end: 8, value: 'a' },
       { token: 'Punctuator', start: 9, end: 10, value: '>' }
+    ]);
+  });
+
+  it('tokenize jsx with comments', () => {
+    const tokens: any[] = [];
+    const source = '<// lorem\na>< /* mm */ / /* xx */ a\n>';
+    parseScript(source, {
+      jsx: true,
+      onToken(token: string, start: number, end: number) {
+        tokens.push({
+          token,
+          start,
+          end,
+          value: source.slice(start, end)
+        });
+      }
+    });
+    t.deepEqual(tokens, [
+      { token: 'Punctuator', start: 0, end: 1, value: '<' },
+      { token: 'Identifier', start: 10, end: 11, value: 'a' },
+      { token: 'Punctuator', start: 11, end: 12, value: '>' },
+      { token: 'Punctuator', start: 12, end: 13, value: '<' },
+      { token: 'Punctuator', start: 23, end: 24, value: '/' },
+      { token: 'Identifier', start: 34, end: 35, value: 'a' },
+      { token: 'Punctuator', start: 36, end: 37, value: '>' }
     ]);
   });
 });


### PR DESCRIPTION
closes #185

This is better I think. Previous fix will take "< /* xx */ /" as one token, that doesn't make sense, now it's "<" and "/" two tokens.