### PR TITLE
refactor: refine `Parser`

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -2,7 +2,7 @@ import { Token, KeywordDescTable } from './token';
 import { Errors, ParseError, report } from './errors';
 import type * as ESTree from './estree';
 import { nextToken } from './lexer/scan';
-import { type Parser } from './parser';
+import { type Parser } from './parser/parser';
 
 /**
  * The core context, passed around everywhere as a simple immutable bit set
@@ -246,7 +246,7 @@ export function matchOrInsertSemicolon(parser: Parser, context: Context): void {
 
   if (!consumeOpt(parser, context, Token.Semicolon)) {
     // Automatic semicolon insertion has occurred
-    parser.onInsertedSemicolon?.(parser.startIndex);
+    parser.options.onInsertedSemicolon?.(parser.startIndex);
   }
 }
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -177,7 +177,13 @@ export const enum ScopeKind {
 /**
  * Comment process function.
  */
-export type OnComment = (type: string, value: string, start: number, end: number, loc: ESTree.SourceLocation) => any;
+export type OnComment = (
+  type: ESTree.CommentType,
+  value: string,
+  start: number,
+  end: number,
+  loc: ESTree.SourceLocation,
+) => any;
 
 /**
  * Function calls when semicolon inserted.
@@ -822,43 +828,6 @@ export function addBindingToExports(parser: Parser, name: string): void {
   if (parser.exportedBindings !== void 0 && name !== '') {
     parser.exportedBindings['#' + name] = 1;
   }
-}
-
-export function pushComment(context: Context, array: any[]): OnComment {
-  return function (type: string, value: string, start: number, end: number, loc: ESTree.SourceLocation) {
-    const comment: any = {
-      type,
-      value,
-    };
-
-    if (context & Context.OptionsRanges) {
-      comment.start = start;
-      comment.end = end;
-      comment.range = [start, end];
-    }
-    if (context & Context.OptionsLoc) {
-      comment.loc = loc;
-    }
-    array.push(comment);
-  };
-}
-
-export function pushToken(context: Context, array: any[]): OnToken {
-  return function (token: string, start: number, end: number, loc: ESTree.SourceLocation) {
-    const tokens: any = {
-      token,
-    };
-
-    if (context & Context.OptionsRanges) {
-      tokens.start = start;
-      tokens.end = end;
-      tokens.range = [start, end];
-    }
-    if (context & Context.OptionsLoc) {
-      tokens.loc = loc;
-    }
-    array.push(tokens);
-  };
 }
 
 export function isValidIdentifier(context: Context, t: Token): boolean {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,6 +1,6 @@
 import { type _Node, type SourceLocation } from './estree';
 import { type ScopeError, type Location } from './common';
-import { type Parser } from './parser';
+import { type Parser } from './parser/parser';
 
 export const enum Errors {
   Unexpected,

--- a/src/estree.ts
+++ b/src/estree.ts
@@ -34,12 +34,9 @@ export type ArgumentExpression =
 
 export type CommentType = 'SingleLine' | 'MultiLine' | 'HTMLOpen' | 'HTMLClose' | 'HashbangComment';
 
-export interface Comment {
+export interface Comment extends _Node {
   type: CommentType;
   value: string;
-  start?: number;
-  end?: number;
-  loc?: SourceLocation | null;
 }
 
 export type Node =

--- a/src/lexer/comments.ts
+++ b/src/lexer/comments.ts
@@ -4,6 +4,7 @@ import { Chars } from '../chars';
 import { Context } from '../common';
 import { type Parser } from '../parser/parser';
 import { report, Errors } from '../errors';
+import type * as ESTree from '../estree';
 
 export const enum CommentType {
   Single,
@@ -13,7 +14,13 @@ export const enum CommentType {
   HashBang,
 }
 
-export const CommentTypes = ['SingleLine', 'MultiLine', 'HTMLOpen', 'HTMLClose', 'HashbangComment'];
+export const CommentTypes: ESTree.CommentType[] = [
+  'SingleLine',
+  'MultiLine',
+  'HTMLOpen',
+  'HTMLClose',
+  'HashbangComment',
+];
 
 /**
  * Skips hashbang (stage 3)

--- a/src/lexer/common.ts
+++ b/src/lexer/common.ts
@@ -1,7 +1,7 @@
 import { Token } from '../token';
 import { Chars } from '../chars';
 import { Flags } from '../common';
-import { type Parser } from '../parser';
+import { type Parser } from '../parser/parser';
 
 export const enum LexerState {
   None = 0,

--- a/src/lexer/identifier.ts
+++ b/src/lexer/identifier.ts
@@ -1,5 +1,5 @@
 import { Context } from '../common';
-import { type Parser } from '../parser';
+import { type Parser } from '../parser/parser';
 import { Token, descKeywordTable } from '../token';
 import { Chars } from '../chars';
 import { advanceChar, consumePossibleSurrogatePair, toHex } from './common';

--- a/src/lexer/jsx.ts
+++ b/src/lexer/jsx.ts
@@ -1,7 +1,7 @@
 import { CharFlags, CharTypes } from './charClassifier';
 import { Token } from '../token';
 import { Context } from '../common';
-import { type Parser } from '../parser';
+import { type Parser } from '../parser/parser';
 import { report, Errors } from '../errors';
 import { advanceChar, LexerState, scanSingleToken, scanNewLine, consumeLineFeed } from './';
 import { decodeHTMLStrict } from './decodeHTML';

--- a/src/lexer/numeric.ts
+++ b/src/lexer/numeric.ts
@@ -1,5 +1,5 @@
 import { Context, Flags } from '../common';
-import { type Parser } from '../parser';
+import { type Parser } from '../parser/parser';
 import { Token } from '../token';
 import { advanceChar, toHex, NumberKind } from './common';
 import { CharTypes, CharFlags, isIdentifierStart } from './charClassifier';

--- a/src/lexer/regexp.ts
+++ b/src/lexer/regexp.ts
@@ -1,6 +1,6 @@
 import { Chars } from '../chars';
 import { Context } from '../common';
-import { type Parser } from '../parser';
+import { type Parser } from '../parser/parser';
 import { Token } from '../token';
 import { advanceChar } from './common';
 import { isIdentifierPart } from './charClassifier';

--- a/src/lexer/scan.ts
+++ b/src/lexer/scan.ts
@@ -1,7 +1,7 @@
 import { Chars } from '../chars';
 import { Token } from '../token';
 import { Context, Flags } from '../common';
-import { type Parser } from '../parser';
+import { type Parser } from '../parser/parser';
 import { report, Errors } from '../errors';
 import { isIDStart } from '../unicode';
 import {

--- a/src/lexer/string.ts
+++ b/src/lexer/string.ts
@@ -1,5 +1,5 @@
 import { Context, Flags } from '../common';
-import { type Parser } from '../parser';
+import { type Parser } from '../parser/parser';
 import { Token } from '../token';
 import { Chars } from '../chars';
 import { report, Errors } from '../errors';

--- a/src/lexer/template.ts
+++ b/src/lexer/template.ts
@@ -1,5 +1,5 @@
 import { Context } from '../common';
-import { type Parser } from '../parser';
+import { type Parser } from '../parser/parser';
 import { Token } from '../token';
 import { Chars } from '../chars';
 import { advanceChar } from './common';

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -52,7 +52,7 @@ import {
   type Location,
 } from './common';
 import { Chars } from './chars';
-import { Parser } from './parser/parser';
+import { Parser, type ParserOptions } from './parser/parser';
 
 /**
  * The parser options.
@@ -96,10 +96,6 @@ export interface Options {
  * Consumes a sequence of tokens and produces an syntax tree
  */
 export function parseSource(source: string, options: Options | void, context: Context): ESTree.Program {
-  let sourceFile = '';
-  let onComment;
-  let onInsertedSemicolon;
-  let onToken;
   if (options != null) {
     if (options.module) context |= Context.Module | Context.Strict;
     if (options.next) context |= Context.OptionsNext;
@@ -114,28 +110,30 @@ export function parseSource(source: string, options: Options | void, context: Co
     if (options.preserveParens) context |= Context.OptionsPreserveParens;
     if (options.impliedStrict) context |= Context.Strict;
     if (options.jsx) context |= Context.OptionsJSX;
-    if (options.source) sourceFile = options.source;
+  }
+
+  const parserOptions: ParserOptions = {
+    shouldAddLoc: Boolean(context & Context.OptionsLoc),
+    shouldAddRanges: Boolean(context & Context.OptionsRanges),
+  };
+  if (options != null) {
+    if (options.source) parserOptions.sourceFile = options.source;
+
     // Accepts either a callback function to be invoked or an array to collect comments (as the node is constructed)
     if (options.onComment != null) {
-      onComment = Array.isArray(options.onComment) ? pushComment(context, options.onComment) : options.onComment;
+      parserOptions.onComment = Array.isArray(options.onComment)
+        ? pushComment(context, options.onComment)
+        : options.onComment;
     }
-    if (options.onInsertedSemicolon != null) onInsertedSemicolon = options.onInsertedSemicolon;
+    if (options.onInsertedSemicolon != null) parserOptions.onInsertedSemicolon = options.onInsertedSemicolon;
     // Accepts either a callback function to be invoked or an array to collect tokens
     if (options.onToken != null) {
-      onToken = Array.isArray(options.onToken) ? pushToken(context, options.onToken) : options.onToken;
+      parserOptions.onToken = Array.isArray(options.onToken) ? pushToken(context, options.onToken) : options.onToken;
     }
   }
 
   // Initialize parser state
-  const parser = new Parser(
-    source,
-    sourceFile,
-    /* shouldAddLoc */ Boolean(context & Context.OptionsLoc),
-    /* shouldAddRanges */ Boolean(context & Context.OptionsRanges),
-    onComment,
-    onToken,
-    onInsertedSemicolon,
-  );
+  const parser = new Parser(source, parserOptions);
 
   // See: https://github.com/tc39/proposal-hashbang
   skipHashBang(parser);
@@ -180,7 +178,7 @@ export function parseSource(source: string, options: Options | void, context: Co
       end: { line: parser.line, column: parser.column },
     };
 
-    if (parser.sourceFile) node.loc.source = sourceFile;
+    if (parser.options.sourceFile) node.loc.source = parser.options.sourceFile;
   }
 
   return node;
@@ -9096,5 +9094,3 @@ export function parseJSXIdentifier(parser: Parser, context: Context): ESTree.JSX
     start,
   );
 }
-
-export { Parser } from './parser/parser';

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -14,8 +14,6 @@ import {
   type OnComment,
   type OnInsertedSemicolon,
   type OnToken,
-  pushComment,
-  pushToken,
   reinterpretToPattern,
   DestructuringKind,
   AssignmentKind,
@@ -52,7 +50,7 @@ import {
   type Location,
 } from './common';
 import { Chars } from './chars';
-import { Parser, type ParserOptions } from './parser/parser';
+import { Parser, type ParserOptions, pushComment, pushToken } from './parser/parser';
 
 /**
  * The parser options.
@@ -122,13 +120,15 @@ export function parseSource(source: string, options: Options | void, context: Co
     // Accepts either a callback function to be invoked or an array to collect comments (as the node is constructed)
     if (options.onComment != null) {
       parserOptions.onComment = Array.isArray(options.onComment)
-        ? pushComment(context, options.onComment)
+        ? pushComment(options.onComment, parserOptions)
         : options.onComment;
     }
     if (options.onInsertedSemicolon != null) parserOptions.onInsertedSemicolon = options.onInsertedSemicolon;
     // Accepts either a callback function to be invoked or an array to collect tokens
     if (options.onToken != null) {
-      parserOptions.onToken = Array.isArray(options.onToken) ? pushToken(context, options.onToken) : options.onToken;
+      parserOptions.onToken = Array.isArray(options.onToken)
+        ? pushToken(options.onToken, parserOptions)
+        : options.onToken;
     }
   }
 

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -11,6 +11,27 @@ import {
   type DestructuringKind,
 } from '../common';
 
+export type ParserOptions = {
+  shouldAddLoc?: boolean;
+  shouldAddRanges?: boolean;
+  /**
+   * Used together with source maps. File containing the code being parsed
+   */
+  sourceFile?: string;
+  /**
+   * Holds either a function or array used on every comment
+   */
+  onComment?: OnComment;
+  /**
+   * Function invoked with the character offset when automatic semicolon insertion occurs
+   */
+  onInsertedSemicolon?: OnInsertedSemicolon;
+  /**
+   * Holds either a function or array used on every token
+   */
+  onToken?: OnToken;
+};
+
 export class Parser {
   private lastOnToken: [string, number, number, ESTree.SourceLocation] | null = null;
 
@@ -122,27 +143,7 @@ export class Parser {
      * The source code to be parsed
      */
     public readonly source: string,
-
-    /**
-     * Used together with source maps. File containing the code being parsed
-     */
-    public readonly sourceFile: string | void,
-
-    private readonly shouldAddLoc: boolean | void,
-    private readonly shouldAddRanges: boolean | void,
-
-    /**
-     * Holds either a function or array used on every comment
-     */
-    public readonly onComment: OnComment | void,
-    /**
-     * Holds either a function or array used on every token
-     */
-    public readonly onToken: OnToken | void,
-    /**
-     * Function invoked with the character offset when automatic semicolon insertion occurs
-     */
-    public readonly onInsertedSemicolon: OnInsertedSemicolon | void,
+    public readonly options: ParserOptions = {},
   ) {
     this.end = source.length;
     this.currentChar = source.charCodeAt(0);
@@ -165,7 +166,7 @@ export class Parser {
   setToken(value: Token, replaceLast = false) {
     this.token = value;
 
-    const { onToken } = this;
+    const { onToken } = this.options;
 
     if (onToken) {
       if (value !== Token.EOF) {
@@ -203,13 +204,13 @@ export class Parser {
   }
 
   finishNode<T extends ESTree.Node>(node: T, start: Location): T {
-    if (this.shouldAddRanges) {
+    if (this.options.shouldAddRanges) {
       node.start = start.index;
       node.end = this.startIndex;
       node.range = [start.index, this.startIndex];
     }
 
-    if (this.shouldAddLoc) {
+    if (this.options.shouldAddLoc) {
       node.loc = {
         start: {
           line: start.line,
@@ -221,8 +222,8 @@ export class Parser {
         },
       };
 
-      if (this.sourceFile) {
-        node.loc.source = this.sourceFile;
+      if (this.options.sourceFile) {
+        node.loc.source = this.options.sourceFile;
       }
     }
 

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -230,3 +230,40 @@ export class Parser {
     return node;
   }
 }
+
+export function pushComment(comments: ESTree.Comment[], options: ParserOptions): OnComment {
+  return function (type: ESTree.CommentType, value: string, start: number, end: number, loc: ESTree.SourceLocation) {
+    const comment: ESTree.Comment = {
+      type,
+      value,
+    };
+
+    if (options.shouldAddRanges) {
+      comment.start = start;
+      comment.end = end;
+      comment.range = [start, end];
+    }
+    if (options.shouldAddLoc) {
+      comment.loc = loc;
+    }
+    comments.push(comment);
+  };
+}
+
+export function pushToken(tokens: any[], options: ParserOptions): OnToken {
+  return function (type: string, start: number, end: number, loc: ESTree.SourceLocation) {
+    const token: any = {
+      token: type,
+    };
+
+    if (options.shouldAddRanges) {
+      token.start = start;
+      token.end = end;
+      token.range = [start, end];
+    }
+    if (options.shouldAddLoc) {
+      token.loc = loc;
+    }
+    tokens.push(token);
+  };
+}

--- a/test/lexer/comments.ts
+++ b/test/lexer/comments.ts
@@ -2,7 +2,7 @@ import * as t from 'node:assert/strict';
 import { describe, it } from 'vitest';
 import { Context } from '../../src/common';
 import { Token } from '../../src/token';
-import { Parser } from '../../src/parser';
+import { Parser } from '../../src/parser/parser';
 import { scanSingleToken } from '../../src/lexer/scan';
 
 describe('Lexer - Comments', () => {
@@ -45,7 +45,7 @@ describe('Lexer - Comments', () => {
 
   for (const [ctx, token, op] of tokens) {
     it(`scans '${op}' at the end`, () => {
-      const state = new Parser(op, '');
+      const state = new Parser(op);
       const found = scanSingleToken(state, ctx, 0);
 
       t.deepEqual(
@@ -65,7 +65,7 @@ describe('Lexer - Comments', () => {
 
   function fail(name: string, source: string, context: Context) {
     it(name, () => {
-      const state = new Parser(source, '');
+      const state = new Parser(source);
       t.throws(() => scanSingleToken(state, context, 0));
     });
   }

--- a/test/lexer/identifiers.ts
+++ b/test/lexer/identifiers.ts
@@ -2,7 +2,7 @@ import * as t from 'node:assert/strict';
 import { describe, it } from 'vitest';
 import { Context } from '../../src/common';
 import { Token } from '../../src/token';
-import { Parser } from '../../src/parser';
+import { Parser } from '../../src/parser/parser';
 import { scanSingleToken } from '../../src/lexer/scan';
 
 describe('Lexer - Identifiers', () => {
@@ -149,7 +149,7 @@ describe('Lexer - Identifiers', () => {
 
   for (const [ctx, token, op, value] of tokens) {
     it(`scans '${op}' at the end`, () => {
-      const state = new Parser(op, '');
+      const state = new Parser(op);
       const found = scanSingleToken(state, ctx, 0);
 
       t.deepEqual(
@@ -169,7 +169,7 @@ describe('Lexer - Identifiers', () => {
     });
 
     it(`scans '${op}' with more to go`, () => {
-      const state = new Parser(`${op} `, '');
+      const state = new Parser(`${op} `);
       const found = scanSingleToken(state, ctx, 0);
 
       t.deepEqual(
@@ -191,7 +191,7 @@ describe('Lexer - Identifiers', () => {
 
   function fail(name: string, source: string, context: Context) {
     it(name, () => {
-      const state = new Parser(source, '');
+      const state = new Parser(source);
       t.throws(() => scanSingleToken(state, context, 0));
     });
   }

--- a/test/lexer/line-terminators.ts
+++ b/test/lexer/line-terminators.ts
@@ -2,7 +2,7 @@ import * as t from 'node:assert/strict';
 import { describe, it } from 'vitest';
 import { Context } from '../../src/common';
 import { Token } from '../../src/token';
-import { Parser } from '../../src/parser';
+import { Parser } from '../../src/parser/parser';
 import { scanSingleToken } from '../../src/lexer/scan';
 
 describe('Lexer - Line terminators', () => {
@@ -24,7 +24,7 @@ describe('Lexer - Line terminators', () => {
 
   for (const [ctx, token, op, value] of tokens) {
     it(`scans '${op}' at the end`, () => {
-      const state = new Parser(op, '');
+      const state = new Parser(op);
       const found = scanSingleToken(state, ctx, 0);
 
       t.deepEqual(
@@ -46,7 +46,7 @@ describe('Lexer - Line terminators', () => {
 
   function fail(name: string, source: string, context: Context) {
     it(name, () => {
-      const state = new Parser(source, '');
+      const state = new Parser(source);
       t.throws(() => scanSingleToken(state, context, 0));
     });
   }

--- a/test/lexer/numbers.ts
+++ b/test/lexer/numbers.ts
@@ -2,7 +2,7 @@ import * as t from 'node:assert/strict';
 import { describe, it } from 'vitest';
 import { Context } from '../../src/common';
 import { Token } from '../../src/token';
-import { Parser } from '../../src/parser';
+import { Parser } from '../../src/parser/parser';
 import { scanSingleToken } from '../../src/lexer/scan';
 
 describe('Lexer - Numberic literals', () => {
@@ -193,7 +193,7 @@ describe('Lexer - Numberic literals', () => {
 
   for (const [ctx, token, op, value] of tokens) {
     it(`scans '${op}' at the end`, () => {
-      const state = new Parser(op, '');
+      const state = new Parser(op);
       const found = scanSingleToken(state, ctx, 0);
 
       t.deepEqual(
@@ -213,7 +213,7 @@ describe('Lexer - Numberic literals', () => {
     });
 
     it(`scans '${op}' with more to go`, () => {
-      const state = new Parser(`${op} `, '');
+      const state = new Parser(`${op} `);
       const found = scanSingleToken(state, ctx, 0);
 
       t.deepEqual(
@@ -235,7 +235,7 @@ describe('Lexer - Numberic literals', () => {
 
   function fail(name: string, source: string, context: Context) {
     it(name, () => {
-      const state = new Parser(source, '');
+      const state = new Parser(source);
       t.throws(() => scanSingleToken(state, context, 0));
     });
   }

--- a/test/lexer/privatename.ts
+++ b/test/lexer/privatename.ts
@@ -2,13 +2,13 @@ import * as t from 'node:assert/strict';
 import { describe, it } from 'vitest';
 import { Context } from '../../src/common';
 import { Token } from '../../src/token';
-import { Parser } from '../../src/parser';
+import { Parser } from '../../src/parser/parser';
 import { scanSingleToken } from '../../src/lexer/scan';
 
 describe('lexer - privatename', () => {
   function pass(name: string, opts: any) {
     it(name, () => {
-      const state = new Parser(opts.source, '');
+      const state = new Parser(opts.source);
       const token = scanSingleToken(state, opts.ctx, 0);
       t.deepEqual(
         {
@@ -36,7 +36,7 @@ describe('lexer - privatename', () => {
 
   function fail(name: string, source: string, context: Context) {
     it(name, () => {
-      const state = new Parser(source, '');
+      const state = new Parser(source);
       t.throws(() => scanSingleToken(state, context, 0));
     });
   }

--- a/test/lexer/punctuators.ts
+++ b/test/lexer/punctuators.ts
@@ -2,7 +2,7 @@ import * as t from 'node:assert/strict';
 import { describe, it } from 'vitest';
 import { Context } from '../../src/common';
 import { Token } from '../../src/token';
-import { Parser } from '../../src/parser';
+import { Parser } from '../../src/parser/parser';
 import { scanSingleToken } from '../../src/lexer/scan';
 
 describe('src/lexer/scan', () => {
@@ -68,7 +68,7 @@ describe('src/lexer/scan', () => {
 
   for (const [ctx, token, op] of tokens) {
     it(`scans '${op}' at the end`, () => {
-      const state = new Parser(op, '');
+      const state = new Parser(op);
       const found = scanSingleToken(state, ctx, 0);
 
       t.deepEqual(
@@ -86,7 +86,7 @@ describe('src/lexer/scan', () => {
     });
 
     it(`scans '${op}' with more to go`, () => {
-      const state = new Parser(`${op} rest`, '');
+      const state = new Parser(`${op} rest`);
       const found = scanSingleToken(state, ctx, 0);
 
       t.deepEqual(

--- a/test/lexer/regexp.ts
+++ b/test/lexer/regexp.ts
@@ -2,7 +2,7 @@ import * as t from 'node:assert/strict';
 import { describe, it } from 'vitest';
 import { Context } from '../../src/common';
 import { Token } from '../../src/token';
-import { Parser } from '../../src/parser';
+import { Parser } from '../../src/parser/parser';
 import { scanSingleToken } from '../../src/lexer/scan';
 import { regexFeatures } from '../../scripts/shared.mjs';
 
@@ -179,7 +179,7 @@ describe('Lexer - Regular expressions', () => {
 
   for (const [ctx, op, value, flags] of tokens) {
     it(`scans '${op}' at the end`, () => {
-      const state = new Parser(op, '');
+      const state = new Parser(op);
       const found = scanSingleToken(state, ctx, 0);
 
       t.deepEqual(
@@ -201,7 +201,7 @@ describe('Lexer - Regular expressions', () => {
 
   function fail(name: string, source: string, context: Context) {
     it(name, () => {
-      const state = new Parser(source, '');
+      const state = new Parser(source);
       t.throws(() => scanSingleToken(state, context, 0));
     });
   }

--- a/test/lexer/scanSingleToken.ts
+++ b/test/lexer/scanSingleToken.ts
@@ -2,23 +2,23 @@ import * as t from 'node:assert/strict';
 import { describe, it } from 'vitest';
 import { Context } from '../../src/common';
 import { Token } from '../../src/token';
-import { Parser } from '../../src/parser';
+import { Parser } from '../../src/parser/parser';
 import { scanSingleToken } from '../../src/lexer/scan';
 
 describe('src/lexer/scan', () => {
   describe('#scanSingleToken()', () => {
     it('should return EOF if the input is empty', () => {
-      const state = new Parser('', '');
+      const state = new Parser('');
       const token = scanSingleToken(state, Context.None, 0);
       t.deepEqual(token, Token.EOF);
     });
     it('should recognise comments', () => {
-      const state = new Parser('// this is a comment', '');
+      const state = new Parser('// this is a comment');
       const token = scanSingleToken(state, Context.None, 0);
       t.deepEqual(token, Token.EOF);
     });
     it('should recognise arithmetic operators', () => {
-      const state = new Parser('+-*/', '');
+      const state = new Parser('+-*/');
       let token = scanSingleToken(state, Context.None, 0);
       t.deepEqual(token, Token.Add);
       token = scanSingleToken(state, Context.None, 0);
@@ -31,7 +31,7 @@ describe('src/lexer/scan', () => {
       t.deepEqual(token, Token.EOF);
     });
     it('should recognise multi character operators', () => {
-      const state = new Parser('>= <=', '');
+      const state = new Parser('>= <=');
       let token = scanSingleToken(state, Context.None, 0);
       t.deepEqual(token, Token.GreaterThanOrEqual);
       token = scanSingleToken(state, Context.None, 0);
@@ -40,7 +40,7 @@ describe('src/lexer/scan', () => {
       t.deepEqual(token, Token.EOF);
     });
     it('should evaluate to "0"', () => {
-      const state = new Parser('0..toString()', '');
+      const state = new Parser('0..toString()');
       let token = scanSingleToken(state, Context.None, 0);
       t.deepEqual(token, Token.NumericLiteral);
       token = scanSingleToken(state, Context.None, 0);
@@ -56,7 +56,7 @@ describe('src/lexer/scan', () => {
       t.deepEqual(token, Token.EOF);
     });
     it('should recognise a simple statement', () => {
-      const state = new Parser('while (foo) { 1; } ', '');
+      const state = new Parser('while (foo) { 1; } ');
       let token = scanSingleToken(state, Context.None, 0);
       t.deepEqual(state.tokenValue, 'while');
       t.deepEqual(token, Token.WhileKeyword);
@@ -81,57 +81,57 @@ describe('src/lexer/scan', () => {
     });
 
     it('should skip any whitespace', () => {
-      const state = new Parser('    \n\t\r  \r \n \t  +', '');
+      const state = new Parser('    \n\t\r  \r \n \t  +');
       const token = scanSingleToken(state, Context.None, 0);
       t.deepEqual(token, Token.Add);
     });
     it('should recognize single character numbers', () => {
       const src = '3';
-      const state = new Parser(src, '');
+      const state = new Parser(src);
       const token = scanSingleToken(state, Context.None, 0);
       t.equal(token, Token.NumericLiteral);
       t.equal(state.tokenValue, Number(src));
     });
     it('should recognize multi character numbers', () => {
       const src = '345';
-      const state = new Parser(src, '');
+      const state = new Parser(src);
       const token = scanSingleToken(state, Context.None, 0);
       t.equal(token, Token.NumericLiteral);
       t.equal(state.tokenValue, Number(src));
     });
     // tslint:disable quotemark
     it('should recognise strings', () => {
-      const state = new Parser("'hello'", '');
+      const state = new Parser("'hello'");
       const token = scanSingleToken(state, Context.None, 0);
       t.deepEqual(token, Token.StringLiteral);
       t.deepEqual(state.tokenValue, 'hello');
     });
     it('should recognise empty strings', () => {
-      const state = new Parser("''", '');
+      const state = new Parser("''");
       const token = scanSingleToken(state, Context.None, 0);
       t.deepEqual(token, Token.StringLiteral);
       t.deepEqual(state.tokenValue, '');
     });
     it('should recognise valid escape sequences.', () => {
-      const state = new Parser(String.raw`'\\ \n \t \r \' \b \f \v \0'`, '');
+      const state = new Parser(String.raw`'\\ \n \t \r \' \b \f \v \0'`);
       const token = scanSingleToken(state, Context.None, 0);
       t.deepEqual(token, Token.StringLiteral);
       t.deepEqual(state.tokenValue, "\\ \n \t \r ' \b \f \v \0");
     });
     it('should throw on unterminated string literals', () => {
-      const state = new Parser("'abdc", '');
+      const state = new Parser("'abdc");
       t.throws(() => scanSingleToken(state, Context.None, 0));
     });
     // tslint:enable quotemark
     it('should recognise keywords', () => {
-      const state = new Parser('let const', '');
+      const state = new Parser('let const');
       let token = scanSingleToken(state, Context.None, 0);
       t.deepEqual(token, Token.LetKeyword);
       token = scanSingleToken(state, Context.None, 0);
       t.deepEqual(token, Token.ConstKeyword);
     });
     it('should recognise identifiers', () => {
-      const state = new Parser('test _test a1', '');
+      const state = new Parser('test _test a1');
       let token = scanSingleToken(state, Context.None, 0);
       t.deepEqual(token, Token.Identifier);
       t.deepEqual(state.tokenValue, 'test');
@@ -143,7 +143,7 @@ describe('src/lexer/scan', () => {
       t.deepEqual(state.tokenValue, 'a1');
     });
     it('should report an unknown character for anything else', () => {
-      const state = new Parser('€', '');
+      const state = new Parser('€');
       t.throws(() => scanSingleToken(state, Context.None, 0));
     });
   });

--- a/test/lexer/skiphashbang.ts
+++ b/test/lexer/skiphashbang.ts
@@ -1,13 +1,13 @@
 import * as t from 'node:assert/strict';
 import { describe, it } from 'vitest';
 import { Flags } from '../../src/common';
-import { Parser } from '../../src/parser';
+import { Parser } from '../../src/parser/parser';
 import { skipHashBang } from '../../src/lexer';
 
 describe('Lexer - skiphashbang', () => {
   function pass(name: string, opts: any) {
     it(name, () => {
-      const state = new Parser(opts.source, '');
+      const state = new Parser(opts.source);
       skipHashBang(state);
       t.deepEqual(
         {

--- a/test/lexer/strings.ts
+++ b/test/lexer/strings.ts
@@ -2,7 +2,7 @@ import * as t from 'node:assert/strict';
 import { describe, it } from 'vitest';
 import { Context } from '../../src/common';
 import { Token } from '../../src/token';
-import { Parser } from '../../src/parser';
+import { Parser } from '../../src/parser/parser';
 import { scanSingleToken } from '../../src/lexer/scan';
 
 describe('Lexer - String', () => {
@@ -158,7 +158,7 @@ describe('Lexer - String', () => {
 
   for (const [ctx, token, op, value] of tokens) {
     it(`scans '${op}' at the end`, () => {
-      const state = new Parser(op, '');
+      const state = new Parser(op);
       const found = scanSingleToken(state, ctx, 0);
 
       t.deepEqual(
@@ -178,7 +178,7 @@ describe('Lexer - String', () => {
     });
 
     it(`scans '${op}' with more to go`, () => {
-      const state = new Parser(`${op} `, '');
+      const state = new Parser(`${op} `);
       const found = scanSingleToken(state, ctx, 0);
 
       t.deepEqual(
@@ -200,7 +200,7 @@ describe('Lexer - String', () => {
 
   function fail(name: string, source: string, context: Context) {
     it(name, () => {
-      const state = new Parser(source, '');
+      const state = new Parser(source);
       t.throws(() => scanSingleToken(state, context, 0));
     });
   }

--- a/test/lexer/template.ts
+++ b/test/lexer/template.ts
@@ -2,7 +2,7 @@ import * as t from 'node:assert/strict';
 import { describe, it } from 'vitest';
 import { Context } from '../../src/common';
 import { Token } from '../../src/token';
-import { Parser } from '../../src/parser';
+import { Parser } from '../../src/parser/parser';
 import { scanSingleToken } from '../../src/lexer/scan';
 
 describe('Lexer - Template', () => {
@@ -39,7 +39,7 @@ describe('Lexer - Template', () => {
 
     for (const [ctx, token, op, value] of tokens) {
       it(`scans '${op}' at the end`, () => {
-        const state = new Parser(op, '');
+        const state = new Parser(op);
         const found = scanSingleToken(state, ctx, 0);
 
         t.deepEqual(
@@ -59,7 +59,7 @@ describe('Lexer - Template', () => {
       });
 
       it(`scans '${op}' with more to go`, () => {
-        const state = new Parser(`${op} `, '');
+        const state = new Parser(`${op} `);
         const found = scanSingleToken(state, ctx, 0);
 
         t.deepEqual(
@@ -89,7 +89,7 @@ describe('Lexer - Template', () => {
 
     for (const [ctx, token, op, value] of tokens) {
       it(`scans '${op}' at the end`, () => {
-        const state = new Parser(op, '');
+        const state = new Parser(op);
         const found = scanSingleToken(state, ctx, 0);
 
         t.deepEqual(
@@ -141,7 +141,7 @@ describe('Lexer - Template', () => {
 
     for (const [ctx, token, op, value] of tokens) {
       it(`scans '${op}' at the end`, () => {
-        const state = new Parser(op, '');
+        const state = new Parser(op);
         const found = scanSingleToken(state, ctx, 0);
 
         t.deepEqual(
@@ -160,7 +160,7 @@ describe('Lexer - Template', () => {
 
   function fail(name: string, source: string, context: Context) {
     it(name, () => {
-      const state = new Parser(source, '');
+      const state = new Parser(source);
       t.throws(() => scanSingleToken(state, context, 0));
     });
   }

--- a/test/lexer/unicode-escape.ts
+++ b/test/lexer/unicode-escape.ts
@@ -2,7 +2,7 @@ import * as t from 'node:assert/strict';
 import { describe, it } from 'vitest';
 import { Context } from '../../src/common';
 import { Token } from '../../src/token';
-import { Parser } from '../../src/parser';
+import { Parser } from '../../src/parser/parser';
 import { scanSingleToken } from '../../src/lexer/scan';
 
 describe('Lexer - Unicode Escape', () => {
@@ -32,7 +32,7 @@ describe('Lexer - Unicode Escape', () => {
 
   for (const [ctx, token, op, value] of tokens) {
     it(`scans '${op}' at the end`, () => {
-      const state = new Parser(op, '');
+      const state = new Parser(op);
       const found = scanSingleToken(state, ctx, 0);
 
       t.deepEqual(
@@ -52,7 +52,7 @@ describe('Lexer - Unicode Escape', () => {
     });
 
     it(`scans '${op}' with more to go`, () => {
-      const state = new Parser(`${op} `, '');
+      const state = new Parser(`${op} `);
       const found = scanSingleToken(state, ctx, 0);
 
       t.deepEqual(
@@ -74,7 +74,7 @@ describe('Lexer - Unicode Escape', () => {
 
   function fail(name: string, source: string, context: Context) {
     it(name, () => {
-      const state = new Parser(source, '');
+      const state = new Parser(source);
       t.throws(() => scanSingleToken(state, context, 0));
     });
   }

--- a/test/lexer/whitespace.ts
+++ b/test/lexer/whitespace.ts
@@ -1,14 +1,14 @@
 import * as t from 'node:assert/strict';
 import { describe, it } from 'vitest';
 import { Flags, Context } from '../../src/common';
-import { Parser } from '../../src/parser';
+import { Parser } from '../../src/parser/parser';
 import { scanSingleToken } from '../../src/lexer/scan';
 
 describe('Lexer - Whitespace', () => {
   function pass(name: string, opts: any) {
     it(name, () => {
       const { source, ...otherOpts } = opts;
-      const state = new Parser(source, '');
+      const state = new Parser(source);
       scanSingleToken(state, Context.OptionsWebCompat, 0);
       t.deepEqual(
         {


### PR DESCRIPTION
- Pack various options into an object
- Reuse in `pushComment` and `pushToken`
- Stricter type in `OnComment`