### PR TITLE
fix(parser): all identifiers can be start of an expression

### DIFF
--- a/src/token.ts
+++ b/src/token.ts
@@ -160,7 +160,7 @@ export const enum Token {
 
   /* Contextual keywords */
   AsKeyword          = 108 | Contextual | IsExpressionStart,
-  AsyncKeyword       = 109 | Contextual | IsIdentifier | IsExpressionStart,
+  AsyncKeyword       = 109 | Contextual | IsExpressionStart | IsIdentifier,
   AwaitKeyword       = 110 | Contextual | IsExpressionStart | IsIdentifier, // await is only reserved word in async functions or modules
   ConstructorKeyword = 111 | Contextual,
   GetKeyword         = 112 | Contextual,
@@ -175,7 +175,7 @@ export const enum Token {
 
   EscapedReserved       = 120 | IsEscaped,
   EscapedFutureReserved = 121 | IsEscaped,
-  AnyIdentifier      = 122 | IsIdentifier,
+  AnyIdentifier      = 122 | IsExpressionStart | IsIdentifier,
 
   PrivateIdentifier  = 123,
   BigIntLiteral      = 124 | IsExpressionStart | IsStringOrNumber,
@@ -189,8 +189,8 @@ export const enum Token {
   PrivateField      = 130,
   Template          = 131,
   Decorator         = 132,
-  Target            = 133 | IsIdentifier,
-  Meta              = 134 | IsIdentifier,
+  Target            = 133 | IsExpressionStart | IsIdentifier,
+  Meta              = 134 | IsExpressionStart | IsIdentifier,
   LineFeed          = 135,
   EscapeStart       = 136,
 

--- a/test/parser/expressions/await.ts
+++ b/test/parser/expressions/await.ts
@@ -37,7 +37,9 @@ describe('Expressions - Await', () => {
     '({ async* f(a, b = 2) { yield 1; } })',
     '({ async* f(a, b) { yield 1; } })',
     '({ async* f(a) { yield 1; } })',
-    '(x = class A {[await](){}; "x"(){}}) => {}'
+    '(x = class A {[await](){}; "x"(){}}) => {}',
+    'async function a() { await target }',
+    'async function a() { await meta }'
   ]) {
     it(`${arg}`, () => {
       t.doesNotThrow(() => {


### PR DESCRIPTION
closes #342