### PR TITLE
refactor: move `declareUnboundVariable` to `Parser`

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -423,24 +423,6 @@ export function isEqualTagName(elementName: any): any {
 }
 
 /**
- * Appends a name to the `ExportedNames` of the `ExportsList`, and checks
- * for duplicates
- *
- * @see [Link](https://tc39.github.io/ecma262/$sec-exports-static-semantics-exportednames)
- *
- * @param parser Parser object
- * @param name Exported name
- */
-export function declareUnboundVariable(parser: Parser, name: string): void {
-  if (parser.exportedNames !== void 0 && name !== '') {
-    if (parser.exportedNames['#' + name]) {
-      parser.report(Errors.DuplicateExportBinding, name);
-    }
-    parser.exportedNames['#' + name] = 1;
-  }
-}
-
-/**
  * Appends a name to the `ExportedBindings` of the `ExportsList`,
  *
  * @see [Link](https://tc39.es/ecma262/$sec-exports-static-semantics-exportedbindings)

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -26,7 +26,6 @@ import {
   HoistedClassFlags,
   HoistedFunctionFlags,
   addBindingToExports,
-  declareUnboundVariable,
   isEqualTagName,
   isValidStrictMode,
   isValidIdentifier,
@@ -2588,7 +2587,7 @@ function parseExportDeclaration(
     }
 
     // See: https://www.ecma-international.org/ecma-262/9.0/index.html#sec-exports-static-semantics-exportednames
-    if (scope) declareUnboundVariable(parser, 'default');
+    if (scope) parser.declareUnboundVariable('default');
 
     return parser.finishNode<ESTree.ExportDefaultDeclaration>(
       {
@@ -2611,7 +2610,7 @@ function parseExportDeclaration(
       const isNamedDeclaration = consumeOpt(parser, context, Token.AsKeyword);
 
       if (isNamedDeclaration) {
-        if (scope) declareUnboundVariable(parser, parser.tokenValue);
+        if (scope) parser.declareUnboundVariable(parser.tokenValue);
         exported = parseModuleExportName(parser, context);
       }
 
@@ -2711,7 +2710,7 @@ function parseExportDeclaration(
         attributes = parseImportAttributes(parser, context);
 
         if (scope) {
-          tmpExportedNames.forEach((n) => declareUnboundVariable(parser, n));
+          tmpExportedNames.forEach((n) => parser.declareUnboundVariable(n));
         }
       } else {
         if (hasLiteralLocal) {
@@ -2719,7 +2718,7 @@ function parseExportDeclaration(
         }
 
         if (scope) {
-          tmpExportedNames.forEach((n) => declareUnboundVariable(parser, n));
+          tmpExportedNames.forEach((n) => parser.declareUnboundVariable(n));
           tmpExportedBindings.forEach((b) => addBindingToExports(parser, b));
         }
       }
@@ -4696,7 +4695,7 @@ function parseFunctionDeclaration(
 
       if (flags) {
         if (flags & HoistedClassFlags.Export) {
-          declareUnboundVariable(parser, parser.tokenValue);
+          parser.declareUnboundVariable(parser.tokenValue);
         }
       }
     }
@@ -7609,7 +7608,7 @@ function parseClassDeclaration(
 
       if (flags) {
         if (flags & HoistedClassFlags.Export) {
-          declareUnboundVariable(parser, tokenValue);
+          parser.declareUnboundVariable(tokenValue);
         }
       }
     }

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -2,7 +2,7 @@ import { convertTokenType } from '../lexer';
 import { Token } from '../token';
 import type * as ESTree from '../estree';
 import { type Location, Flags, type AssignmentKind, type DestructuringKind } from '../common';
-import { ParseError, type Errors } from '../errors';
+import { ParseError, Errors } from '../errors';
 import { type NormalizedOptions, type OnComment, type OnToken } from '../options';
 import { Scope, type ScopeKind } from './scope';
 import { PrivateScope } from './private-scope';
@@ -90,7 +90,7 @@ export class Parser {
   /**
    *  https://tc39.es/ecma262/#sec-module-semantics-static-semantics-exportednames
    */
-  exportedNames: Record<string, number> = {};
+  exportedNames = new Set<string>();
 
   /**
    * https://tc39.es/ecma262/#sec-exports-static-semantics-exportedbindings
@@ -208,6 +208,24 @@ export class Parser {
     }
 
     return node;
+  }
+
+  /**
+   * Appends a name to the `ExportedNames` of the `ExportsList`, and checks
+   * for duplicates
+   *
+   * @see [Link](https://tc39.github.io/ecma262/$sec-exports-static-semantics-exportednames)
+   *
+   * @param name Exported name
+   */
+  declareUnboundVariable(name: string): void {
+    const { exportedNames } = this;
+    if (name !== '') {
+      if (exportedNames.has(name)) {
+        this.report(Errors.DuplicateExportBinding, name);
+      }
+      exportedNames.add(name);
+    }
   }
 
   /**

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -220,12 +220,12 @@ export class Parser {
    */
   declareUnboundVariable(name: string): void {
     const { exportedNames } = this;
-    if (name !== '') {
-      if (exportedNames.has(name)) {
-        this.report(Errors.DuplicateExportBinding, name);
-      }
-      exportedNames.add(name);
+
+    if (exportedNames.has(name)) {
+      this.report(Errors.DuplicateExportBinding, name);
     }
+
+    exportedNames.add(name);
   }
 
   /**

--- a/src/parser/scope.ts
+++ b/src/parser/scope.ts
@@ -1,5 +1,5 @@
 import { Errors, ParseError } from '../errors';
-import { type Location, declareUnboundVariable, Context, BindingKind, Origin } from '../common';
+import { type Location, Context, BindingKind, Origin } from '../common';
 import { type Parser } from './parser';
 
 /**
@@ -59,7 +59,7 @@ export class Scope {
       this.addBlockName(context, name, kind, origin);
     }
     if (origin & Origin.Export) {
-      declareUnboundVariable(this.parser, name);
+      this.parser.declareUnboundVariable(name);
     }
   }
 

--- a/test/parser/module/__snapshots__/export.ts.snap
+++ b/test/parser/module/__snapshots__/export.ts.snap
@@ -72,6 +72,12 @@ exports[`Module - Export > Module - Export (fail) > const a = 0; export let a; 1
     |                          ^ Duplicate binding 'a'"
 `;
 
+exports[`Module - Export > Module - Export (fail) > const a = 1; export {a as "", a as ""} 1`] = `
+"SyntaxError [1:37-1:38]: Cannot export a duplicate name ''
+> 1 | const a = 1; export {a as "", a as ""}
+    |                                      ^ Cannot export a duplicate name ''"
+`;
+
 exports[`Module - Export > Module - Export (fail) > const a = 1; export {a as "a", a as "a"} 1`] = `
 "SyntaxError [1:39-1:40]: Cannot export a duplicate name 'a'
 > 1 | const a = 1; export {a as "a", a as "a"}

--- a/test/parser/module/__snapshots__/export.ts.snap
+++ b/test/parser/module/__snapshots__/export.ts.snap
@@ -72,6 +72,12 @@ exports[`Module - Export > Module - Export (fail) > const a = 0; export let a; 1
     |                          ^ Duplicate binding 'a'"
 `;
 
+exports[`Module - Export > Module - Export (fail) > const a = 1; export {a as "a", a as "a"} 1`] = `
+"SyntaxError [1:39-1:40]: Cannot export a duplicate name 'a'
+> 1 | const a = 1; export {a as "a", a as "a"}
+    |                                        ^ Cannot export a duplicate name 'a'"
+`;
+
 exports[`Module - Export > Module - Export (fail) > const f = foo; export async function f(){}; 1`] = `
 "SyntaxError [1:37-1:38]: Duplicate binding 'f'
 > 1 | const f = foo; export async function f(){};

--- a/test/parser/module/export.ts
+++ b/test/parser/module/export.ts
@@ -417,6 +417,8 @@ describe('Module - Export', () => {
     { code: 'export async function a() {}\nexport function a() {}', options: { module: true, lexical: true } },
     { code: 'export async function a() {}\nexport const a = 1;', options: { module: true, lexical: true } },
     { code: 'export let a = 1;\nexport async function a() {}', options: { module: true, lexical: true } },
+    { code: 'const a = 1; export {a as "a", a as "a"}', options: { module: true, lexical: true } },
+    { code: 'const a = 1; export {a as "", a as ""}', options: { module: true, lexical: true } },
   ]);
 
   for (const arg of [


### PR DESCRIPTION
- Change `exportedNames` to a `Set`
- Add `Parser#declareUnboundVariable()`
- Fix duplicate export as empty string, and add tests https://github.com/meriyah/meriyah/pull/502#discussion_r2176807681