### PR TITLE
fix: add missing `AccessorProperty` to `Node`

### DIFF
--- a/src/estree.ts
+++ b/src/estree.ts
@@ -40,6 +40,7 @@ export interface Comment extends _Node {
 }
 
 export type Node =
+  | AccessorProperty
   | ArrayExpression
   | ArrayPattern
   | ArrowFunctionExpression


### PR DESCRIPTION
`AccessorProperty` is currently missing in `Node` type