### PR TITLE
ci: use yarn to install dependencies

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,6 +24,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - run: npm i
+      - run: yarn
       - run: npm run lint
       - run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,6 +24,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: 'yarn'
+          cache-dependency-path: ./package.json
       - run: yarn
       - run: npm run lint
       - run: npm test


### PR DESCRIPTION
`npm i` is so [slow](https://github.com/meriyah/meriyah/actions/runs/14377174160/job/40312236071?pr=380#step:4:19), choose yarn since it can use directly on ci.