### PR TITLE
fix(parser): fix line/column where string literal contains `U+2028` or `U+2029` followed by `\`

### DIFF
--- a/src/lexer/string.ts
+++ b/src/lexer/string.ts
@@ -45,14 +45,12 @@ export function scanString(parser: Parser, context: Context, quote: number): Tok
         ret += String.fromCodePoint(char);
       }
       marker = parser.index + 1;
-    }
-
-    if (parser.index >= parser.end) report(parser, Errors.UnterminatedString);
-
-    if (char === Chars.LineSeparator || char === Chars.ParagraphSeparator) {
+    } else if (char === Chars.LineSeparator || char === Chars.ParagraphSeparator) {
       parser.line++;
       parser.column = 0;
     }
+
+    if (parser.index >= parser.end) report(parser, Errors.UnterminatedString);
 
     char = advanceChar(parser);
   }

--- a/test/parser/expressions/__snapshots__/string.ts.snap
+++ b/test/parser/expressions/__snapshots__/string.ts.snap
@@ -9,8 +9,8 @@ exports[`StringLiteral > ("\\ "); 1`] = `
         "end": 5,
         "loc": {
           "end": {
-            "column": 2,
-            "line": 3,
+            "column": 1,
+            "line": 2,
           },
           "start": {
             "column": 1,
@@ -21,14 +21,15 @@ exports[`StringLiteral > ("\\ "); 1`] = `
           1,
           5,
         ],
+        "raw": ""\\ "",
         "start": 1,
         "type": "Literal",
         "value": "",
       },
       "loc": {
         "end": {
-          "column": 4,
-          "line": 3,
+          "column": 3,
+          "line": 2,
         },
         "start": {
           "column": 0,
@@ -46,8 +47,8 @@ exports[`StringLiteral > ("\\ "); 1`] = `
   "end": 7,
   "loc": {
     "end": {
-      "column": 4,
-      "line": 3,
+      "column": 3,
+      "line": 2,
     },
     "start": {
       "column": 0,
@@ -73,8 +74,8 @@ exports[`StringLiteral > ("\\ "); 1`] = `
         "end": 5,
         "loc": {
           "end": {
-            "column": 2,
-            "line": 3,
+            "column": 1,
+            "line": 2,
           },
           "start": {
             "column": 1,
@@ -85,14 +86,15 @@ exports[`StringLiteral > ("\\ "); 1`] = `
           1,
           5,
         ],
+        "raw": ""\\ "",
         "start": 1,
         "type": "Literal",
         "value": "",
       },
       "loc": {
         "end": {
-          "column": 4,
-          "line": 3,
+          "column": 3,
+          "line": 2,
         },
         "start": {
           "column": 0,
@@ -110,8 +112,8 @@ exports[`StringLiteral > ("\\ "); 1`] = `
   "end": 7,
   "loc": {
     "end": {
-      "column": 4,
-      "line": 3,
+      "column": 3,
+      "line": 2,
     },
     "start": {
       "column": 0,
@@ -149,6 +151,7 @@ exports[`StringLiteral > (" "); 1`] = `
           1,
           4,
         ],
+        "raw": "" "",
         "start": 1,
         "type": "Literal",
         "value": " ",
@@ -213,6 +216,7 @@ exports[`StringLiteral > (" "); 1`] = `
           1,
           4,
         ],
+        "raw": "" "",
         "start": 1,
         "type": "Literal",
         "value": " ",

--- a/test/parser/expressions/__snapshots__/string.ts.snap
+++ b/test/parser/expressions/__snapshots__/string.ts.snap
@@ -21,7 +21,6 @@ exports[`StringLiteral > ("\\ "); 1`] = `
           1,
           5,
         ],
-        "raw": ""\\ "",
         "start": 1,
         "type": "Literal",
         "value": "",
@@ -86,7 +85,6 @@ exports[`StringLiteral > ("\\ "); 1`] = `
           1,
           5,
         ],
-        "raw": ""\\ "",
         "start": 1,
         "type": "Literal",
         "value": "",
@@ -151,7 +149,6 @@ exports[`StringLiteral > (" "); 1`] = `
           1,
           4,
         ],
-        "raw": "" "",
         "start": 1,
         "type": "Literal",
         "value": " ",
@@ -216,7 +213,6 @@ exports[`StringLiteral > (" "); 1`] = `
           1,
           4,
         ],
-        "raw": "" "",
         "start": 1,
         "type": "Literal",
         "value": " ",

--- a/test/parser/expressions/__snapshots__/string.ts.snap
+++ b/test/parser/expressions/__snapshots__/string.ts.snap
@@ -1,5 +1,133 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`StringLiteral > ("\\ "); 1`] = `
+{
+  "body": [
+    {
+      "end": 7,
+      "expression": {
+        "end": 5,
+        "loc": {
+          "end": {
+            "column": 2,
+            "line": 3,
+          },
+          "start": {
+            "column": 1,
+            "line": 1,
+          },
+        },
+        "range": [
+          1,
+          5,
+        ],
+        "start": 1,
+        "type": "Literal",
+        "value": "",
+      },
+      "loc": {
+        "end": {
+          "column": 4,
+          "line": 3,
+        },
+        "start": {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": [
+        0,
+        7,
+      ],
+      "start": 0,
+      "type": "ExpressionStatement",
+    },
+  ],
+  "end": 7,
+  "loc": {
+    "end": {
+      "column": 4,
+      "line": 3,
+    },
+    "start": {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": [
+    0,
+    7,
+  ],
+  "sourceType": "script",
+  "start": 0,
+  "type": "Program",
+}
+`;
+
+exports[`StringLiteral > ("\\ "); 1`] = `
+{
+  "body": [
+    {
+      "end": 7,
+      "expression": {
+        "end": 5,
+        "loc": {
+          "end": {
+            "column": 2,
+            "line": 3,
+          },
+          "start": {
+            "column": 1,
+            "line": 1,
+          },
+        },
+        "range": [
+          1,
+          5,
+        ],
+        "start": 1,
+        "type": "Literal",
+        "value": "",
+      },
+      "loc": {
+        "end": {
+          "column": 4,
+          "line": 3,
+        },
+        "start": {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": [
+        0,
+        7,
+      ],
+      "start": 0,
+      "type": "ExpressionStatement",
+    },
+  ],
+  "end": 7,
+  "loc": {
+    "end": {
+      "column": 4,
+      "line": 3,
+    },
+    "start": {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": [
+    0,
+    7,
+  ],
+  "sourceType": "script",
+  "start": 0,
+  "type": "Program",
+}
+`;
+
 exports[`StringLiteral > (" "); 1`] = `
 {
   "body": [

--- a/test/parser/expressions/string.ts
+++ b/test/parser/expressions/string.ts
@@ -3,4 +3,6 @@ import { pass } from '../../test-utils';
 pass('StringLiteral', [
   { code: '("\u2028");', options: { loc: true, ranges: true } },
   { code: '("\u2029");', options: { loc: true, ranges: true } },
+  { code: '("\\\u2028");', options: { loc: true, ranges: true } },
+  { code: '("\\\u2029");', options: { loc: true, ranges: true } },
 ]);


### PR DESCRIPTION
Turns out [#477](https://github.com/meriyah/meriyah/pull/477) is not corret, it should not count a new line when escaped...