### PR TITLE
fix: remove `ESTree` export

### DIFF
--- a/src/meriyah.ts
+++ b/src/meriyah.ts
@@ -1,6 +1,6 @@
 import { Context } from './common';
 import { parseSource, Options } from './parser';
-import * as ESTree from './estree';
+import { type Program } from './estree';
 // Current version
 import { version as pkgVersion } from '../package.json';
 
@@ -10,22 +10,23 @@ const version: string = pkgVersion;
 /**
  * Parse a script, optionally with various options.
  */
-export function parseScript(source: string, options?: Options): ESTree.Program {
+export function parseScript(source: string, options?: Options): Program {
   return parseSource(source, options, Context.None);
 }
 
 /**
  * Parse a module, optionally with various options.
  */
-export function parseModule(source: string, options?: Options): ESTree.Program {
+export function parseModule(source: string, options?: Options): Program {
   return parseSource(source, options, Context.Strict | Context.Module);
 }
 
 /**
  * Parse a module or a script, optionally with various options.
  */
-export function parse(source: string, options?: Options): ESTree.Program {
+export function parse(source: string, options?: Options): Program {
   return parseSource(source, options, Context.None);
 }
 
-export { Options, ESTree, version };
+export { Options, version };
+export type * as ESTree from './estree';


### PR DESCRIPTION
 `ESTree` should only export in types

Before:

```console
> await import('./dist/meriyah.mjs')
[Module: null prototype] {
  ESTree: [Object: null prototype] {},
  parse: [Function: parse],
  parseModule: [Function: parseModule],
  parseScript: [Function: parseScript],
  version: '6.0.6'
}
```

After:

```console
> await import('./dist/meriyah.mjs')
[Module: null prototype] {
  parse: [Function: parse],
  parseModule: [Function: parseModule],
  parseScript: [Function: parseScript],
  version: '6.0.6'
}
```