### PR TITLE
refactor: add `tokenStart` getter to `Parser`

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -492,25 +492,18 @@ export function validateAndDeclareLabel(parser: Parser, labels: any, name: strin
   labels['$' + name] = 1;
 }
 
-export function finishNode<T extends Node>(
-  parser: Parser,
-  context: Context,
-  start: number,
-  line: number,
-  column: number,
-  node: T,
-): T {
+export function finishNode<T extends Node>(parser: Parser, context: Context, start: Location, node: T): T {
   if (context & Context.OptionsRanges) {
-    node.start = start;
+    node.start = start.index;
     node.end = parser.startIndex;
-    node.range = [start, parser.startIndex];
+    node.range = [start.index, parser.startIndex];
   }
 
   if (context & Context.OptionsLoc) {
     node.loc = {
       start: {
-        line,
-        column,
+        line: start.line,
+        column: start.column,
       },
       end: {
         line: parser.startLine,
@@ -914,3 +907,9 @@ export function classifyIdentifier(parser: Parser, context: Context, t: Token): 
 
   if (!isValidIdentifier(context, t)) report(parser, Errors.Unexpected);
 }
+
+export type Location = {
+  index: number;
+  line: number;
+  column: number;
+};

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,5 @@
 import { type _Node, type SourceLocation } from './estree';
-import { type ScopeError } from './common';
+import { type ScopeError, type Location } from './common';
 import { type Parser } from './parser';
 
 export const enum Errors {
@@ -452,16 +452,23 @@ export function reportScopeError(scope: ScopeError): never {
  * @param {...string[]} params
  */
 export function reportMessageAt(
-  tokenIndex: number,
-  tokenLine: number,
-  tokenColumn: number,
+  tokenLocation: Location,
   index: number,
   line: number,
   column: number,
   type: Errors,
   ...params: string[]
 ): never {
-  throw new ParseError(tokenIndex, tokenLine, tokenColumn, index, line, column, type, ...params);
+  throw new ParseError(
+    tokenLocation.index,
+    tokenLocation.line,
+    tokenLocation.column,
+    index,
+    line,
+    column,
+    type,
+    ...params,
+  );
 }
 
 /**

--- a/src/estree.ts
+++ b/src/estree.ts
@@ -455,6 +455,7 @@ export interface ExportSpecifier extends _Node {
 export interface ExpressionStatement extends _Node {
   type: 'ExpressionStatement';
   expression: Expression;
+  directive?: string;
 }
 
 export interface ForInStatement extends _Node {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -386,10 +386,10 @@ export function parseStatementList(
 
   while (parser.getToken() === Token.StringLiteral) {
     // "use strict" must be the exact literal without escape sequences or line continuation.
-    const { index, tokenValue, tokenStart } = parser;
+    const { index, tokenValue, tokenStart, tokenIndex } = parser;
     const token = parser.getToken();
     const expr = parseLiteral(parser, context);
-    if (isValidStrictMode(parser, index, tokenStart.index, tokenValue)) {
+    if (isValidStrictMode(parser, index, tokenIndex, tokenValue)) {
       context |= Context.Strict;
 
       if (parser.flags & Flags.Octal) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -6642,7 +6642,7 @@ export function parseParenthesizedExpression(
 ): any {
   parser.flags = (parser.flags | Flags.NonSimpleParameterList) ^ Flags.NonSimpleParameterList;
 
-  const { tokenIndex: piStart, tokenLine: plStart, tokenColumn: pcStart } = parser;
+  const parenthesesStart = parser.tokenStart;
 
   nextToken(parser, context | Context.AllowRegExp | Context.AllowEscapedKeyword);
 
@@ -6666,7 +6666,7 @@ export function parseParenthesizedExpression(
   let isNonSimpleParameterList: 0 | 1 = 0;
   let hasStrictReserved: 0 | 1 = 0;
 
-  const { tokenIndex: iStart, tokenLine: lStart, tokenColumn: cStart } = parser;
+  const tokenAfterParenthesesStart = parser.tokenStart;
 
   parser.assignable = AssignmentKind.Assignable;
 
@@ -6781,15 +6781,10 @@ export function parseParenthesizedExpression(
 
         parser.assignable = AssignmentKind.CannotAssign;
 
-        expr = finishNode(
-          parser,
-          context,
-          { index: iStart, line: lStart, column: cStart },
-          {
-            type: 'SequenceExpression',
-            expressions,
-          },
-        );
+        expr = finishNode(parser, context, tokenAfterParenthesesStart, {
+          type: 'SequenceExpression',
+          expressions,
+        });
       }
 
       consume(parser, context, Token.RightParen);
@@ -6797,15 +6792,10 @@ export function parseParenthesizedExpression(
       parser.destructible = destructible;
 
       return context & Context.OptionsPreserveParens
-        ? finishNode(
-            parser,
-            context,
-            { index: piStart, line: plStart, column: pcStart },
-            {
-              type: 'ParenthesizedExpression',
-              expression: expr,
-            },
-          )
+        ? finishNode(parser, context, parenthesesStart, {
+            type: 'ParenthesizedExpression',
+            expression: expr,
+          })
         : expr;
     }
 
@@ -6829,15 +6819,10 @@ export function parseParenthesizedExpression(
   if (isSequence) {
     parser.assignable = AssignmentKind.CannotAssign;
 
-    expr = finishNode(
-      parser,
-      context,
-      { index: iStart, line: lStart, column: cStart },
-      {
-        type: 'SequenceExpression',
-        expressions,
-      },
-    );
+    expr = finishNode(parser, context, tokenAfterParenthesesStart, {
+      type: 'SequenceExpression',
+      expressions,
+    });
   }
 
   consume(parser, context, Token.RightParen);
@@ -6885,15 +6870,10 @@ export function parseParenthesizedExpression(
   parser.destructible = ((parser.destructible | DestructuringKind.Yield) ^ DestructuringKind.Yield) | destructible;
 
   return context & Context.OptionsPreserveParens
-    ? finishNode(
-        parser,
-        context,
-        { index: piStart, line: plStart, column: pcStart },
-        {
-          type: 'ParenthesizedExpression',
-          expression: expr,
-        },
-      )
+    ? finishNode(parser, context, parenthesesStart, {
+        type: 'ParenthesizedExpression',
+        expression: expr,
+      })
     : expr;
 }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -6912,8 +6912,6 @@ function parseArrowFromIdentifier(
  * @param params
  * @param isAsync
  * @param start Start index
- * @param line Start line
- * @param column Start of column
  */
 function parseParenthesizedArrow(
   parser: Parser,
@@ -6940,8 +6938,6 @@ function parseParenthesizedArrow(
  * @param params
  * @param isAsync
  * @param start Start index
- * @param line Start line
- * @param column Start of column
  */
 export function parseArrowFunctionExpression(
   parser: Parser,
@@ -7182,8 +7178,6 @@ export function parseFormalParametersOrFormalList(
  * @param expr  ESTree AST node
  * @param inGroup
  * @param start
- * @param line
- * @param column
  */
 export function parseMemberExpressionNoCall(
   parser: Parser,
@@ -7376,8 +7370,6 @@ export function parseMetaProperty(
  * @param context  Context masks
  * @param canAssign Either true or false
  * @param start Start pos of node
- * @param line Line pos of node
- * @param column Column pos of node
  */
 function parseAsyncArrowAfterIdent(
   parser: Parser,
@@ -7422,10 +7414,7 @@ function parseAsyncArrowAfterIdent(
  * @param origin Binding origin
  * @param flags Mutual parser flags
  * @param start Start pos of node
- * @param line Line pos of node
- * @param column Column pos of node
  */
-
 export function parseAsyncArrowOrCallExpression(
   parser: Parser,
   context: Context,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -879,8 +879,6 @@ export function parseReturnStatement(
  * @param context Context masks
  * @param expression AST node
  * @param start
- * @param line
- * @param column
  */
 export function parseExpressionStatement(
   parser: Parser,
@@ -904,9 +902,6 @@ export function parseExpressionStatement(
  * @param token Token to validate
  * @param allowFuncDecl Allow / disallow func statement
  * @param start
- * @param line
- * @param column
- *
  */
 export function parseLabelledStatement(
   parser: Parser,
@@ -965,10 +960,6 @@ export function parseLabelledStatement(
  * @param context Context masks
  * @param labels
  * @param allowFuncDecl Allow / disallow func statement
- * @param start Start position of current AST node
- * @param start
- * @param line
- * @param column
  */
 
 export function parseAsyncArrowOrAsyncFunctionDeclaration(
@@ -1633,8 +1624,6 @@ export function parseTryStatement(
  * @param context Context masks
  * @param scope Scope instance
  * @param start Start pos of node
- * @param line
- * @param column
  */
 export function parseCatchBlock(
   parser: Parser,
@@ -3024,8 +3013,6 @@ function parseExportDeclaration(
  * @param canAssign
  * @param inGroup,
  * @param start,
- * @param line,
- * @param column,
  */
 export function parseExpression(
   parser: Parser,
@@ -3104,8 +3091,6 @@ export function parseExpressions(
  * @param inGroup
  * @param isPattern
  * @param start
- * @param line
- * @param column
  * @param left ESTree AST node
  */
 export function parseAssignmentExpression(
@@ -3192,8 +3177,6 @@ export function parseAssignmentExpression(
  * @param inGroup
  * @param isPattern
  * @param start
- * @param line
- * @param column
  * @param left
  */
 export function parseAssignmentExpressionOrPattern(
@@ -3709,9 +3692,6 @@ export function parseSuperExpression(parser: Parser, context: Context): ESTree.S
  * @param parser  Parser object
  * @param context Context masks
  * @param canAssign
- * @param start
- * @param line
- * @param column
  */
 export function parseLeftHandSideExpression(
   parser: Parser,
@@ -3747,8 +3727,6 @@ export function parseLeftHandSideExpression(
  * @param context Context masks
  * @param inNew
  * @param start
- * @param line
- * @param column
  */
 function parseUpdateExpression(parser: Parser, context: Context, expr: ESTree.Expression, start: Location) {
   if (parser.assignable & AssignmentKind.CannotAssign) report(parser, Errors.InvalidIncDecTarget);
@@ -3774,8 +3752,6 @@ function parseUpdateExpression(parser: Parser, context: Context, expr: ESTree.Ex
  * @param expr ESTree AST node
  * @param inGroup
  * @param start
- * @param line
- * @param column
  */
 export function parseMemberOrUpdateExpression(
   parser: Parser,
@@ -4014,8 +3990,6 @@ export function parsePropertyOrPrivatePropertyName(
  * @param context Context masks
  * @param inNew
  * @param start
- * @param line
- * @param column
  */
 export function parseUpdateExpressionPrefixed(
   parser: Parser,
@@ -4062,8 +4036,6 @@ export function parseUpdateExpressionPrefixed(
  * @param canAssign
  * @param inGroup
  * @param start
- * @param line
- * @param column
  */
 export function parsePrimaryExpression(
   parser: Parser,
@@ -4225,8 +4197,6 @@ export function parsePrimaryExpression(
  * @param context Context masks
  * @param inGroup
  * @param start
- * @param line
- * @param column
  */
 function parseImportCallOrMetaExpression(
   parser: Parser,
@@ -4293,10 +4263,7 @@ export function parseImportMetaExpression(
  * @param context Context masks
  * @param inGroup
  * @param start
- * @param line
- * @param column
  */
-
 export function parseImportExpression(
   parser: Parser,
   context: Context,
@@ -5351,8 +5318,6 @@ export function parseArrayExpressionOrPattern(
  * @param destructible
  * @param inGroup
  * @param start Start index
- * @param line Start line
- * @param column Start of column
  * @param node ESTree AST node
  */
 function parseArrayOrObjectAssignmentPattern(
@@ -5603,8 +5568,6 @@ function parseSpreadOrRestElement(
  * @param kind
  * @param inGroup
  * @param start Start index
- * @param line Start line
- * @param column Start of column
  */
 export function parseMethodDefinition(
   parser: Parser,
@@ -6628,8 +6591,6 @@ export function parseComputedPropertyName(
  * @param context Context masks
  * @param assignable
  * @param start Start index
- * @param line Start line
- * @param column Start of column
  */
 export function parseParenthesizedExpression(
   parser: Parser,
@@ -6923,8 +6884,6 @@ export function parseIdentifierOrArrow(
  * @param params
  * @param isAsync
  * @param start Start index
- * @param line Start line
- * @param column Start of column
  */
 function parseArrowFromIdentifier(
   parser: Parser,


### PR DESCRIPTION
Use `tokenStart` instead of individual `tokenIndex`,`tokenLine`,`tokenColumn` which can easily get wrong, I see a few places already not correct.