### PR TITLE
chore: fix TS2687 error

### DIFF
--- a/src/estree.ts
+++ b/src/estree.ts
@@ -373,7 +373,6 @@ export interface PropertyDefinition extends _Node {
   type: 'PropertyDefinition';
   key: PrivateIdentifier | Expression;
   value: any;
-  // @ts-expect-error -- Unknown reason
   decorators?: Decorator[];
   computed: boolean;
   static: boolean;
@@ -663,7 +662,6 @@ export interface MethodDefinition extends _Node {
   computed: boolean;
   static: boolean;
   kind: 'method' | 'get' | 'set' | 'constructor';
-  // @ts-expect-error -- Unknown reason
   decorators?: Decorator[];
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "alwaysStrict": true,
-    "baseUrl": "./src",
     "declaration": true,
     "declarationMap": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
My guess is add `baseUrl` cause TS resolve 

```ts
declare module 'estree' {}
```

[Line 3 in this file](https://app.unpkg.com/rollup@4.40.0/files/dist/rollup.d.ts)

to `src/estree.ts`