### PR TITLE
build: improve bundle speed

### DIFF
--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { join } from 'node:path';
+import path from 'node:path';
 import fs from 'node:fs/promises';
 import { rollup } from 'rollup';
 import typescript2 from 'rollup-plugin-typescript2';
@@ -9,11 +9,11 @@ import * as ts from 'typescript';
 
 // eslint-disable-next-line n/no-unsupported-features/node-builtins
 const { dirname } = import.meta;
-const ENTRY = join(dirname, '../src/meriyah.ts');
-const TSCONFIG = join(dirname, '../tsconfig.json');
-const DIST = join(dirname, '../dist/');
+const ENTRY = path.join(dirname, '../src/meriyah.ts');
+const TSCONFIG = path.join(dirname, '../tsconfig.json');
+const DIST = path.join(dirname, '../dist/');
 
-function getRollupOutputOptions(format, minified) {
+function createRollupOutputOptions(format, minified) {
   let suffix = format === 'umd' ? '.umd' : '';
   suffix += minified ? '.min' : '';
   suffix += format === 'esm' ? '.mjs' : format === 'cjs' ? '.cjs' : '.js';
@@ -21,34 +21,41 @@ function getRollupOutputOptions(format, minified) {
   return {
     name: 'meriyah',
     format,
-    file: join(DIST, `meriyah${suffix}`)
+    file: path.join(DIST, `meriyah${suffix}`),
+    plugins: minified ? [terser()] : []
   };
 }
 
+function* getRollupOutputOptions() {
+  for (const format of ['esm', 'umd', 'cjs']) {
+    yield createRollupOutputOptions(format, false);
+
+    // CommonJS version don't need minify
+    if (format === 'cjs') {
+      continue;
+    }
+
+    // Minified
+    yield createRollupOutputOptions(format, true);
+  }
+}
+
+// Clean up `dist/`
 await fs.rm(DIST, { force: true, recursive: true });
 
-for (const { formats, minified } of [
-  { formats: ['esm', 'umd', 'cjs'], minified: false },
-  { formats: ['esm', 'umd'], minified: true }
-]) {
-  const bundle = await rollup({
-    input: ENTRY,
-    plugins: [
-      typescript2({
-        tsconfig: TSCONFIG,
-        typescript: ts,
-        clean: true
-      }),
-      json(),
-      ...(minified ? [terser()] : [])
-    ]
-  });
+const bundle = await rollup({
+  input: ENTRY,
+  plugins: [
+    typescript2({
+      tsconfig: TSCONFIG,
+      typescript: ts,
+      clean: true
+    }),
+    json()
+  ]
+});
 
-  await Promise.all(
-    formats.map((format) => {
-      const options = getRollupOutputOptions(format, minified);
-      console.log(`writing ${options.file}`);
-      return bundle.write(options);
-    })
-  );
+for (const options of getRollupOutputOptions()) {
+  console.log(`writing ${path.relative(process.cwd(), options.file)}`);
+  await bundle.write(options);
 }

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -56,6 +56,6 @@ const bundle = await rollup({
 });
 
 for (const options of getRollupOutputOptions()) {
-  console.log(`writing ${path.relative(process.cwd(), options.file)}`);
+  console.log(`writing ${path.relative(process.cwd(), options.file).replaceAll('\\', '/')}`);
   await bundle.write(options);
 }

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -14,14 +14,17 @@ const TSCONFIG = path.join(dirname, '../tsconfig.json');
 const DIST = path.join(dirname, '../dist/');
 
 function getRollupOutputOptions(format, minified) {
-  let suffix = format === 'umd' ? '.umd' : '';
-  suffix += minified ? '.min' : '';
-  suffix += format === 'esm' ? '.mjs' : format === 'cjs' ? '.cjs' : '.js';
+  const filename = [
+    'meriyah',
+    format === 'umd' ? '.umd' : '',
+    minified ? '.min' : '',
+    format === 'esm' ? '.mjs' : format === 'cjs' ? '.cjs' : '.js'
+  ].join('');
 
   return {
     name: 'meriyah',
     format,
-    file: path.join(DIST, `meriyah${suffix}`),
+    file: path.join(DIST, filename),
     plugins: minified ? [terser()] : []
   };
 }

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -13,7 +13,7 @@ const ENTRY = path.join(dirname, '../src/meriyah.ts');
 const TSCONFIG = path.join(dirname, '../tsconfig.json');
 const DIST = path.join(dirname, '../dist/');
 
-function createRollupOutputOptions(format, minified) {
+function getRollupOutputOptions(format, minified) {
   let suffix = format === 'umd' ? '.umd' : '';
   suffix += minified ? '.min' : '';
   suffix += format === 'esm' ? '.mjs' : format === 'cjs' ? '.cjs' : '.js';
@@ -26,9 +26,9 @@ function createRollupOutputOptions(format, minified) {
   };
 }
 
-function* getRollupOutputOptions() {
+function* getEntries() {
   for (const format of ['esm', 'umd', 'cjs']) {
-    yield createRollupOutputOptions(format, false);
+    yield getRollupOutputOptions(format, false);
 
     // CommonJS version don't need minify
     if (format === 'cjs') {
@@ -36,7 +36,7 @@ function* getRollupOutputOptions() {
     }
 
     // Minified
-    yield createRollupOutputOptions(format, true);
+    yield getRollupOutputOptions(format, true);
   }
 }
 
@@ -55,7 +55,7 @@ const bundle = await rollup({
   ]
 });
 
-for (const options of getRollupOutputOptions()) {
+for (const options of getEntries()) {
   console.log(`writing ${path.relative(process.cwd(), options.file).replaceAll('\\', '/')}`);
   await bundle.write(options);
 }

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -30,7 +30,14 @@ function getRollupOutputOptions(format, minified) {
 }
 
 function* getEntries() {
-  for (const format of ['esm', 'umd', 'cjs']) {
+  for (const format of [
+    // ESM
+    'esm',
+    // UMD supports AMD, CommonJS, and IIFE
+    'umd',
+    // CommonJS
+    'cjs'
+  ]) {
     yield getRollupOutputOptions(format, false);
 
     // CommonJS version don't need minify


### PR DESCRIPTION
Before:

```console
$ node scripts/bundle.mjs
writing E:\oss\forks\meriyah\dist\meriyah.cjs
writing E:\oss\forks\meriyah\dist\meriyah.min.mjs
writing E:\oss\forks\meriyah\dist\meriyah.mjs
writing E:\oss\forks\meriyah\dist\meriyah.umd.min.js
writing E:\oss\forks\meriyah\dist\meriyah.umd.js
Done in 17.74s.
```

After:

```console
$ node scripts/bundle.mjs
writing dist/meriyah.mjs
writing dist/meriyah.min.mjs
writing dist/meriyah.umd.js
writing dist/meriyah.umd.min.js
writing dist/meriyah.cjs
Done in 6.65s.
```


