### PR TITLE
fix(parser): fix edge case on property definition parsing

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -87,6 +87,6 @@ export default [
     },
   },
   {
-    ignores: ['dist', 'src/unicode.ts', 'test262/test262'],
+    ignores: ['dist', 'src/unicode.ts', 'test.ts', 'test262/test262'],
   },
 ];

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -8348,8 +8348,9 @@ export function parsePropertyDefinition(
     );
 
     if (
-      (parser.getToken() & Token.IsClassField) !== Token.IsClassField ||
-      (parser.getToken() & Token.IsAssignOp) === Token.IsAssignOp
+      (parser.flags & Flags.NewLine) === 0 &&
+      ((parser.getToken() & Token.IsClassField) !== Token.IsClassField ||
+        (parser.getToken() & Token.IsAssignOp) === Token.IsAssignOp)
     ) {
       value = parseMemberOrUpdateExpression(
         parser,

--- a/test/parser/declarations/__snapshots__/class.ts.snap
+++ b/test/parser/declarations/__snapshots__/class.ts.snap
@@ -1,0 +1,69 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Declarations - Class > Declarations - Class (fail) > class A {
+a = () => {}["1"] = 2
+} 1`] = `
+"SyntaxError [2:12-2:13]: Block body arrows can not be immediately invoked without a group
+  1 | class A {
+> 2 | a = () => {}["1"] = 2
+    |             ^ Block body arrows can not be immediately invoked without a group
+  3 | }"
+`;
+
+exports[`Declarations - Class > Declarations - Class (pass) > class A {
+a = () => {}
+["1"] = 2
+} 1`] = `
+{
+  "body": [
+    {
+      "body": {
+        "body": [
+          {
+            "computed": false,
+            "key": {
+              "name": "a",
+              "type": "Identifier",
+            },
+            "static": false,
+            "type": "PropertyDefinition",
+            "value": {
+              "async": false,
+              "body": {
+                "body": [],
+                "type": "BlockStatement",
+              },
+              "expression": false,
+              "generator": false,
+              "params": [],
+              "type": "ArrowFunctionExpression",
+            },
+          },
+          {
+            "computed": true,
+            "key": {
+              "type": "Literal",
+              "value": "1",
+            },
+            "static": false,
+            "type": "PropertyDefinition",
+            "value": {
+              "type": "Literal",
+              "value": 2,
+            },
+          },
+        ],
+        "type": "ClassBody",
+      },
+      "id": {
+        "name": "A",
+        "type": "Identifier",
+      },
+      "superClass": null,
+      "type": "ClassDeclaration",
+    },
+  ],
+  "sourceType": "script",
+  "type": "Program",
+}
+`;

--- a/test/parser/declarations/class.ts
+++ b/test/parser/declarations/class.ts
@@ -2,6 +2,7 @@ import { Context } from '../../../src/common';
 import * as t from 'node:assert/strict';
 import { describe, it } from 'vitest';
 import { parseSource } from '../../../src/parser';
+import { pass, fail } from '../../test-utils';
 
 describe('Declarations - Class', () => {
   // Strict mode errors
@@ -608,4 +609,7 @@ describe('Declarations - Class', () => {
       });
     });
   }
+
+  pass('Declarations - Class (pass)', ['class A {\na = () => {}\n["1"] = 2\n}']);
+  fail('Declarations - Class (fail)', [['class A {\na = () => {}["1"] = 2\n}', Context.None]]);
 });


### PR DESCRIPTION
closes #475

I vaguely recall I read in ecma spec that line break has some effect in class body, but I cannot find that piece of text in ecma now. I will try to find it before merging this one.