### PR TITLE
fix: forbid pass `module` in `parse{Script,Module}`

### DIFF
--- a/src/meriyah.ts
+++ b/src/meriyah.ts
@@ -1,4 +1,3 @@
-import { Context } from './common';
 import { parseSource, Options } from './parser';
 import { type Program } from './estree';
 // Current version
@@ -10,22 +9,22 @@ const version: string = pkgVersion;
 /**
  * Parse a script, optionally with various options.
  */
-export function parseScript(source: string, options?: Options): Program {
-  return parseSource(source, options, Context.None);
+export function parseScript(source: string, options?: Omit<Options, 'module'>): Program {
+  return parseSource(source, { ...options, module: false });
 }
 
 /**
  * Parse a module, optionally with various options.
  */
-export function parseModule(source: string, options?: Options): Program {
-  return parseSource(source, options, Context.Strict | Context.Module);
+export function parseModule(source: string, options?: Omit<Options, 'module'>): Program {
+  return parseSource(source, { ...options, module: true });
 }
 
 /**
  * Parse a module or a script, optionally with various options.
  */
 export function parse(source: string, options?: Options): Program {
-  return parseSource(source, options, Context.None);
+  return parseSource(source, options);
 }
 
 export { Options, version };

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -93,7 +93,7 @@ export interface Options {
 /**
  * Consumes a sequence of tokens and produces an syntax tree
  */
-export function parseSource(source: string, options: Options | void, context: Context): ESTree.Program {
+export function parseSource(source: string, options: Options | void, context: Context = Context.None): ESTree.Program {
   if (options != null) {
     if (options.module) context |= Context.Module | Context.Strict;
     if (options.next) context |= Context.OptionsNext;


### PR DESCRIPTION
I don't think this should be allowed.

```
> require('meriyah').parseScript('import.meta.url',{module:true})
{
  type: 'Program',
  sourceType: 'module',
  body: [ { type: 'ExpressionStatement', expression: [Object] } ]
}
>
```