### PR TITLE
Fix another issue with octal template strings

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -5674,7 +5674,7 @@ export function parseArguments(
     if (parser.getToken() === Token.RightParen) break;
   }
 
-  consume(parser, context, Token.RightParen);
+  consume(parser, context | Context.TaggedTemplate, Token.RightParen);
 
   return args;
 }

--- a/test/parser/expressions/template.ts
+++ b/test/parser/expressions/template.ts
@@ -341,6 +341,11 @@ describe('Expressions - Template', () => {
     '(`\r`)',
     'new nestedNewOperatorFunction`1``2``3``array`',
     "tag()`'\\00a0'`;",
+    "tag('a')`'\\00a0'`",
+    "tag()('a')`'\\00a0'`",
+    "tag('a')('b')`'\\00a0'`",
+    "tag()(...a)`'\\00a0'`",
+    "tag('a')(b)(c, ...d)`'\\00a0'`;",
     "(tag = () => {})`'\\00a0'`",
     "(() => {})`'\\00a0'`",
     "(function tag() { return () => {}; })()`'\\00a0'`",
@@ -4091,6 +4096,219 @@ describe('Expressions - Template', () => {
                 callee: {
                   name: 'tag',
                   type: 'Identifier'
+                },
+                type: 'CallExpression'
+              },
+              type: 'TaggedTemplateExpression'
+            },
+            type: 'ExpressionStatement'
+          }
+        ],
+        sourceType: 'script',
+        type: 'Program'
+      }
+    ],
+    [
+      "tag('a')`'\\00a0'`;",
+      Context.None,
+      {
+        body: [
+          {
+            expression: {
+              quasi: {
+                expressions: [],
+                quasis: [
+                  {
+                    tail: true,
+                    type: 'TemplateElement',
+                    value: {
+                      cooked: null,
+                      raw: "'\\00a0'"
+                    }
+                  }
+                ],
+                type: 'TemplateLiteral'
+              },
+              tag: {
+                arguments: [
+                  {
+                    type: 'Literal',
+                    value: 'a'
+                  }
+                ],
+                callee: {
+                  name: 'tag',
+                  type: 'Identifier'
+                },
+                type: 'CallExpression'
+              },
+              type: 'TaggedTemplateExpression'
+            },
+            type: 'ExpressionStatement'
+          }
+        ],
+        sourceType: 'script',
+        type: 'Program'
+      }
+    ],
+    [
+      "tag('a')('b')`'\\00a0'`;",
+      Context.None,
+      {
+        body: [
+          {
+            expression: {
+              quasi: {
+                expressions: [],
+                quasis: [
+                  {
+                    tail: true,
+                    type: 'TemplateElement',
+                    value: {
+                      cooked: null,
+                      raw: "'\\00a0'"
+                    }
+                  }
+                ],
+                type: 'TemplateLiteral'
+              },
+              tag: {
+                arguments: [
+                  {
+                    type: 'Literal',
+                    value: 'b'
+                  }
+                ],
+                callee: {
+                  arguments: [
+                    {
+                      type: 'Literal',
+                      value: 'a'
+                    }
+                  ],
+                  callee: {
+                    name: 'tag',
+                    type: 'Identifier'
+                  },
+                  type: 'CallExpression'
+                },
+                type: 'CallExpression'
+              },
+              type: 'TaggedTemplateExpression'
+            },
+            type: 'ExpressionStatement'
+          }
+        ],
+        sourceType: 'script',
+        type: 'Program'
+      }
+    ],
+    [
+      "tag()(...a)`'\\00a0'`;",
+      Context.None,
+      {
+        body: [
+          {
+            expression: {
+              quasi: {
+                expressions: [],
+                quasis: [
+                  {
+                    tail: true,
+                    type: 'TemplateElement',
+                    value: {
+                      cooked: null,
+                      raw: "'\\00a0'"
+                    }
+                  }
+                ],
+                type: 'TemplateLiteral'
+              },
+              tag: {
+                arguments: [
+                  {
+                    argument: {
+                      name: 'a',
+                      type: 'Identifier'
+                    },
+                    type: 'SpreadElement'
+                  }
+                ],
+                callee: {
+                  arguments: [],
+                  callee: {
+                    name: 'tag',
+                    type: 'Identifier'
+                  },
+                  type: 'CallExpression'
+                },
+                type: 'CallExpression'
+              },
+              type: 'TaggedTemplateExpression'
+            },
+            type: 'ExpressionStatement'
+          }
+        ],
+        sourceType: 'script',
+        type: 'Program'
+      }
+    ],
+    [
+      "tag('a')(b)(c, ...d)`'\\00a0'`;",
+      Context.None,
+      {
+        body: [
+          {
+            expression: {
+              quasi: {
+                expressions: [],
+                quasis: [
+                  {
+                    tail: true,
+                    type: 'TemplateElement',
+                    value: {
+                      cooked: null,
+                      raw: "'\\00a0'"
+                    }
+                  }
+                ],
+                type: 'TemplateLiteral'
+              },
+              tag: {
+                arguments: [
+                  {
+                    name: 'c',
+                    type: 'Identifier'
+                  },
+                  {
+                    argument: {
+                      name: 'd',
+                      type: 'Identifier'
+                    },
+                    type: 'SpreadElement'
+                  }
+                ],
+                callee: {
+                  arguments: [
+                    {
+                      name: 'b',
+                      type: 'Identifier'
+                    }
+                  ],
+                  callee: {
+                    arguments: [
+                      {
+                        type: 'Literal',
+                        value: 'a'
+                      }
+                    ],
+                    callee: {
+                      name: 'tag',
+                      type: 'Identifier'
+                    },
+                    type: 'CallExpression'
+                  },
+                  type: 'CallExpression'
                 },
                 type: 'CallExpression'
               },


### PR DESCRIPTION
The parser fails to parse an octal string template when the tagged function contains arguments, for example:
```js
tag('a')`'\\00a0'`
```