### PR TITLE
fix(parser): add missing `generator` property to `ArrowFunctionExpression`

### DIFF
--- a/src/estree.ts
+++ b/src/estree.ts
@@ -290,6 +290,7 @@ export interface ArrowFunctionExpression extends _Node {
   body: Expression | BlockStatement;
   async: boolean;
   expression: boolean;
+  generator: false;
 }
 
 export interface AssignmentExpression extends _Node {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -8909,7 +8909,8 @@ export function parseArrowFunctionExpression(
     params,
     body,
     async: isAsync === 1,
-    expression
+    expression,
+    generator: false
   });
 }
 

--- a/test/parser/declarations/async-function.ts
+++ b/test/parser/declarations/async-function.ts
@@ -1267,6 +1267,7 @@ describe('Declarations - Async Function', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'AwaitExpression',
                 argument: {
@@ -1810,6 +1811,7 @@ describe('Declarations - Async Function', () => {
                 },
                 right: {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'AwaitExpression',
                     argument: {
@@ -2139,6 +2141,7 @@ describe('Declarations - Async Function', () => {
               },
               right: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 start: 4,
                 end: 111,
                 range: [4, 111],

--- a/test/parser/declarations/async-generator.ts
+++ b/test/parser/declarations/async-generator.ts
@@ -510,6 +510,7 @@ describe('Declarations - Async Generator', () => {
                     },
                     right: {
                       type: 'ArrowFunctionExpression',
+                      generator: false,
                       body: {
                         type: 'BlockStatement',
                         body: []
@@ -1019,6 +1020,7 @@ describe('Declarations - Async Generator', () => {
                       },
                       right: {
                         type: 'ArrowFunctionExpression',
+                        generator: false,
                         body: {
                           type: 'BlockStatement',
                           body: []

--- a/test/parser/declarations/const.ts
+++ b/test/parser/declarations/const.ts
@@ -1331,7 +1331,8 @@ describe('Declarations - const', () => {
                             type: 'ObjectPattern'
                           }
                         ],
-                        type: 'ArrowFunctionExpression'
+                        type: 'ArrowFunctionExpression',
+                        generator: false
                       },
                       kind: 'init',
                       method: false,
@@ -1432,6 +1433,7 @@ describe('Declarations - const', () => {
                         },
                         right: {
                           type: 'ArrowFunctionExpression',
+                          generator: false,
                           body: {
                             type: 'BlockStatement',
                             body: [

--- a/test/parser/declarations/functions.ts
+++ b/test/parser/declarations/functions.ts
@@ -721,6 +721,7 @@ describe('Declarations - Function', () => {
                   },
                   right: {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     body: {
                       type: 'BlockStatement',
                       body: []
@@ -802,6 +803,7 @@ describe('Declarations - Function', () => {
               operator: '=',
               right: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'BlockStatement',
                   body: []
@@ -1940,7 +1942,8 @@ describe('Declarations - Function', () => {
                   type: 'Identifier'
                 }
               ],
-              type: 'ArrowFunctionExpression'
+              type: 'ArrowFunctionExpression',
+              generator: false
             },
             type: 'ExpressionStatement'
           }

--- a/test/parser/declarations/let.ts
+++ b/test/parser/declarations/let.ts
@@ -958,6 +958,7 @@ describe('Declarations - Let', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: [

--- a/test/parser/expressions/array.ts
+++ b/test/parser/expressions/array.ts
@@ -739,7 +739,8 @@ describe('Expressions - Array', () => {
                           type: 'Identifier'
                         }
                       ],
-                      type: 'ArrowFunctionExpression'
+                      type: 'ArrowFunctionExpression',
+                      generator: false
                     },
                     type: 'AssignmentExpression'
                   },
@@ -4885,6 +4886,7 @@ describe('Expressions - Array', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -5108,6 +5110,7 @@ describe('Expressions - Array', () => {
               operator: '=',
               right: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'BlockStatement',
                   body: []
@@ -7718,6 +7721,7 @@ describe('Expressions - Array', () => {
                     type: 'MemberExpression',
                     object: {
                       type: 'ArrowFunctionExpression',
+                      generator: false,
                       body: {
                         type: 'Identifier',
                         name: 'z'
@@ -7772,6 +7776,7 @@ describe('Expressions - Array', () => {
                     type: 'MemberExpression',
                     object: {
                       type: 'ArrowFunctionExpression',
+                      generator: false,
                       body: {
                         type: 'Identifier',
                         name: 'z'
@@ -8889,6 +8894,7 @@ describe('Expressions - Array', () => {
               elements: [
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'BlockStatement',
                     body: []
@@ -8918,6 +8924,7 @@ describe('Expressions - Array', () => {
               elements: [
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'BlockStatement',
                     body: []

--- a/test/parser/expressions/arrow.ts
+++ b/test/parser/expressions/arrow.ts
@@ -1182,6 +1182,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -1210,6 +1211,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -1246,6 +1248,7 @@ describe('Expressions - Arrow', () => {
               operator: '=',
               right: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'BlockStatement',
                   body: []
@@ -1293,6 +1296,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: [
@@ -1347,7 +1351,8 @@ describe('Expressions - Arrow', () => {
                   type: 'Identifier'
                 }
               ],
-              type: 'ArrowFunctionExpression'
+              type: 'ArrowFunctionExpression',
+              generator: false
             },
             type: 'ExpressionStatement'
           }
@@ -1377,7 +1382,8 @@ describe('Expressions - Arrow', () => {
                       type: 'Identifier'
                     }
                   ],
-                  type: 'ArrowFunctionExpression'
+                  type: 'ArrowFunctionExpression',
+                  generator: false
                 },
                 {
                   async: false,
@@ -1392,7 +1398,8 @@ describe('Expressions - Arrow', () => {
                       type: 'Identifier'
                     }
                   ],
-                  type: 'ArrowFunctionExpression'
+                  type: 'ArrowFunctionExpression',
+                  generator: false
                 }
               ],
               type: 'SequenceExpression'
@@ -1425,7 +1432,8 @@ describe('Expressions - Arrow', () => {
                       type: 'Identifier'
                     }
                   ],
-                  type: 'ArrowFunctionExpression'
+                  type: 'ArrowFunctionExpression',
+                  generator: false
                 },
                 {
                   async: false,
@@ -1440,7 +1448,8 @@ describe('Expressions - Arrow', () => {
                       type: 'Identifier'
                     }
                   ],
-                  type: 'ArrowFunctionExpression'
+                  type: 'ArrowFunctionExpression',
+                  generator: false
                 }
               ],
               type: 'SequenceExpression'
@@ -1463,6 +1472,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -1498,6 +1508,7 @@ describe('Expressions - Arrow', () => {
               operator: '=',
               right: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'BlockStatement',
                   body: []
@@ -1544,6 +1555,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Literal',
                 value: 0
@@ -1703,6 +1715,7 @@ describe('Expressions - Arrow', () => {
             range: [0, 10],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 10,
               range: [0, 10],
@@ -1760,6 +1773,7 @@ describe('Expressions - Arrow', () => {
             range: [0, 10],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 10,
               range: [0, 10],
@@ -1817,6 +1831,7 @@ describe('Expressions - Arrow', () => {
             range: [0, 10],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 10,
               range: [0, 10],
@@ -1879,6 +1894,7 @@ describe('Expressions - Arrow', () => {
               range: [0, 15],
               left: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 start: 1,
                 end: 9,
                 range: [1, 9],
@@ -1923,6 +1939,7 @@ describe('Expressions - Arrow', () => {
             range: [0, 11],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 11,
               range: [0, 11],
@@ -1980,6 +1997,7 @@ describe('Expressions - Arrow', () => {
             range: [0, 8],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 8,
               range: [0, 8],
@@ -2029,7 +2047,8 @@ describe('Expressions - Arrow', () => {
                 },
                 expression: false,
                 params: [],
-                type: 'ArrowFunctionExpression'
+                type: 'ArrowFunctionExpression',
+                generator: false
               },
               operator: '+',
               right: {
@@ -2081,6 +2100,7 @@ describe('Expressions - Arrow', () => {
               },
               right: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 start: 5,
                 end: 22,
                 range: [5, 22],
@@ -2171,6 +2191,7 @@ describe('Expressions - Arrow', () => {
             range: [0, 10],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 10,
               range: [0, 10],
@@ -2214,6 +2235,7 @@ describe('Expressions - Arrow', () => {
             range: [0, 20],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 20,
               range: [0, 20],
@@ -2284,6 +2306,7 @@ describe('Expressions - Arrow', () => {
             range: [0, 18],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 18,
               range: [0, 18],
@@ -2422,6 +2445,7 @@ describe('Expressions - Arrow', () => {
             range: [0, 13],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 13,
               range: [0, 13],
@@ -2467,6 +2491,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -2525,6 +2550,7 @@ describe('Expressions - Arrow', () => {
             range: [0, 522],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 522,
               range: [0, 522],
@@ -2687,6 +2713,7 @@ describe('Expressions - Arrow', () => {
                       },
                       right: {
                         type: 'ArrowFunctionExpression',
+                        generator: false,
                         start: 181,
                         end: 243,
                         range: [181, 243],
@@ -2884,6 +2911,7 @@ describe('Expressions - Arrow', () => {
                             arguments: [
                               {
                                 type: 'ArrowFunctionExpression',
+                                generator: false,
                                 start: 353,
                                 end: 498,
                                 range: [353, 498],
@@ -3030,6 +3058,7 @@ describe('Expressions - Arrow', () => {
             range: [0, 16],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 16,
               range: [0, 16],
@@ -3093,6 +3122,7 @@ describe('Expressions - Arrow', () => {
             range: [0, 23],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 23,
               range: [0, 23],
@@ -3176,6 +3206,7 @@ describe('Expressions - Arrow', () => {
             range: [0, 16],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 16,
               range: [0, 16],
@@ -3270,6 +3301,7 @@ describe('Expressions - Arrow', () => {
                 },
                 init: {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   start: 8,
                   end: 22,
                   range: [8, 22],
@@ -3367,6 +3399,7 @@ describe('Expressions - Arrow', () => {
             range: [0, 16],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 16,
               range: [0, 16],
@@ -3426,6 +3459,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Literal',
                 value: 0
@@ -3459,6 +3493,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Literal',
                 value: 'test'
@@ -3494,6 +3529,7 @@ describe('Expressions - Arrow', () => {
             range: [0, 18],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 18,
               range: [0, 18],
@@ -3559,6 +3595,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: [
@@ -3606,6 +3643,7 @@ describe('Expressions - Arrow', () => {
             range: [0, 14],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 14,
               range: [0, 14],
@@ -3671,6 +3709,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Literal',
                 value: 42
@@ -3701,6 +3740,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Literal',
                 value: 42
@@ -3738,8 +3778,10 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'SequenceExpression',
                   expressions: [
@@ -3805,6 +3847,7 @@ describe('Expressions - Arrow', () => {
               arguments: [
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'BlockStatement',
                     body: []
@@ -3839,6 +3882,7 @@ describe('Expressions - Arrow', () => {
               arguments: [
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'BlockStatement',
                     body: []
@@ -3875,6 +3919,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: [
@@ -3920,6 +3965,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -3957,6 +4003,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -3990,6 +4037,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -4026,6 +4074,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
 
               expression: true,
 
@@ -4057,6 +4106,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: [
@@ -4102,6 +4152,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -4148,6 +4199,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -4186,6 +4238,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -4228,6 +4281,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -4300,7 +4354,8 @@ describe('Expressions - Arrow', () => {
               },
               expression: false,
               params: [],
-              type: 'ArrowFunctionExpression'
+              type: 'ArrowFunctionExpression',
+              generator: false
             },
             type: 'ExpressionStatement'
           }
@@ -4320,6 +4375,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -4354,6 +4410,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -4409,6 +4466,7 @@ describe('Expressions - Arrow', () => {
               operator: '=',
               right: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'Identifier',
                   name: 'c'
@@ -4473,6 +4531,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -4535,6 +4594,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -4602,6 +4662,7 @@ describe('Expressions - Arrow', () => {
             range: [0, 16],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 16,
               range: [0, 16],
@@ -4703,6 +4764,7 @@ describe('Expressions - Arrow', () => {
                 },
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   start: 7,
                   end: 18,
                   range: [7, 18],
@@ -4761,6 +4823,7 @@ describe('Expressions - Arrow', () => {
               expressions: [
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   start: 0,
                   end: 11,
                   range: [0, 11],
@@ -4792,6 +4855,7 @@ describe('Expressions - Arrow', () => {
                 },
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   start: 13,
                   end: 24,
                   range: [13, 24],
@@ -4857,6 +4921,7 @@ describe('Expressions - Arrow', () => {
                 },
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   start: 4,
                   end: 11,
                   range: [4, 11],
@@ -4881,6 +4946,7 @@ describe('Expressions - Arrow', () => {
                 },
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   start: 13,
                   end: 23,
                   range: [13, 23],
@@ -4940,6 +5006,7 @@ describe('Expressions - Arrow', () => {
             range: [0, 23],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 23,
               range: [0, 23],
@@ -5017,6 +5084,7 @@ describe('Expressions - Arrow', () => {
             range: [0, 35],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 35,
               range: [0, 35],
@@ -5177,6 +5245,7 @@ describe('Expressions - Arrow', () => {
             range: [0, 15],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 15,
               range: [0, 15],
@@ -5258,6 +5327,7 @@ describe('Expressions - Arrow', () => {
             range: [0, 13],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 13,
               range: [0, 13],
@@ -5303,6 +5373,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -5337,6 +5408,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Literal',
                 value: 42
@@ -5379,6 +5451,7 @@ describe('Expressions - Arrow', () => {
             range: [0, 16],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 16,
               range: [0, 16],
@@ -5437,6 +5510,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -5479,6 +5553,7 @@ describe('Expressions - Arrow', () => {
             range: [0, 10],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 9,
               range: [0, 9],
@@ -5517,6 +5592,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BinaryExpression',
                 left: {
@@ -5564,6 +5640,7 @@ describe('Expressions - Arrow', () => {
             range: [0, 26],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 26,
               range: [0, 26],
@@ -5587,6 +5664,7 @@ describe('Expressions - Arrow', () => {
               ],
               body: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 start: 10,
                 end: 26,
                 range: [10, 26],
@@ -5654,6 +5732,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -5707,6 +5786,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'bar'
@@ -5732,6 +5812,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -5783,6 +5864,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -5848,6 +5930,7 @@ describe('Expressions - Arrow', () => {
             },
             init: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BinaryExpression',
                 left: {
@@ -5891,8 +5974,10 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'BinaryExpression',
                   left: {
@@ -5954,8 +6039,10 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'BinaryExpression',
                   left: {
@@ -6024,6 +6111,7 @@ describe('Expressions - Arrow', () => {
                 },
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'Literal',
                     value: 0
@@ -6067,6 +6155,7 @@ describe('Expressions - Arrow', () => {
                 },
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'Literal',
                     value: 0
@@ -6107,6 +6196,7 @@ describe('Expressions - Arrow', () => {
                 type: 'VariableDeclarator',
                 init: {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'Identifier',
                     name: 'x'
@@ -6183,10 +6273,13 @@ describe('Expressions - Arrow', () => {
                 type: 'VariableDeclarator',
                 init: {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     body: {
                       type: 'ArrowFunctionExpression',
+                      generator: false,
                       body: {
                         type: 'AssignmentExpression',
                         left: {
@@ -6285,12 +6378,16 @@ describe('Expressions - Arrow', () => {
                 type: 'VariableDeclarator',
                 init: {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     body: {
                       type: 'ArrowFunctionExpression',
+                      generator: false,
                       body: {
                         type: 'ArrowFunctionExpression',
+                        generator: false,
                         body: {
                           type: 'BlockStatement',
                           body: [
@@ -6371,6 +6468,7 @@ describe('Expressions - Arrow', () => {
               expressions: [
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'Literal',
                     value: 0
@@ -6392,6 +6490,7 @@ describe('Expressions - Arrow', () => {
                 },
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'Literal',
                     value: 1
@@ -6435,6 +6534,7 @@ describe('Expressions - Arrow', () => {
                 },
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'BlockStatement',
                     body: []
@@ -6452,6 +6552,7 @@ describe('Expressions - Arrow', () => {
                 },
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'BinaryExpression',
                     left: {
@@ -6495,6 +6596,7 @@ describe('Expressions - Arrow', () => {
               expressions: [
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'BlockStatement',
                     body: []
@@ -6516,6 +6618,7 @@ describe('Expressions - Arrow', () => {
                 },
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'BinaryExpression',
                     left: {
@@ -6570,6 +6673,7 @@ describe('Expressions - Arrow', () => {
                     },
                     {
                       type: 'ArrowFunctionExpression',
+                      generator: false,
                       body: {
                         type: 'Literal',
                         value: 0
@@ -6632,6 +6736,7 @@ describe('Expressions - Arrow', () => {
               },
               alternate: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 start: 12,
                 end: 21,
                 range: [12, 21],
@@ -6671,6 +6776,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -6705,6 +6811,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -6739,6 +6846,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -6785,6 +6893,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -6822,6 +6931,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -6863,6 +6973,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -6904,6 +7015,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -6956,6 +7068,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -7009,6 +7122,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -7051,6 +7165,7 @@ describe('Expressions - Arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -7105,6 +7220,7 @@ describe('Expressions - Arrow', () => {
             range: [0, 9],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 8,
               range: [0, 8],
@@ -7135,6 +7251,7 @@ describe('Expressions - Arrow', () => {
             range: [25, 37],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 25,
               end: 36,
               range: [25, 36],
@@ -7172,6 +7289,7 @@ describe('Expressions - Arrow', () => {
             range: [53, 61],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 53,
               end: 60,
               range: [53, 60],
@@ -7194,6 +7312,7 @@ describe('Expressions - Arrow', () => {
             range: [77, 93],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 77,
               end: 92,
               range: [77, 92],
@@ -7210,6 +7329,7 @@ describe('Expressions - Arrow', () => {
               ],
               body: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 start: 84,
                 end: 92,
                 range: [84, 92],
@@ -7241,6 +7361,7 @@ describe('Expressions - Arrow', () => {
             range: [133, 151],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 133,
               end: 150,
               range: [133, 150],
@@ -7257,6 +7378,7 @@ describe('Expressions - Arrow', () => {
               ],
               body: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 start: 141,
                 end: 149,
                 range: [141, 149],
@@ -7288,6 +7410,7 @@ describe('Expressions - Arrow', () => {
             range: [188, 205],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 188,
               end: 204,
               range: [188, 204],
@@ -7296,6 +7419,7 @@ describe('Expressions - Arrow', () => {
               params: [],
               body: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 start: 194,
                 end: 204,
                 range: [194, 204],
@@ -7334,6 +7458,7 @@ describe('Expressions - Arrow', () => {
             range: [245, 259],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 245,
               end: 259,
               range: [245, 259],
@@ -7378,6 +7503,7 @@ describe('Expressions - Arrow', () => {
             range: [264, 273],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 264,
               end: 272,
               range: [264, 272],
@@ -7434,6 +7560,7 @@ describe('Expressions - Arrow', () => {
                 },
                 init: {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   start: 10,
                   end: 32,
                   range: [10, 32],
@@ -7507,6 +7634,7 @@ describe('Expressions - Arrow', () => {
               range: [0, 18],
               left: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 start: 1,
                 end: 9,
                 range: [1, 9],
@@ -7543,6 +7671,7 @@ describe('Expressions - Arrow', () => {
               range: [24, 42],
               test: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 start: 25,
                 end: 33,
                 range: [25, 33],
@@ -7598,6 +7727,7 @@ describe('Expressions - Arrow', () => {
               range: [0, 14],
               left: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 start: 1,
                 end: 9,
                 range: [1, 9],
@@ -7654,6 +7784,7 @@ describe('Expressions - Arrow', () => {
               },
               consequent: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 start: 8,
                 end: 37,
                 range: [8, 37],
@@ -7677,6 +7808,7 @@ describe('Expressions - Arrow', () => {
                 ],
                 body: {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   start: 18,
                   end: 37,
                   range: [18, 37],

--- a/test/parser/expressions/async-arrow.ts
+++ b/test/parser/expressions/async-arrow.ts
@@ -882,6 +882,7 @@ describe('Expressions - Async arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: [],
@@ -901,6 +902,7 @@ describe('Expressions - Async arrow', () => {
                   },
                   right: {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     body: {
                       type: 'BlockStatement',
                       body: [
@@ -996,6 +998,7 @@ describe('Expressions - Async arrow', () => {
                     arguments: [
                       {
                         type: 'ArrowFunctionExpression',
+                        generator: false,
                         start: 7,
                         end: 14,
                         range: [7, 14],
@@ -1064,6 +1067,7 @@ describe('Expressions - Async arrow', () => {
             },
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 34,
               range: [0, 34],
@@ -1229,6 +1233,7 @@ describe('Expressions - Async arrow', () => {
                     range: [0, 39],
                     callee: {
                       type: 'ArrowFunctionExpression',
+                      generator: false,
                       start: 1,
                       end: 15,
                       range: [1, 15],
@@ -1246,6 +1251,7 @@ describe('Expressions - Async arrow', () => {
                     arguments: [
                       {
                         type: 'ArrowFunctionExpression',
+                        generator: false,
                         start: 24,
                         end: 38,
                         range: [24, 38],
@@ -1265,6 +1271,7 @@ describe('Expressions - Async arrow', () => {
                   arguments: [
                     {
                       type: 'ArrowFunctionExpression',
+                      generator: false,
                       start: 47,
                       end: 61,
                       range: [47, 61],
@@ -1284,6 +1291,7 @@ describe('Expressions - Async arrow', () => {
                 arguments: [
                   {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     start: 70,
                     end: 84,
                     range: [70, 84],
@@ -1303,6 +1311,7 @@ describe('Expressions - Async arrow', () => {
               arguments: [
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   start: 93,
                   end: 107,
                   range: [93, 107],
@@ -1335,6 +1344,7 @@ describe('Expressions - Async arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -1383,6 +1393,7 @@ describe('Expressions - Async arrow', () => {
               operator: '+',
               right: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 start: 5,
                 end: 17,
                 range: [5, 17],
@@ -1452,6 +1463,7 @@ describe('Expressions - Async arrow', () => {
                   },
                   consequent: {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     start: 15,
                     end: 26,
                     range: [15, 26],
@@ -1504,6 +1516,7 @@ describe('Expressions - Async arrow', () => {
                   },
                   alternate: {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     start: 29,
                     end: 69,
                     range: [29, 69],
@@ -1603,6 +1616,7 @@ describe('Expressions - Async arrow', () => {
                       operator: '+',
                       right: {
                         type: 'ArrowFunctionExpression',
+                        generator: false,
                         start: 57,
                         end: 68,
                         range: [57, 68],
@@ -1658,6 +1672,7 @@ describe('Expressions - Async arrow', () => {
               elements: [
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   start: 1,
                   end: 16,
                   range: [1, 16],
@@ -1716,6 +1731,7 @@ describe('Expressions - Async arrow', () => {
               elements: [
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   start: 1,
                   end: 13,
                   range: [1, 13],
@@ -1781,6 +1797,7 @@ describe('Expressions - Async arrow', () => {
                 },
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   start: 5,
                   end: 23,
                   range: [5, 23],
@@ -1853,6 +1870,7 @@ describe('Expressions - Async arrow', () => {
                   },
                   value: {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     start: 5,
                     end: 21,
                     range: [5, 21],
@@ -1913,6 +1931,7 @@ describe('Expressions - Async arrow', () => {
               expressions: [
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   start: 0,
                   end: 17,
                   range: [0, 17],
@@ -1944,6 +1963,7 @@ describe('Expressions - Async arrow', () => {
                 },
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   start: 19,
                   end: 30,
                   range: [19, 30],
@@ -1996,6 +2016,7 @@ describe('Expressions - Async arrow', () => {
             range: [0, 26],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 1,
               end: 24,
               range: [1, 24],
@@ -2077,6 +2098,7 @@ describe('Expressions - Async arrow', () => {
             range: [0, 27],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 27,
               range: [0, 27],
@@ -2198,6 +2220,7 @@ describe('Expressions - Async arrow', () => {
             range: [0, 23],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 1,
               end: 22,
               range: [1, 22],
@@ -2329,6 +2352,7 @@ describe('Expressions - Async arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Literal',
                 value: 1
@@ -2385,6 +2409,7 @@ describe('Expressions - Async arrow', () => {
                   operator: '=',
                   right: {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     body: {
                       type: 'Identifier',
                       name: 'x'
@@ -2410,6 +2435,7 @@ describe('Expressions - Async arrow', () => {
                   operator: '=',
                   right: {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     body: {
                       type: 'BlockStatement',
                       body: []
@@ -2445,6 +2471,7 @@ describe('Expressions - Async arrow', () => {
               type: 'CallExpression',
               callee: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'BlockStatement',
                   body: []
@@ -2587,8 +2614,10 @@ describe('Expressions - Async arrow', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'Identifier',
                   name: 'c'
@@ -2648,6 +2677,7 @@ describe('Expressions - Async arrow', () => {
               arguments: [
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   start: 2,
                   end: 13,
                   range: [2, 13],
@@ -2685,6 +2715,7 @@ describe('Expressions - Async arrow', () => {
             range: [0, 27],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 27,
               range: [0, 27],
@@ -2701,6 +2732,7 @@ describe('Expressions - Async arrow', () => {
               ],
               body: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 start: 5,
                 end: 27,
                 range: [5, 27],
@@ -2717,6 +2749,7 @@ describe('Expressions - Async arrow', () => {
                 ],
                 body: {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   start: 10,
                   end: 27,
                   range: [10, 27],
@@ -2733,6 +2766,7 @@ describe('Expressions - Async arrow', () => {
                   ],
                   body: {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     start: 15,
                     end: 27,
                     range: [15, 27],
@@ -2799,6 +2833,7 @@ describe('Expressions - Async arrow', () => {
                 },
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   start: 5,
                   end: 33,
                   range: [5, 33],

--- a/test/parser/expressions/async.ts
+++ b/test/parser/expressions/async.ts
@@ -356,6 +356,7 @@ describe('Expressions - Async', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'AssignmentExpression',
                 left: {
@@ -441,6 +442,7 @@ describe('Expressions - Async', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'AssignmentExpression',
                 left: {
@@ -556,7 +558,8 @@ describe('Expressions - Async', () => {
                         },
                         expression: false,
                         params: [],
-                        type: 'ArrowFunctionExpression'
+                        type: 'ArrowFunctionExpression',
+                        generator: false
                       }
                     },
                     {
@@ -582,7 +585,8 @@ describe('Expressions - Async', () => {
                             type: 'Identifier'
                           }
                         ],
-                        type: 'ArrowFunctionExpression'
+                        type: 'ArrowFunctionExpression',
+                        generator: false
                       }
                     },
                     {
@@ -608,7 +612,8 @@ describe('Expressions - Async', () => {
                             type: 'Identifier'
                           }
                         ],
-                        type: 'ArrowFunctionExpression'
+                        type: 'ArrowFunctionExpression',
+                        generator: false
                       }
                     }
                   ],
@@ -647,7 +652,8 @@ describe('Expressions - Async', () => {
                         },
                         expression: false,
                         params: [],
-                        type: 'ArrowFunctionExpression'
+                        type: 'ArrowFunctionExpression',
+                        generator: false
                       }
                     },
                     {
@@ -673,7 +679,8 @@ describe('Expressions - Async', () => {
                             type: 'Identifier'
                           }
                         ],
-                        type: 'ArrowFunctionExpression'
+                        type: 'ArrowFunctionExpression',
+                        generator: false
                       }
                     }
                   ],
@@ -727,7 +734,8 @@ describe('Expressions - Async', () => {
                         },
                         expression: false,
                         params: [],
-                        type: 'ArrowFunctionExpression'
+                        type: 'ArrowFunctionExpression',
+                        generator: false
                       }
                     },
                     {
@@ -753,7 +761,8 @@ describe('Expressions - Async', () => {
                             type: 'Identifier'
                           }
                         ],
-                        type: 'ArrowFunctionExpression'
+                        type: 'ArrowFunctionExpression',
+                        generator: false
                       }
                     }
                   ],
@@ -920,8 +929,7 @@ describe('Expressions - Async', () => {
                   type: 'Identifier'
                 }
               ],
-              type: 'ArrowFunctionExpression'
-            },
+              type: 'ArrowFunctionExpression',generator: false,            },
             type: 'ExpressionStatement'
           }
         ],
@@ -1156,7 +1164,8 @@ describe('Expressions - Async', () => {
                         type: 'Identifier'
                       }
                     ],
-                    type: 'ArrowFunctionExpression'
+                    type: 'ArrowFunctionExpression',
+                    generator: false
                   },
                   type: 'ExpressionStatement'
                 }
@@ -1219,7 +1228,8 @@ describe('Expressions - Async', () => {
                       type: 'Identifier'
                     }
                   ],
-                  type: 'ArrowFunctionExpression'
+                  type: 'ArrowFunctionExpression',
+                  generator: false
                 },
                 type: 'VariableDeclarator'
               }
@@ -1273,6 +1283,7 @@ describe('Expressions - Async', () => {
                       type: 'VariableDeclarator',
                       init: {
                         type: 'ArrowFunctionExpression',
+                        generator: false,
                         body: {
                           type: 'BlockStatement',
                           body: []
@@ -1668,6 +1679,7 @@ describe('Expressions - Async', () => {
               arguments: [
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'Identifier',
                     name: 'c'
@@ -1701,6 +1713,7 @@ describe('Expressions - Async', () => {
               arguments: [
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'Identifier',
                     name: 'c'
@@ -1828,6 +1841,7 @@ describe('Expressions - Async', () => {
               arguments: [
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'Identifier',
                     name: 'x'
@@ -1990,6 +2004,7 @@ describe('Expressions - Async', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'bar'
@@ -2593,6 +2608,7 @@ describe('Expressions - Async', () => {
               arguments: [
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
 
                   params: [],
                   body: {
@@ -2620,6 +2636,7 @@ describe('Expressions - Async', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'a'
@@ -2802,6 +2819,7 @@ describe('Expressions - Async', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -2826,6 +2844,7 @@ describe('Expressions - Async', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -3034,6 +3053,7 @@ describe('Expressions - Async', () => {
                   operator: '=',
                   right: {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     body: {
                       type: 'Identifier',
                       name: 'x'
@@ -3105,6 +3125,7 @@ describe('Expressions - Async', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []

--- a/test/parser/expressions/await.ts
+++ b/test/parser/expressions/await.ts
@@ -2000,6 +2000,7 @@ describe('Expressions - Await', () => {
               operator: '=',
               right: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'AwaitExpression',
                   argument: {
@@ -2430,6 +2431,7 @@ describe('Expressions - Await', () => {
               operator: '=',
               right: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'Identifier',
                   name: 'x'
@@ -2579,6 +2581,7 @@ describe('Expressions - Await', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -2726,6 +2729,7 @@ describe('Expressions - Await', () => {
                   type: 'ExpressionStatement',
                   expression: {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     body: {
                       type: 'Identifier',
                       name: 'x'
@@ -2955,6 +2959,7 @@ describe('Expressions - Await', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'

--- a/test/parser/expressions/call.ts
+++ b/test/parser/expressions/call.ts
@@ -421,7 +421,8 @@ describe('Expressions - Call', () => {
                   type: 'Identifier'
                 }
               ],
-              type: 'ArrowFunctionExpression'
+              type: 'ArrowFunctionExpression',
+              generator: false
             },
             type: 'ExpressionStatement'
           }
@@ -1771,6 +1772,7 @@ describe('Expressions - Call', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []

--- a/test/parser/expressions/class.ts
+++ b/test/parser/expressions/class.ts
@@ -2591,6 +2591,7 @@ describe('Expressions - Class', () => {
               operator: '=',
               right: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'BlockStatement',
                   body: []
@@ -3180,6 +3181,7 @@ describe('Expressions - Class', () => {
               operator: '=',
               right: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'BlockStatement',
                   body: []
@@ -3233,6 +3235,7 @@ describe('Expressions - Class', () => {
               operator: '=',
               right: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'BlockStatement',
                   body: []
@@ -3710,6 +3713,7 @@ describe('Expressions - Class', () => {
               operator: '=',
               right: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'BlockStatement',
                   body: []
@@ -3785,6 +3789,7 @@ describe('Expressions - Class', () => {
               operator: '=',
               right: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'BlockStatement',
                   body: []

--- a/test/parser/expressions/conditional.ts
+++ b/test/parser/expressions/conditional.ts
@@ -458,6 +458,7 @@ describe('Expressions - Conditional', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'ConditionalExpression',
                 test: {

--- a/test/parser/expressions/function.ts
+++ b/test/parser/expressions/function.ts
@@ -505,6 +505,7 @@ describe('Expressions - Functions', () => {
                             arguments: [
                               {
                                 type: 'ArrowFunctionExpression',
+                                generator: false,
                                 body: {
                                   type: 'Literal',
                                   value: 123
@@ -4918,6 +4919,7 @@ describe('Expressions - Functions', () => {
               operator: '=',
               right: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'BlockStatement',
                   body: []
@@ -5800,6 +5802,7 @@ describe('Expressions - Functions', () => {
                     type: 'CallExpression',
                     callee: {
                       type: 'ArrowFunctionExpression',
+                      generator: false,
                       body: {
                         type: 'ObjectExpression',
                         properties: [
@@ -6890,6 +6893,7 @@ describe('Expressions - Functions', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -6942,6 +6946,7 @@ describe('Expressions - Functions', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -6996,6 +7001,7 @@ describe('Expressions - Functions', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -7089,6 +7095,7 @@ describe('Expressions - Functions', () => {
                       },
                       {
                         type: 'ArrowFunctionExpression',
+                        generator: false,
                         body: {
                           type: 'CallExpression',
                           callee: {

--- a/test/parser/expressions/group.ts
+++ b/test/parser/expressions/group.ts
@@ -728,6 +728,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'z'
@@ -2149,6 +2150,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'foo'
@@ -2481,6 +2483,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'z'
@@ -2733,6 +2736,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -2829,6 +2833,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -2866,6 +2871,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -2913,6 +2919,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -2944,6 +2951,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -2980,6 +2988,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -3027,6 +3036,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'b'
@@ -3060,6 +3070,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'c'
@@ -3100,6 +3111,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'e'
@@ -3464,6 +3476,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -3554,6 +3567,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -3609,6 +3623,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'foo'
@@ -3783,6 +3798,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'foo'
@@ -3811,6 +3827,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'y'
@@ -3915,6 +3932,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -3975,6 +3993,7 @@ describe('Expressions - Group', () => {
               operator: 'delete',
               argument: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'Identifier',
                   name: 'foo'
@@ -4160,6 +4179,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'baz'
@@ -4284,6 +4304,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -4376,6 +4397,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'z'
@@ -4599,6 +4621,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -4660,6 +4683,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'z'
@@ -4719,6 +4743,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'z'
@@ -5172,6 +5197,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -5223,6 +5249,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -5263,6 +5290,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -5307,6 +5335,7 @@ describe('Expressions - Group', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -6387,6 +6416,7 @@ describe('Expressions - Group', () => {
                       type: 'MemberExpression',
                       object: {
                         type: 'ArrowFunctionExpression',
+                        generator: false,
                         body: {
                           type: 'Identifier',
                           name: 'z'
@@ -6453,6 +6483,7 @@ describe('Expressions - Group', () => {
                     type: 'MemberExpression',
                     object: {
                       type: 'ArrowFunctionExpression',
+                      generator: false,
                       body: {
                         type: 'Identifier',
                         name: 'x'

--- a/test/parser/expressions/import_call.ts
+++ b/test/parser/expressions/import_call.ts
@@ -282,7 +282,8 @@ describe('Next - ImportCall', () => {
                             },
                             expression: false,
                             params: [],
-                            type: 'ArrowFunctionExpression'
+                            type: 'ArrowFunctionExpression',
+                            generator: false
                           }
                         ],
                         callee: {

--- a/test/parser/expressions/new-target.ts
+++ b/test/parser/expressions/new-target.ts
@@ -402,6 +402,7 @@ describe('Expressions - New target', () => {
                   range: [14, 36],
                   argument: {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     start: 21,
                     end: 36,
                     range: [21, 36],
@@ -482,6 +483,7 @@ describe('Expressions - New target', () => {
                   range: [14, 34],
                   expression: {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     start: 14,
                     end: 34,
                     range: [14, 34],
@@ -498,6 +500,7 @@ describe('Expressions - New target', () => {
                     ],
                     body: {
                       type: 'ArrowFunctionExpression',
+                      generator: false,
                       start: 19,
                       end: 34,
                       range: [19, 34],
@@ -553,6 +556,7 @@ describe('Expressions - New target', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'FunctionExpression',
                 params: [],

--- a/test/parser/expressions/object.ts
+++ b/test/parser/expressions/object.ts
@@ -3165,6 +3165,7 @@ describe('Expressions - Object', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'z'
@@ -3508,6 +3509,7 @@ describe('Expressions - Object', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -5667,6 +5669,7 @@ describe('Expressions - Object', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -6050,6 +6053,7 @@ describe('Expressions - Object', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -6102,6 +6106,7 @@ describe('Expressions - Object', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -6498,6 +6503,7 @@ describe('Expressions - Object', () => {
               operator: '=',
               right: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'BinaryExpression',
                   left: {
@@ -7933,6 +7939,7 @@ describe('Expressions - Object', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -18477,6 +18484,7 @@ describe('Expressions - Object', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'a'
@@ -18531,6 +18539,7 @@ describe('Expressions - Object', () => {
               type: 'CallExpression',
               callee: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'Identifier',
                   name: 'a'
@@ -18647,6 +18656,7 @@ describe('Expressions - Object', () => {
               type: 'CallExpression',
               callee: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'Identifier',
                   name: 'a'
@@ -20457,6 +20467,7 @@ describe('Expressions - Object', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Literal',
                 value: null
@@ -21048,6 +21059,7 @@ describe('Expressions - Object', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -23781,6 +23793,7 @@ describe('Expressions - Object', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -24099,6 +24112,7 @@ describe('Expressions - Object', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'y'
@@ -24380,6 +24394,7 @@ describe('Expressions - Object', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -24432,6 +24447,7 @@ describe('Expressions - Object', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -24484,6 +24500,7 @@ describe('Expressions - Object', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -25741,6 +25758,7 @@ describe('Expressions - Object', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -26345,6 +26363,7 @@ describe('Expressions - Object', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'

--- a/test/parser/expressions/super.ts
+++ b/test/parser/expressions/super.ts
@@ -1667,6 +1667,7 @@ describe('Expressions - Super', () => {
                           type: 'ReturnStatement',
                           argument: {
                             type: 'ArrowFunctionExpression',
+                            generator: false,
                             body: {
                               type: 'CallExpression',
                               callee: {
@@ -1733,6 +1734,7 @@ describe('Expressions - Super', () => {
                           type: 'ReturnStatement',
                           argument: {
                             type: 'ArrowFunctionExpression',
+                            generator: false,
                             body: {
                               type: 'Identifier',
                               name: 'a'
@@ -1811,8 +1813,10 @@ describe('Expressions - Super', () => {
                           type: 'ReturnStatement',
                           argument: {
                             type: 'ArrowFunctionExpression',
+                            generator: false,
                             body: {
                               type: 'ArrowFunctionExpression',
+                              generator: false,
                               body: {
                                 type: 'CallExpression',
                                 callee: {
@@ -1882,6 +1886,7 @@ describe('Expressions - Super', () => {
                           type: 'ReturnStatement',
                           argument: {
                             type: 'ArrowFunctionExpression',
+                            generator: false,
                             body: {
                               type: 'MemberExpression',
                               object: {
@@ -1951,6 +1956,7 @@ describe('Expressions - Super', () => {
                           type: 'ReturnStatement',
                           argument: {
                             type: 'ArrowFunctionExpression',
+                            generator: false,
                             body: {
                               type: 'MemberExpression',
                               object: {
@@ -2018,6 +2024,7 @@ describe('Expressions - Super', () => {
                           type: 'ReturnStatement',
                           argument: {
                             type: 'ArrowFunctionExpression',
+                            generator: false,
                             body: {
                               type: 'MemberExpression',
                               object: {
@@ -2087,6 +2094,7 @@ describe('Expressions - Super', () => {
                           type: 'ReturnStatement',
                           argument: {
                             type: 'ArrowFunctionExpression',
+                            generator: false,
                             body: {
                               type: 'Identifier',
                               name: 'a'
@@ -2199,6 +2207,7 @@ describe('Expressions - Super', () => {
                           range: [35, 61],
                           argument: {
                             type: 'ArrowFunctionExpression',
+                            generator: false,
                             start: 42,
                             end: 60,
                             range: [42, 60],
@@ -2330,6 +2339,7 @@ describe('Expressions - Super', () => {
                           range: [35, 64],
                           argument: {
                             type: 'ArrowFunctionExpression',
+                            generator: false,
                             start: 42,
                             end: 63,
                             range: [42, 63],
@@ -2338,6 +2348,7 @@ describe('Expressions - Super', () => {
                             params: [],
                             body: {
                               type: 'ArrowFunctionExpression',
+                              generator: false,
                               start: 48,
                               end: 63,
                               range: [48, 63],
@@ -2414,8 +2425,10 @@ describe('Expressions - Super', () => {
                           type: 'ReturnStatement',
                           argument: {
                             type: 'ArrowFunctionExpression',
+                            generator: false,
                             body: {
                               type: 'ArrowFunctionExpression',
+                              generator: false,
                               body: {
                                 type: 'MemberExpression',
                                 object: {
@@ -2486,6 +2499,7 @@ describe('Expressions - Super', () => {
                           type: 'ReturnStatement',
                           argument: {
                             type: 'ArrowFunctionExpression',
+                            generator: false,
                             body: {
                               type: 'MemberExpression',
                               object: {
@@ -2555,6 +2569,7 @@ describe('Expressions - Super', () => {
                           type: 'ReturnStatement',
                           argument: {
                             type: 'ArrowFunctionExpression',
+                            generator: false,
                             body: {
                               type: 'Identifier',
                               name: 'a'
@@ -2632,6 +2647,7 @@ describe('Expressions - Super', () => {
                           type: 'ReturnStatement',
                           argument: {
                             type: 'ArrowFunctionExpression',
+                            generator: false,
                             body: {
                               type: 'Identifier',
                               name: 'a'
@@ -2712,8 +2728,10 @@ describe('Expressions - Super', () => {
                           type: 'ReturnStatement',
                           argument: {
                             type: 'ArrowFunctionExpression',
+                            generator: false,
                             body: {
                               type: 'ArrowFunctionExpression',
+                              generator: false,
                               body: {
                                 type: 'MemberExpression',
                                 object: {
@@ -2783,6 +2801,7 @@ describe('Expressions - Super', () => {
                             type: 'ReturnStatement',
                             argument: {
                               type: 'ArrowFunctionExpression',
+                              generator: false,
                               body: {
                                 type: 'MemberExpression',
                                 object: {
@@ -2853,6 +2872,7 @@ describe('Expressions - Super', () => {
                             type: 'ReturnStatement',
                             argument: {
                               type: 'ArrowFunctionExpression',
+                              generator: false,
                               body: {
                                 type: 'Identifier',
                                 name: 'a'
@@ -2934,8 +2954,10 @@ describe('Expressions - Super', () => {
                             type: 'ReturnStatement',
                             argument: {
                               type: 'ArrowFunctionExpression',
+                              generator: false,
                               body: {
                                 type: 'ArrowFunctionExpression',
+                                generator: false,
                                 body: {
                                   type: 'MemberExpression',
                                   object: {
@@ -3815,7 +3837,8 @@ describe('Expressions - Super', () => {
                     params: [],
                     range: [24, 39],
                     start: 24,
-                    type: 'ArrowFunctionExpression'
+                    type: 'ArrowFunctionExpression',
+                    generator: false
                   }
                 }
               ],
@@ -3923,7 +3946,8 @@ describe('Expressions - Super', () => {
                     params: [],
                     range: [24, 44],
                     start: 24,
-                    type: 'ArrowFunctionExpression'
+                    type: 'ArrowFunctionExpression',
+                    generator: false
                   }
                 }
               ],
@@ -4023,7 +4047,8 @@ describe('Expressions - Super', () => {
                     params: [],
                     range: [24, 51],
                     start: 24,
-                    type: 'ArrowFunctionExpression'
+                    type: 'ArrowFunctionExpression',
+                    generator: false
                   }
                 }
               ],
@@ -4137,7 +4162,8 @@ describe('Expressions - Super', () => {
                     params: [],
                     range: [24, 56],
                     start: 24,
-                    type: 'ArrowFunctionExpression'
+                    type: 'ArrowFunctionExpression',
+                    generator: false
                   }
                 }
               ],

--- a/test/parser/expressions/template.ts
+++ b/test/parser/expressions/template.ts
@@ -2976,6 +2976,7 @@ describe('Expressions - Template', () => {
               expressions: [
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'BlockStatement',
                     body: []
@@ -3023,6 +3024,7 @@ describe('Expressions - Template', () => {
               expressions: [
                 {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'BlockStatement',
                     body: [
@@ -4356,7 +4358,8 @@ describe('Expressions - Template', () => {
                   },
                   expression: false,
                   params: [],
-                  type: 'ArrowFunctionExpression'
+                  type: 'ArrowFunctionExpression',
+                  generator: false
                 },
                 type: 'AssignmentExpression'
               },

--- a/test/parser/expressions/unary.ts
+++ b/test/parser/expressions/unary.ts
@@ -652,6 +652,7 @@ describe('Expressions - Unary', () => {
               prefix: true,
               argument: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 start: 8,
                 end: 14,
                 range: [8, 14],
@@ -703,6 +704,7 @@ describe('Expressions - Unary', () => {
               prefix: true,
               argument: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 start: 8,
                 end: 22,
                 range: [8, 22],
@@ -769,6 +771,7 @@ describe('Expressions - Unary', () => {
                 type: 'MemberExpression',
                 object: {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'Identifier',
                     name: 'b'
@@ -809,6 +812,7 @@ describe('Expressions - Unary', () => {
               operator: 'delete',
               argument: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'Identifier',
                   name: 'b'
@@ -937,6 +941,7 @@ describe('Expressions - Unary', () => {
               operator: 'delete',
               argument: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'Identifier',
                   name: 'b'
@@ -972,6 +977,7 @@ describe('Expressions - Unary', () => {
               operator: 'delete',
               argument: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'Identifier',
                   name: 'b'
@@ -1020,6 +1026,7 @@ describe('Expressions - Unary', () => {
               operator: 'delete',
               argument: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'Identifier',
                   name: 'b'
@@ -1374,7 +1381,8 @@ describe('Expressions - Unary', () => {
                 expression: true,
 
                 params: [],
-                type: 'ArrowFunctionExpression'
+                type: 'ArrowFunctionExpression',
+                generator: false
               },
               operator: 'delete',
               prefix: true,
@@ -1500,6 +1508,7 @@ describe('Expressions - Unary', () => {
               operator: 'delete',
               argument: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'Identifier',
                   name: 'b'
@@ -1535,6 +1544,7 @@ describe('Expressions - Unary', () => {
               operator: 'delete',
               argument: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'Identifier',
                   name: 'b'
@@ -1583,6 +1593,7 @@ describe('Expressions - Unary', () => {
               operator: 'delete',
               argument: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'Identifier',
                   name: 'b'
@@ -1937,7 +1948,8 @@ describe('Expressions - Unary', () => {
                 expression: true,
 
                 params: [],
-                type: 'ArrowFunctionExpression'
+                type: 'ArrowFunctionExpression',
+                generator: false
               },
               operator: 'delete',
               prefix: true,
@@ -2350,6 +2362,7 @@ describe('Expressions - Unary', () => {
             range: [0, 44],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 44,
               range: [0, 44],
@@ -2578,6 +2591,7 @@ describe('Expressions - Unary', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'UnaryExpression',
                 operator: 'delete',
@@ -2858,6 +2872,7 @@ describe('Expressions - Unary', () => {
                 type: 'VariableDeclarator',
                 init: {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'UpdateExpression',
                     argument: {
@@ -3059,7 +3074,8 @@ describe('Expressions - Unary', () => {
                   expression: true,
 
                   params: [],
-                  type: 'ArrowFunctionExpression'
+                  type: 'ArrowFunctionExpression',
+                  generator: false
                 },
                 type: 'VariableDeclarator'
               }

--- a/test/parser/expressions/yield.ts
+++ b/test/parser/expressions/yield.ts
@@ -2554,6 +2554,7 @@ yield d;
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -4192,6 +4193,7 @@ yield d;
                   type: 'ReturnStatement',
                   argument: {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     body: {
                       type: 'Identifier',
                       name: 'x'
@@ -4495,6 +4497,7 @@ yield d;
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -4538,6 +4541,7 @@ yield d;
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -4633,6 +4637,7 @@ yield d;
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -5132,6 +5137,7 @@ yield d;
                 type: 'ExpressionStatement',
                 expression: {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'Identifier',
                     name: 'z'
@@ -5212,6 +5218,7 @@ yield d;
                 type: 'ExpressionStatement',
                 expression: {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'Identifier',
                     name: 'z'
@@ -5314,6 +5321,7 @@ yield d;
                 type: 'ExpressionStatement',
                 expression: {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'Identifier',
                     name: 'x'
@@ -5430,6 +5438,7 @@ yield d;
                 type: 'ExpressionStatement',
                 expression: {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'BlockStatement',
                     body: []
@@ -5470,6 +5479,7 @@ yield d;
                 type: 'ExpressionStatement',
                 expression: {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'BlockStatement',
                     body: []
@@ -5915,6 +5925,7 @@ yield d;
                   type: 'ExpressionStatement',
                   expression: {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     body: {
                       type: 'Identifier',
                       name: 'x'
@@ -6338,6 +6349,7 @@ yield d;
                   type: 'ExpressionStatement',
                   expression: {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     body: {
                       type: 'BinaryExpression',
                       left: {
@@ -7748,6 +7760,7 @@ yield d;
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Identifier',
                 name: 'x'
@@ -8037,6 +8050,7 @@ yield d;
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -8132,6 +8146,7 @@ yield d;
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -8167,6 +8182,7 @@ yield d;
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -8360,6 +8376,7 @@ yield d;
               type: 'ExpressionStatement',
               expression: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'BlockStatement',
                   body: []
@@ -8389,6 +8406,7 @@ yield d;
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -8418,6 +8436,7 @@ yield d;
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'ConditionalExpression',
                 test: {
@@ -8487,6 +8506,7 @@ yield d;
                   type: 'ExpressionStatement',
                   expression: {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     body: {
                       type: 'BlockStatement',
                       body: []
@@ -10087,6 +10107,7 @@ yield d;
                   type: 'ExpressionStatement',
                   expression: {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     body: {
                       type: 'Identifier',
                       name: 'yield'
@@ -10100,6 +10121,7 @@ yield d;
                   type: 'ExpressionStatement',
                   expression: {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     body: {
                       type: 'BlockStatement',
                       body: [
@@ -10147,6 +10169,7 @@ yield d;
                   type: 'ExpressionStatement',
                   expression: {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     body: {
                       type: 'Identifier',
                       name: 'yield'
@@ -10762,6 +10785,7 @@ yield d;
                   type: 'ExpressionStatement',
                   expression: {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     body: {
                       type: 'BlockStatement',
                       body: []

--- a/test/parser/miscellaneous/asi.ts
+++ b/test/parser/miscellaneous/asi.ts
@@ -482,7 +482,8 @@ describe('Miscellaneous - ASI', () => {
               },
               expression: false,
               params: [],
-              type: 'ArrowFunctionExpression'
+              type: 'ArrowFunctionExpression',
+              generator: false
             },
             type: 'ExpressionStatement'
           }

--- a/test/parser/miscellaneous/jsx.ts
+++ b/test/parser/miscellaneous/jsx.ts
@@ -2522,6 +2522,7 @@ describe('Miscellaneous - JSX', () => {
                 type: 'VariableDeclarator',
                 init: {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'JSXElement',
                     children: [
@@ -3536,6 +3537,7 @@ describe('Miscellaneous - JSX', () => {
                     arguments: [
                       {
                         type: 'ArrowFunctionExpression',
+                        generator: false,
                         body: {
                           type: 'JSXElement',
                           children: [
@@ -5740,6 +5742,7 @@ describe('Miscellaneous - JSX', () => {
                         arguments: [
                           {
                             type: 'ArrowFunctionExpression',
+                            generator: false,
                             body: {
                               type: 'JSXElement',
                               children: [],
@@ -6563,6 +6566,7 @@ describe('Miscellaneous - JSX', () => {
                   type: 'JSXExpressionContainer',
                   expression: {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     body: {
                       type: 'JSXElement',
                       children: [],
@@ -7702,6 +7706,7 @@ describe('Miscellaneous - JSX', () => {
                       type: 'JSXExpressionContainer',
                       expression: {
                         type: 'ArrowFunctionExpression',
+                        generator: false,
                         body: {
                           type: 'ThisExpression'
                         },
@@ -7929,6 +7934,7 @@ describe('Miscellaneous - JSX', () => {
                           range: [23, 35],
                           expression: {
                             type: 'ArrowFunctionExpression',
+                            generator: false,
                             start: 24,
                             end: 34,
                             range: [24, 34],
@@ -8295,6 +8301,7 @@ describe('Miscellaneous - JSX', () => {
                 type: 'VariableDeclarator',
                 init: {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'JSXElement',
                     children: [],
@@ -8698,6 +8705,7 @@ describe('Miscellaneous - JSX', () => {
                               },
                               value: {
                                 type: 'ArrowFunctionExpression',
+                                generator: false,
                                 body: {
                                   type: 'BlockStatement',
                                   body: [
@@ -9574,6 +9582,7 @@ describe('Miscellaneous - JSX', () => {
                   type: 'JSXExpressionContainer',
                   expression: {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     body: {
                       type: 'JSXElement',
                       children: [],

--- a/test/parser/miscellaneous/private_methods.ts
+++ b/test/parser/miscellaneous/private_methods.ts
@@ -2825,6 +2825,7 @@ describe('Next - Private methods', () => {
                   },
                   value: {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     body: {
                       type: 'Literal',
                       value: 'bar'

--- a/test/parser/miscellaneous/public-fields.ts
+++ b/test/parser/miscellaneous/public-fields.ts
@@ -420,6 +420,7 @@ describe('Next - Public fields', () => {
                 type: 'VariableDeclarator',
                 init: {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'ClassExpression',
                     decorators: [],
@@ -855,6 +856,7 @@ describe('Next - Public fields', () => {
                   },
                   value: {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     body: {
                       type: 'BlockStatement',
                       body: [
@@ -1046,6 +1048,7 @@ describe('Next - Public fields', () => {
                       },
                       value: {
                         type: 'ArrowFunctionExpression',
+                        generator: false,
                         body: {
                           type: 'BlockStatement',
                           body: [
@@ -1297,7 +1300,8 @@ describe('Next - Public fields', () => {
                         type: 'Identifier'
                       }
                     ],
-                    type: 'ArrowFunctionExpression'
+                    type: 'ArrowFunctionExpression',
+                    generator: false
                   }
                 }
               ],

--- a/test/parser/miscellaneous/ranges.ts
+++ b/test/parser/miscellaneous/ranges.ts
@@ -23,6 +23,7 @@ describe('Miscellaneous - ranges', () => {
                 type: 'VariableDeclarator',
                 init: {
                   type: 'ArrowFunctionExpression',
+                  generator: false,
                   body: {
                     type: 'BlockStatement',
                     body: [
@@ -1083,6 +1084,7 @@ describe('Miscellaneous - ranges', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'Literal',
                 value: 0,
@@ -1371,6 +1373,7 @@ describe('Miscellaneous - ranges', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'ArrayExpression',
                 elements: [
@@ -1529,6 +1532,7 @@ describe('Miscellaneous - ranges', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: [],
@@ -1605,6 +1609,7 @@ describe('Miscellaneous - ranges', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: [],
@@ -1638,6 +1643,7 @@ describe('Miscellaneous - ranges', () => {
                           },
                           right: {
                             type: 'ArrowFunctionExpression',
+                            generator: false,
                             body: {
                               type: 'Identifier',
                               name: 'a',
@@ -1963,6 +1969,7 @@ describe('Miscellaneous - ranges', () => {
               operator: '=',
               right: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'BlockStatement',
                   body: [
@@ -2167,6 +2174,7 @@ describe('Miscellaneous - ranges', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: [
@@ -4843,6 +4851,7 @@ describe('Miscellaneous - ranges', () => {
                     operator: '=',
                     right: {
                       type: 'ArrowFunctionExpression',
+                      generator: false,
                       body: {
                         type: 'CallExpression',
                         callee: {
@@ -4954,6 +4963,7 @@ describe('Miscellaneous - ranges', () => {
                     operator: '=',
                     right: {
                       type: 'ArrowFunctionExpression',
+                      generator: false,
                       body: {
                         type: 'CallExpression',
                         callee: {
@@ -5031,6 +5041,7 @@ describe('Miscellaneous - ranges', () => {
               operator: '=',
               right: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'BlockStatement',
                   body: [
@@ -6955,6 +6966,7 @@ describe('Miscellaneous - ranges', () => {
             },
             init: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: [],
@@ -7158,6 +7170,7 @@ describe('Miscellaneous - ranges', () => {
               type: 'MemberExpression',
               object: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'BlockStatement',
                   body: [],
@@ -11121,6 +11134,7 @@ describe('Miscellaneous - ranges', () => {
             range: [0, 25],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 24,
               range: [0, 24],
@@ -11283,6 +11297,7 @@ describe('Miscellaneous - ranges', () => {
             range: [0, 34],
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 0,
               end: 34,
               range: [0, 34],
@@ -11527,6 +11542,7 @@ describe('Miscellaneous - ranges', () => {
               },
               right: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 start: 4,
                 end: 28,
                 range: [4, 28],
@@ -11613,6 +11629,7 @@ describe('Miscellaneous - ranges', () => {
               },
               right: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 start: 4,
                 end: 83,
                 range: [4, 83],

--- a/test/parser/module/export.ts
+++ b/test/parser/module/export.ts
@@ -2358,6 +2358,7 @@ describe('Module - Export', () => {
             range: [0, 28],
             declaration: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 15,
               end: 28,
               range: [15, 28],
@@ -2393,6 +2394,7 @@ describe('Module - Export', () => {
             range: [0, 29],
             declaration: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 15,
               end: 29,
               range: [15, 29],
@@ -2567,6 +2569,7 @@ describe('Module - Export', () => {
             range: [0, 27],
             declaration: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 15,
               end: 27,
               range: [15, 27],
@@ -2610,6 +2613,7 @@ describe('Module - Export', () => {
             range: [0, 26],
             declaration: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               start: 15,
               end: 26,
               range: [15, 26],
@@ -2655,6 +2659,7 @@ describe('Module - Export', () => {
             type: 'ExportDefaultDeclaration',
             declaration: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: []
@@ -3273,6 +3278,7 @@ describe('Module - Export', () => {
               },
               right: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 start: 56,
                 end: 65,
                 range: [56, 65],

--- a/test/parser/next/decorators.ts
+++ b/test/parser/next/decorators.ts
@@ -1424,6 +1424,7 @@ describe('Next - Decorators', () => {
                       type: 'Decorator',
                       expression: {
                         type: 'ArrowFunctionExpression',
+                        generator: false,
                         body: {
                           type: 'BlockStatement',
                           body: [
@@ -1894,6 +1895,7 @@ describe('Next - Decorators', () => {
                       type: 'Decorator',
                       expression: {
                         type: 'ArrowFunctionExpression',
+                        generator: false,
                         body: {
                           type: 'BlockStatement',
                           body: [
@@ -1991,6 +1993,7 @@ describe('Next - Decorators', () => {
                   type: 'ReturnStatement',
                   argument: {
                     type: 'ArrowFunctionExpression',
+                    generator: false,
                     body: {
                       type: 'BlockStatement',
                       body: [
@@ -2267,6 +2270,7 @@ describe('Next - Decorators', () => {
                       type: 'Decorator',
                       expression: {
                         type: 'ArrowFunctionExpression',
+                        generator: false,
                         body: {
                           type: 'AssignmentExpression',
                           left: {

--- a/test/parser/next/import-meta.ts
+++ b/test/parser/next/import-meta.ts
@@ -750,6 +750,7 @@ describe('Next - Import Meta', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: [

--- a/test/parser/statements/continue.ts
+++ b/test/parser/statements/continue.ts
@@ -371,6 +371,7 @@ describe('Statements - Continue', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: [

--- a/test/parser/statements/do-while.ts
+++ b/test/parser/statements/do-while.ts
@@ -236,6 +236,7 @@ describe('Statements - Do while', () => {
               type: 'IfStatement',
               test: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'BlockStatement',
                   body: [],
@@ -313,6 +314,7 @@ describe('Statements - Do while', () => {
               type: 'IfStatement',
               test: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'BlockStatement',
                   body: [],
@@ -617,6 +619,7 @@ while(y)
               type: 'ExpressionStatement',
               expression: {
                 type: 'ArrowFunctionExpression',
+                generator: false,
                 body: {
                   type: 'Identifier',
                   name: 'x',

--- a/test/parser/statements/for-of.ts
+++ b/test/parser/statements/for-of.ts
@@ -867,6 +867,7 @@ describe('Statements - For of', () => {
                         },
                         value: {
                           type: 'ArrowFunctionExpression',
+                          generator: false,
                           body: {
                             type: 'BlockStatement',
                             body: []
@@ -918,8 +919,10 @@ describe('Statements - For of', () => {
                         type: 'LogicalExpression',
                         left: {
                           type: 'ArrowFunctionExpression',
+                          generator: false,
                           body: {
                             type: 'ArrowFunctionExpression',
+                            generator: false,
                             body: {
                               type: 'Literal',
                               value: 2646

--- a/test/parser/statements/for.ts
+++ b/test/parser/statements/for.ts
@@ -832,6 +832,7 @@ describe('Statements - For', () => {
             },
             init: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: [
@@ -1046,6 +1047,7 @@ describe('Statements - For', () => {
             },
             init: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: [
@@ -1126,6 +1128,7 @@ describe('Statements - For', () => {
                     },
                     {
                       type: 'ArrowFunctionExpression',
+                      generator: false,
                       body: {
                         type: 'BlockStatement',
                         body: []

--- a/test/parser/statements/if.ts
+++ b/test/parser/statements/if.ts
@@ -276,6 +276,7 @@ describe('Statements - None', () => {
                         type: 'ReturnStatement',
                         argument: {
                           type: 'ArrowFunctionExpression',
+                          generator: false,
                           body: {
                             type: 'BlockStatement',
                             body: [

--- a/test/parser/statements/return.ts
+++ b/test/parser/statements/return.ts
@@ -92,6 +92,7 @@ describe('Statements - Return', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: [
@@ -126,6 +127,7 @@ describe('Statements - Return', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: [
@@ -439,6 +441,7 @@ describe('Statements - Return', () => {
             type: 'ExpressionStatement',
             expression: {
               type: 'ArrowFunctionExpression',
+              generator: false,
               body: {
                 type: 'BlockStatement',
                 body: [


### PR DESCRIPTION
Fixes #414