### PR TITLE
feat(parser): add token start and end index/line/column to ParseError

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -202,6 +202,9 @@ export interface ScopeError {
   index: number;
   line: number;
   column: number;
+  tokenIndex: number;
+  tokenLine: number;
+  tokenColumn: number;
 }
 
 /**
@@ -579,13 +582,16 @@ export function createArrowHeadParsingScope(parser: ParserState, context: Contex
  * @param type Errors type
  */
 export function recordScopeError(parser: ParserState, type: Errors, ...params: string[]): ScopeError {
-  const { index, line, column } = parser;
+  const { index, line, column, tokenIndex, tokenLine, tokenColumn } = parser;
   return {
     type,
     params,
     index,
     line,
-    column
+    column,
+    tokenIndex,
+    tokenLine,
+    tokenColumn
   };
 }
 

--- a/src/lexer/identifier.ts
+++ b/src/lexer/identifier.ts
@@ -177,12 +177,29 @@ export function scanUnicodeEscape(parser: ParserState): number {
     const begin = parser.index - 2;
     while (CharTypes[advanceChar(parser)] & CharFlags.Hex) {
       codePoint = (codePoint << 4) | toHex(parser.currentChar);
-      if (codePoint > Chars.NonBMPMax) reportScannerError(begin, parser.line, parser.index + 1, Errors.UnicodeOverflow);
+      if (codePoint > Chars.NonBMPMax)
+        reportScannerError(
+          begin,
+          parser.line,
+          parser.column,
+          parser.index,
+          parser.line,
+          parser.column,
+          Errors.UnicodeOverflow
+        );
     }
 
     // At least 4 characters have to be read
     if ((parser.currentChar as number) !== Chars.RightBrace) {
-      reportScannerError(begin, parser.line, parser.index - 1, Errors.InvalidHexEscapeSequence);
+      reportScannerError(
+        begin,
+        parser.line,
+        parser.column,
+        parser.index,
+        parser.line,
+        parser.column,
+        Errors.InvalidHexEscapeSequence
+      );
     }
     advanceChar(parser); // consumes '}'
     return codePoint;

--- a/src/lexer/numeric.ts
+++ b/src/lexer/numeric.ts
@@ -125,7 +125,10 @@ export function scanNumber(parser: ParserState, context: Context, kind: NumberKi
               reportScannerError(
                 parser.index,
                 parser.line,
-                parser.index + 1 /* skips `_` */,
+                parser.column,
+                parser.index + 1,
+                parser.line,
+                parser.column,
                 Errors.ContinuousNumericSeparator
               );
             }
@@ -142,7 +145,10 @@ export function scanNumber(parser: ParserState, context: Context, kind: NumberKi
           reportScannerError(
             parser.index,
             parser.line,
-            parser.index + 1 /* skips `_` */,
+            parser.column,
+            parser.index + 1,
+            parser.line,
+            parser.column,
             Errors.TrailingNumericSeparator
           );
         }
@@ -238,7 +244,10 @@ export function scanDecimalDigitsOrSeparator(parser: ParserState, char: number):
         reportScannerError(
           parser.index,
           parser.line,
-          parser.index + 1 /* skips `_` */,
+          parser.column,
+          parser.index + 1,
+          parser.line,
+          parser.column,
           Errors.ContinuousNumericSeparator
         );
       }
@@ -252,7 +261,15 @@ export function scanDecimalDigitsOrSeparator(parser: ParserState, char: number):
   }
 
   if (allowSeparator) {
-    reportScannerError(parser.index, parser.line, parser.index + 1 /* skips `_` */, Errors.TrailingNumericSeparator);
+    reportScannerError(
+      parser.index,
+      parser.line,
+      parser.column,
+      parser.index + 1,
+      parser.line,
+      parser.column,
+      Errors.TrailingNumericSeparator
+    );
   }
 
   return ret + parser.source.substring(start, parser.index);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -388,7 +388,15 @@ export function parseStatementList(
       context |= Context.Strict;
 
       if (parser.flags & Flags.Octals) {
-        reportMessageAt(parser.index, parser.line, parser.tokenIndex, Errors.StrictOctalLiteral);
+        reportMessageAt(
+          parser.tokenIndex,
+          parser.tokenLine,
+          parser.tokenColumn,
+          parser.index,
+          parser.line,
+          parser.column,
+          Errors.StrictOctalLiteral
+        );
       }
     }
     statements.push(parseDirective(parser, context, expr, token, tokenIndex, tokenLine, tokenColumn));
@@ -2206,8 +2214,11 @@ function parseVariableDeclaration(
       ) {
         reportMessageAt(
           tokenIndex,
+          tokenLine,
+          tokenColumn,
+          parser.index,
           parser.line,
-          parser.index - 3,
+          parser.column,
           Errors.ForInOfLoopInitializer,
           parser.getToken() === Token.OfKeyword ? 'of' : 'in'
         );
@@ -2645,8 +2656,11 @@ function parseImportNamespaceSpecifier(
   if ((parser.getToken() & Token.IsStringOrNumber) === Token.IsStringOrNumber) {
     reportMessageAt(
       tokenIndex,
-      parser.line,
+      tokenLine,
+      tokenColumn,
       parser.index,
+      parser.line,
+      parser.column,
       Errors.UnexpectedToken,
       KeywordDescTable[parser.getToken() & Token.Type]
     );
@@ -3805,7 +3819,15 @@ export function parseAwaitExpression(
     if (inNew) report(parser, Errors.Unexpected);
 
     if (context & Context.InArgumentList) {
-      reportMessageAt(parser.index, parser.line, parser.index, Errors.AwaitInParameter);
+      reportMessageAt(
+        parser.tokenIndex,
+        parser.tokenLine,
+        parser.tokenColumn,
+        parser.index,
+        parser.line,
+        parser.column,
+        Errors.AwaitInParameter
+      );
     }
 
     nextToken(parser, context | Context.AllowRegExp);
@@ -3871,11 +3893,27 @@ export function parseFunctionBody(
         // in the body of a function with non-simple parameter list, on
         // 29/7/2015. https://goo.gl/ueA7Ln
         if (parser.flags & Flags.NonSimpleParameterList) {
-          reportMessageAt(parser.index, parser.line, parser.tokenIndex, Errors.IllegalUseStrict);
+          reportMessageAt(
+            tokenIndex,
+            tokenLine,
+            tokenColumn,
+            parser.index,
+            parser.line,
+            parser.column,
+            Errors.IllegalUseStrict
+          );
         }
 
         if (parser.flags & Flags.Octals) {
-          reportMessageAt(parser.index, parser.line, parser.tokenIndex, Errors.StrictOctalLiteral);
+          reportMessageAt(
+            tokenIndex,
+            tokenLine,
+            tokenColumn,
+            parser.index,
+            parser.line,
+            parser.column,
+            Errors.StrictOctalLiteral
+          );
         }
       }
       body.push(parseDirective(parser, context, expr, token, tokenIndex, parser.tokenLine, parser.tokenColumn));
@@ -7098,7 +7136,6 @@ export function parseObjectLiteralOrPattern(
         state |= PropertyKind.Generator;
 
         if (parser.getToken() & Token.IsIdentifier) {
-          const { line, index } = parser;
           const token = parser.getToken();
 
           key = parseIdentifier(parser, context);
@@ -7118,9 +7155,12 @@ export function parseObjectLiteralOrPattern(
             );
           } else {
             reportMessageAt(
-              index,
-              line,
-              index,
+              parser.tokenIndex,
+              parser.tokenLine,
+              parser.tokenColumn,
+              parser.index,
+              parser.line,
+              parser.column,
               token === Token.AsyncKeyword
                 ? Errors.InvalidAsyncGetter
                 : token === Token.GetKeyword || parser.getToken() === Token.SetKeyword
@@ -7356,7 +7396,7 @@ export function parseMethodFormals(
     report(parser, Errors.AccessorWrongArgs, 'Setter', 'one', '');
   }
 
-  if (scope && scope.scopeError !== void 0) reportScopeError(scope.scopeError);
+  if (scope && scope.scopeError) reportScopeError(scope.scopeError);
   if (isNonSimpleParameterList) parser.flags |= Flags.NonSimpleParameterList;
 
   consume(parser, context, Token.RightParen);
@@ -7818,7 +7858,7 @@ export function parseArrowFunctionExpression(
 
   let body: ESTree.BlockStatement | ESTree.Expression;
 
-  if (scope && scope.scopeError !== void 0) {
+  if (scope && scope.scopeError) {
     reportScopeError(scope.scopeError);
   }
 
@@ -8048,7 +8088,7 @@ export function parseFormalParametersOrFormalList(
   }
   if (isNonSimpleParameterList) parser.flags |= Flags.NonSimpleParameterList;
 
-  if (scope && (isNonSimpleParameterList || context & Context.Strict) && scope.scopeError !== void 0) {
+  if (scope && (isNonSimpleParameterList || context & Context.Strict) && scope.scopeError) {
     reportScopeError(scope.scopeError);
   }
 


### PR DESCRIPTION
Meriyah actually reported the end position in ParseError, this change added tokenIndex/tokenLine/tokenColumn to ParseError as the start position, together with end position in index/line/column. User can catch the error from meriyah and then uses tool like @babel/code-frame to visualise the failing token.

closes #156