### PR TITLE
feat: remove location information from `ParseError.description`

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -391,17 +391,8 @@ export class ParseError extends SyntaxError implements _Node {
     type: Errors,
     ...params: string[]
   ) {
-    const message =
-      '[' +
-      startLine +
-      ':' +
-      startColumn +
-      '-' +
-      endLine +
-      ':' +
-      endColumn +
-      ']: ' +
-      errorMessages[type].replace(/%(\d+)/g, (_: string, i: number) => params[i]);
+    const description = errorMessages[type].replace(/%(\d+)/g, (_: string, i: number) => params[i]);
+    const message = '[' + startLine + ':' + startColumn + '-' + endLine + ':' + endColumn + ']: ' + description;
     super(`${message}`);
     this.start = start;
     this.end = end;
@@ -410,7 +401,7 @@ export class ParseError extends SyntaxError implements _Node {
       start: { line: startLine, column: startColumn },
       end: { line: endLine, column: endColumn }
     };
-    this.description = message;
+    this.description = description;
   }
 }
 /**

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -393,7 +393,7 @@ export class ParseError extends SyntaxError implements _Node {
   ) {
     const description = errorMessages[type].replace(/%(\d+)/g, (_: string, i: number) => params[i]);
     const message = '[' + startLine + ':' + startColumn + '-' + endLine + ':' + endColumn + ']: ' + description;
-    super(`${message}`);
+    super(message);
     this.start = start;
     this.end = end;
     this.range = [start, end];


### PR DESCRIPTION
Not sure why `description` exists at first place, but if it is the same as `.message` makes it completely useless.

Remove location information so that if user don't need it can use `.description` directly.

Prettier is now removing it

https://github.com/prettier/prettier/blob/88e35f974fecd06d64fba59d4dc94a6b371a0728/src/language-js/parse/meriyah.js#L65-L68