### PR TITLE
refactor: add `Parser#{createScope,createScopeIfLexical}()`

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -41,7 +41,7 @@ import {
 import { Chars } from './chars';
 import { Parser } from './parser/parser';
 import { type Options, normalizeOptions } from './options';
-import { Scope, ScopeKind, createArrowHeadParsingScope } from './parser/scope';
+import { type Scope, ScopeKind, createArrowHeadParsingScope } from './parser/scope';
 
 /**
  * Consumes a sequence of tokens and produces an syntax tree
@@ -60,7 +60,7 @@ export function parseSource(source: string, rawOptions: Options = {}, context: C
   // See: https://github.com/tc39/proposal-hashbang
   skipHashBang(parser);
 
-  const scope = options.lexical ? new Scope() : void 0;
+  const scope = options.lexical ? parser.createScope() : void 0;
 
   let body: (ESTree.Statement | ReturnType<typeof parseDirective | typeof parseModuleItem>)[] = [];
 
@@ -2113,7 +2113,7 @@ function parseRestrictedIdentifier(parser: Parser, context: Context, scope: Scop
   if (!isValidIdentifier(context, parser.getToken())) parser.report(Errors.UnexpectedStrictReserved);
   if ((parser.getToken() & Token.IsEvalOrArguments) === Token.IsEvalOrArguments)
     parser.report(Errors.StrictEvalArguments);
-  scope?.addBlockName(parser, context, parser.tokenValue, BindingKind.Let, Origin.None);
+  scope?.addBlockName(context, parser.tokenValue, BindingKind.Let, Origin.None);
   return parseIdentifier(parser, context);
 }
 
@@ -2333,7 +2333,7 @@ function parseImportSpecifierOrNamedImports(
       parser.report(Errors.ExpectedToken, KeywordDescTable[Token.AsKeyword & Token.Type]);
     }
 
-    scope?.addBlockName(parser, context, tokenValue, BindingKind.Let, Origin.None);
+    scope?.addBlockName(context, tokenValue, BindingKind.Let, Origin.None);
 
     specifiers.push(
       parser.finishNode<ESTree.ImportSpecifier>(
@@ -4675,7 +4675,7 @@ function parseFunctionDeclaration(
   let funcNameToken: Token | undefined;
 
   // Create a new function scope
-  let functionScope = scope ? new Scope() : void 0;
+  let functionScope = scope ? parser.createScope() : void 0;
 
   if (parser.getToken() === Token.LeftParen) {
     if ((flags & HoistedClassFlags.Hoisted) === 0) parser.report(Errors.DeclNoName, 'Function');
@@ -4691,9 +4691,9 @@ function parseFunctionDeclaration(
 
     if (scope) {
       if (kind & BindingKind.Variable) {
-        scope.addVarName(parser, context, parser.tokenValue, kind);
+        scope.addVarName(context, parser.tokenValue, kind);
       } else {
-        scope.addBlockName(parser, context, parser.tokenValue, kind, origin);
+        scope.addBlockName(context, parser.tokenValue, kind, origin);
       }
 
       functionScope = functionScope?.createChildScope(ScopeKind.FunctionRoot);
@@ -4797,7 +4797,7 @@ function parseFunctionExpression(
   let funcNameToken: Token | undefined;
 
   // Create a new function scope
-  let scope = parser.options.lexical ? new Scope() : void 0;
+  let scope = parser.options.lexical ? parser.createScope() : void 0;
 
   const modifierFlags =
     Context.SuperProperty |
@@ -5006,7 +5006,7 @@ function parseArrayExpressionOrPattern(
 
           nextToken(parser, context | Context.AllowRegExp);
 
-          scope?.addVarOrBlock(parser, context, tokenValue, kind, origin);
+          scope?.addVarOrBlock(context, tokenValue, kind, origin);
 
           const right = parseExpression(parser, context, privateScope, 1, inGroup, parser.tokenStart);
 
@@ -5036,7 +5036,7 @@ function parseArrayExpressionOrPattern(
           if (parser.assignable & AssignmentKind.CannotAssign) {
             destructible |= DestructuringKind.CannotDestruct;
           } else {
-            scope?.addVarOrBlock(parser, context, tokenValue, kind, origin);
+            scope?.addVarOrBlock(context, tokenValue, kind, origin);
           }
           destructible |=
             parser.destructible & DestructuringKind.Yield
@@ -5289,7 +5289,7 @@ function parseSpreadOrRestElement(
     if (parser.assignable & AssignmentKind.CannotAssign) {
       destructible |= DestructuringKind.CannotDestruct;
     } else if (token === closingToken || token === Token.Comma) {
-      scope?.addVarOrBlock(parser, context, tokenValue, kind, origin);
+      scope?.addVarOrBlock(context, tokenValue, kind, origin);
     } else {
       destructible |= DestructuringKind.Assignable;
     }
@@ -5449,7 +5449,7 @@ function parseMethodDefinition(
     Context.InMethodOrFunction |
     Context.AllowNewTarget;
 
-  let scope = parser.options.lexical ? new Scope(ScopeKind.FunctionParams) : void 0;
+  let scope = parser.options.lexical ? parser.createScope(ScopeKind.FunctionParams) : void 0;
 
   const params = parseMethodFormals(
     parser,
@@ -5681,7 +5681,7 @@ function parseObjectLiteralOrPattern(
             validateBindingIdentifier(parser, context, kind, token, 0);
           }
 
-          scope?.addVarOrBlock(parser, context, tokenValue, kind, origin);
+          scope?.addVarOrBlock(context, tokenValue, kind, origin);
 
           if (consumeOpt(parser, context | Context.AllowRegExp, Token.Assign)) {
             destructible |= DestructuringKind.HasToDestruct;
@@ -5730,7 +5730,7 @@ function parseObjectLiteralOrPattern(
                 if (parser.assignable & AssignmentKind.CannotAssign) {
                   destructible |= DestructuringKind.CannotDestruct;
                 } else if ((tokenAfterColon & Token.IsIdentifier) === Token.IsIdentifier) {
-                  scope?.addVarOrBlock(parser, context, valueAfterColon, kind, origin);
+                  scope?.addVarOrBlock(context, valueAfterColon, kind, origin);
                 }
               } else {
                 destructible |=
@@ -5744,7 +5744,7 @@ function parseObjectLiteralOrPattern(
               } else if (token !== Token.Assign) {
                 destructible |= DestructuringKind.Assignable;
               } else {
-                scope?.addVarOrBlock(parser, context, valueAfterColon, kind, origin);
+                scope?.addVarOrBlock(context, valueAfterColon, kind, origin);
               }
               value = parseAssignmentExpression(parser, context, privateScope, inGroup, isPattern, tokenStart, value);
             } else {
@@ -5944,7 +5944,7 @@ function parseObjectLiteralOrPattern(
                 if (parser.assignable & AssignmentKind.CannotAssign) {
                   destructible |= DestructuringKind.CannotDestruct;
                 } else {
-                  scope?.addVarOrBlock(parser, context, valueAfterColon, kind, origin);
+                  scope?.addVarOrBlock(context, valueAfterColon, kind, origin);
                 }
               } else {
                 destructible |=
@@ -6092,7 +6092,7 @@ function parseObjectLiteralOrPattern(
                 if (parser.assignable & AssignmentKind.CannotAssign) {
                   destructible |= DestructuringKind.CannotDestruct;
                 } else if ((tokenAfterColon & Token.IsIdentifier) === Token.IsIdentifier) {
-                  scope?.addVarOrBlock(parser, context, tokenValue, kind, origin);
+                  scope?.addVarOrBlock(context, tokenValue, kind, origin);
                 }
               } else {
                 destructible |=
@@ -6477,7 +6477,7 @@ function parseParenthesizedExpression(
 
   nextToken(parser, context | Context.AllowRegExp | Context.AllowEscapedKeyword);
 
-  const scope = parser.options.lexical ? new Scope().createChildScope(ScopeKind.ArrowParams) : void 0;
+  const scope = parser.options.lexical ? parser.createScope().createChildScope(ScopeKind.ArrowParams) : void 0;
 
   context = (context | Context.DisallowIn) ^ Context.DisallowIn;
 
@@ -6506,7 +6506,7 @@ function parseParenthesizedExpression(
     const token = parser.getToken();
 
     if (token & Token.IsIdentifier) {
-      scope?.addBlockName(parser, context, parser.tokenValue, BindingKind.ArgumentList, Origin.None);
+      scope?.addBlockName(context, parser.tokenValue, BindingKind.ArgumentList, Origin.None);
 
       if ((token & Token.IsEvalOrArguments) === Token.IsEvalOrArguments) {
         isNonSimpleParameterList = 1;
@@ -7329,7 +7329,7 @@ function parseAsyncArrowOrCallExpression(
 ): ESTree.CallExpression | ESTree.ArrowFunctionExpression {
   nextToken(parser, context | Context.AllowRegExp);
 
-  const scope = parser.options.lexical ? new Scope().createChildScope(ScopeKind.ArrowParams) : void 0;
+  const scope = parser.options.lexical ? parser.createScope().createChildScope(ScopeKind.ArrowParams) : void 0;
 
   context = (context | Context.DisallowIn) ^ Context.DisallowIn;
 
@@ -7368,7 +7368,7 @@ function parseAsyncArrowOrCallExpression(
     const token = parser.getToken();
 
     if (token & Token.IsIdentifier) {
-      scope?.addBlockName(parser, context, parser.tokenValue, kind, Origin.None);
+      scope?.addBlockName(context, parser.tokenValue, kind, Origin.None);
 
       if ((token & Token.IsEvalOrArguments) === Token.IsEvalOrArguments) {
         parser.flags |= Flags.StrictEvalArguments;
@@ -7609,7 +7609,7 @@ function parseClassDeclaration(
     if (scope) {
       // A named class creates a new lexical scope with a const binding of the
       // class name for the "inner name".
-      scope.addBlockName(parser, context, tokenValue, BindingKind.Class, Origin.None);
+      scope.addBlockName(context, tokenValue, BindingKind.Class, Origin.None);
 
       if (flags) {
         if (flags & HoistedClassFlags.Export) {
@@ -8344,7 +8344,7 @@ function parseAndClassifyIdentifier(
   const { tokenValue, tokenStart: start } = parser;
   nextToken(parser, context);
 
-  scope?.addVarOrBlock(parser, context, tokenValue, kind, origin);
+  scope?.addVarOrBlock(context, tokenValue, kind, origin);
 
   return parser.finishNode<ESTree.Identifier>(
     {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -60,7 +60,7 @@ export function parseSource(source: string, rawOptions: Options = {}, context: C
   // See: https://github.com/tc39/proposal-hashbang
   skipHashBang(parser);
 
-  const scope = options.lexical ? parser.createScope() : void 0;
+  const scope = parser.createScopeIfLexical();
 
   let body: (ESTree.Statement | ReturnType<typeof parseDirective | typeof parseModuleItem>)[] = [];
 
@@ -4797,7 +4797,7 @@ function parseFunctionExpression(
   let funcNameToken: Token | undefined;
 
   // Create a new function scope
-  let scope = parser.options.lexical ? parser.createScope() : void 0;
+  let scope = parser.createScopeIfLexical();
 
   const modifierFlags =
     Context.SuperProperty |
@@ -5449,7 +5449,7 @@ function parseMethodDefinition(
     Context.InMethodOrFunction |
     Context.AllowNewTarget;
 
-  let scope = parser.options.lexical ? parser.createScope(ScopeKind.FunctionParams) : void 0;
+  let scope = parser.createScopeIfLexical(ScopeKind.FunctionParams);
 
   const params = parseMethodFormals(
     parser,
@@ -6477,7 +6477,7 @@ function parseParenthesizedExpression(
 
   nextToken(parser, context | Context.AllowRegExp | Context.AllowEscapedKeyword);
 
-  const scope = parser.options.lexical ? parser.createScope().createChildScope(ScopeKind.ArrowParams) : void 0;
+  const scope = parser.createScopeIfLexical()?.createChildScope(ScopeKind.ArrowParams);
 
   context = (context | Context.DisallowIn) ^ Context.DisallowIn;
 
@@ -7329,7 +7329,7 @@ function parseAsyncArrowOrCallExpression(
 ): ESTree.CallExpression | ESTree.ArrowFunctionExpression {
   nextToken(parser, context | Context.AllowRegExp);
 
-  const scope = parser.options.lexical ? parser.createScope().createChildScope(ScopeKind.ArrowParams) : void 0;
+  const scope = parser.createScopeIfLexical()?.createChildScope(ScopeKind.ArrowParams);
 
   context = (context | Context.DisallowIn) ^ Context.DisallowIn;
 

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -4,7 +4,7 @@ import type * as ESTree from '../estree';
 import { type Location, Flags, type AssignmentKind, type DestructuringKind } from '../common';
 import { ParseError, type Errors } from '../errors';
 import { type NormalizedOptions, type OnComment, type OnToken } from '../options';
-import { Scope, ScopeKind } from './scope';
+import { Scope, type ScopeKind } from './scope';
 
 export class Parser {
   private lastOnToken: [string, number, number, ESTree.SourceLocation] | null = null;
@@ -221,7 +221,15 @@ export class Parser {
     throw new ParseError(this.tokenStart, this.currentLocation, type, ...params);
   }
 
-  createScope(type: ScopeKind = ScopeKind.Block, parent?: Scope) {
+  createScopeIfLexical(type?: ScopeKind, parent?: Scope) {
+    if (this.options.lexical) {
+      return this.createScope(type, parent);
+    }
+
+    return undefined;
+  }
+
+  createScope(type?: ScopeKind, parent?: Scope) {
     return new Scope(this, type, parent);
   }
 }

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -4,6 +4,7 @@ import type * as ESTree from '../estree';
 import { type Location, Flags, type AssignmentKind, type DestructuringKind } from '../common';
 import { ParseError, type Errors } from '../errors';
 import { type NormalizedOptions, type OnComment, type OnToken } from '../options';
+import { Scope, ScopeKind } from './scope';
 
 export class Parser {
   private lastOnToken: [string, number, number, ESTree.SourceLocation] | null = null;
@@ -218,6 +219,10 @@ export class Parser {
    */
   report(type: Errors, ...params: string[]): never {
     throw new ParseError(this.tokenStart, this.currentLocation, type, ...params);
+  }
+
+  createScope(type: ScopeKind = ScopeKind.Block, parent?: Scope) {
+    return new Scope(this, type, parent);
   }
 }
 

--- a/src/parser/scope.ts
+++ b/src/parser/scope.ts
@@ -35,43 +35,43 @@ export class Scope {
   scopeError?: ScopeError;
 
   constructor(
+    public readonly parser: Parser,
     public readonly type: ScopeKind = ScopeKind.Block,
     public readonly parent?: Scope,
   ) {}
 
   createChildScope(type?: ScopeKind) {
-    return new Scope(type, this);
+    return new Scope(this.parser, type, this);
   }
 
   /**
    * Adds either a var binding or a block scoped binding.
    *
-   * @param parser Parser state
    * @param context Context masks
    * @param name Binding name
    * @param type Binding kind
    * @param origin Binding Origin
    */
-  addVarOrBlock(parser: Parser, context: Context, name: string, kind: BindingKind, origin: Origin) {
+  addVarOrBlock(context: Context, name: string, kind: BindingKind, origin: Origin) {
     if (kind & BindingKind.Variable) {
-      this.addVarName(parser, context, name, kind);
+      this.addVarName(context, name, kind);
     } else {
-      this.addBlockName(parser, context, name, kind, origin);
+      this.addBlockName(context, name, kind, origin);
     }
     if (origin & Origin.Export) {
-      declareUnboundVariable(parser, name);
+      declareUnboundVariable(this.parser, name);
     }
   }
 
   /**
    * Adds a variable binding
    *
-   * @param parser Parser state
    * @param context Context masks
    * @param name Binding name
    * @param type Binding kind
    */
-  addVarName(parser: Parser, context: Context, name: string, kind: BindingKind): void {
+  addVarName(context: Context, name: string, kind: BindingKind): void {
+    const { parser } = this;
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     let currentScope: any = this;
 
@@ -92,7 +92,7 @@ export class Scope {
       }
       if (currentScope === this) {
         if (value & BindingKind.ArgumentList && kind & BindingKind.ArgumentList) {
-          currentScope.recordScopeError(parser, Errors.DuplicateBinding, name);
+          currentScope.recordScopeError(Errors.DuplicateBinding, name);
         }
       }
       if (value & BindingKind.CatchPattern || (value & BindingKind.CatchIdentifier && !parser.options.webcompat)) {
@@ -108,18 +108,18 @@ export class Scope {
   /**
    * Adds block scoped binding
    *
-   * @param parser Parser state
    * @param context Context masks
    * @param name Binding name
    * @param type Binding kind
    * @param origin Binding Origin
    */
-  addBlockName(parser: Parser, context: Context, name: string, kind: BindingKind, origin: Origin) {
+  addBlockName(context: Context, name: string, kind: BindingKind, origin: Origin) {
+    const { parser } = this;
     const value = (this as any)['#' + name];
 
     if (value && (value & BindingKind.Empty) === 0) {
       if (kind & BindingKind.ArgumentList) {
-        this.recordScopeError(parser, Errors.DuplicateBinding, name);
+        this.recordScopeError(Errors.DuplicateBinding, name);
       } else if (
         parser.options.webcompat &&
         (context & Context.Strict) === 0 &&
@@ -143,7 +143,7 @@ export class Scope {
 
     if (this.type & ScopeKind.ArrowParams && value && (value & BindingKind.Empty) === 0) {
       if (kind & BindingKind.ArgumentList) {
-        this.recordScopeError(parser, Errors.DuplicateBinding, name);
+        this.recordScopeError(Errors.DuplicateBinding, name);
       }
     }
 
@@ -161,12 +161,12 @@ export class Scope {
    * @param parser Parser state
    * @param type Errors type
    */
-  recordScopeError(parser: Parser, type: Errors, ...params: string[]) {
+  recordScopeError(type: Errors, ...params: string[]) {
     this.scopeError = {
       type,
       params,
-      start: parser.tokenStart,
-      end: parser.currentLocation,
+      start: this.parser.tokenStart,
+      end: this.parser.currentLocation,
     };
   }
 
@@ -188,7 +188,7 @@ export class Scope {
  * @param value Binding name to be declared
  */
 export function createArrowHeadParsingScope(parser: Parser, context: Context, value: string): Scope {
-  const scope = new Scope().createChildScope(ScopeKind.ArrowParams);
-  scope.addBlockName(parser, context, value, BindingKind.ArgumentList, Origin.None);
+  const scope = parser.createScope().createChildScope(ScopeKind.ArrowParams);
+  scope.addBlockName(context, value, BindingKind.ArgumentList, Origin.None);
   return scope;
 }


### PR DESCRIPTION
So we don't need pass `parser` around.