### PR TITLE
fix(parser): generate unique location info for shorthand pattern

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -5701,7 +5701,7 @@ function parseObjectLiteralOrPattern(
             destructible |=
               (token === Token.AwaitKeyword ? DestructuringKind.Await : 0) |
               (token === Token.EscapedReserved ? DestructuringKind.CannotDestruct : 0);
-            value = parser.options.uniqueKeyInPattern ? Object.assign({}, key) : key;
+            value = parser.options.uniqueKeyInPattern ? parser.cloneIdentifier(key) : key;
           }
         } else if (consumeOpt(parser, context | Context.AllowRegExp, Token.Colon)) {
           const { tokenStart } = parser;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -5692,7 +5692,7 @@ function parseObjectLiteralOrPattern(
             value = parser.finishNode<ESTree.AssignmentPattern>(
               {
                 type: 'AssignmentPattern',
-                left: parser.options.uniqueKeyInPattern ? Object.assign({}, key) : key,
+                left: parser.options.uniqueKeyInPattern ? parser.cloneIdentifier(key) : key,
                 right,
               },
               tokenStart,

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -270,6 +270,24 @@ export class Parser {
 
     return undefined;
   }
+
+  cloneIdentifier(original: ESTree.Identifier): ESTree.Identifier {
+    const node: ESTree.Identifier = { ...original };
+
+    if (this.options.ranges) {
+      node.range = [...original.range!];
+    }
+
+    if (this.options.loc) {
+      node.loc = {
+        ...original.loc,
+        start: { ...original.loc!.start },
+        end: { ...original.loc!.end },
+      };
+    }
+
+    return node;
+  }
 }
 
 export function pushComment(comments: ESTree.Comment[], options: NormalizedOptions): OnComment {

--- a/test/parser/miscellaneous/unique-node.ts
+++ b/test/parser/miscellaneous/unique-node.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import type * as ESTree from '../../../src/estree';
+import { parseSource } from '../../../src/parser';
+
+const assertPropety = (property: ESTree.Property) => {
+  expect(property.type).toBe('Property');
+  expect(property.shorthand).toBe(true);
+  expect(property.key).toEqual(property.value);
+  expect(property.key).not.toBe(property.value);
+  expect(property.key.range).not.toBe(property.value.range);
+  expect(property.key.loc).not.toBe(property.value.loc);
+};
+
+describe('Unique node', () => {
+  it('ObjectExpression', () => {
+    const ast = parseSource('({a})', { uniqueKeyInPattern: true, loc: true, ranges: true });
+    const declaration = ast.body[0] as ESTree.ExpressionStatement;
+    const object = declaration.expression as ESTree.ObjectExpression;
+    const property = object.properties[0] as ESTree.Property;
+    assertPropety(property);
+  });
+
+  it('ObjectPattern', () => {
+    const ast = parseSource('const {a} = {}', { uniqueKeyInPattern: true, loc: true, ranges: true });
+    const declaration = ast.body[0] as ESTree.VariableDeclaration;
+    const pattern = declaration.declarations[0].id as ESTree.ObjectPattern;
+    const property = pattern.properties[0] as ESTree.Property;
+    assertPropety(property);
+  });
+});

--- a/test/parser/miscellaneous/unique-node.ts
+++ b/test/parser/miscellaneous/unique-node.ts
@@ -2,29 +2,54 @@ import { describe, expect, it } from 'vitest';
 import type * as ESTree from '../../../src/estree';
 import { parseSource } from '../../../src/parser';
 
+const parseOption = { source: 'foo.js', uniqueKeyInPattern: true, loc: true, ranges: true };
+
+const assertClone = (nodeA: ESTree.Node, nodeB: ESTree.Node) => {
+  // Same struct
+  expect(nodeA).toEqual(nodeB);
+  // But not same reference
+  expect(nodeA).not.toBe(nodeB);
+  expect(nodeA.range).not.toBe(nodeB.range);
+  expect(nodeA.loc).not.toBe(nodeB.loc);
+  expect(nodeA.loc!.start).not.toBe(nodeB.loc!.start);
+  expect(nodeA.loc!.end).not.toBe(nodeB.loc!.end);
+  expect(nodeA.loc!.source).toBe(parseOption.source);
+};
+
 const assertPropety = (property: ESTree.Property) => {
   expect(property.type).toBe('Property');
   expect(property.shorthand).toBe(true);
-  expect(property.key).toEqual(property.value);
-  expect(property.key).not.toBe(property.value);
-  expect(property.key.range).not.toBe(property.value.range);
-  expect(property.key.loc).not.toBe(property.value.loc);
+  assertClone(property.key, property.value);
+};
+
+const assertAssignmentPattern = (property: ESTree.Property) => {
+  expect(property.type).toBe('Property');
+  expect(property.shorthand).toBe(true);
+  assertClone(property.key, (property.value as ESTree.AssignmentPattern).left);
 };
 
 describe('Unique node', () => {
   it('ObjectExpression', () => {
-    const ast = parseSource('({a})', { uniqueKeyInPattern: true, loc: true, ranges: true });
-    const declaration = ast.body[0] as ESTree.ExpressionStatement;
-    const object = declaration.expression as ESTree.ObjectExpression;
+    const program = parseSource('({a})', parseOption);
+    const expression = program.body[0] as ESTree.ExpressionStatement;
+    const object = expression.expression as ESTree.ObjectExpression;
     const property = object.properties[0] as ESTree.Property;
     assertPropety(property);
   });
 
   it('ObjectPattern', () => {
-    const ast = parseSource('const {a} = {}', { uniqueKeyInPattern: true, loc: true, ranges: true });
-    const declaration = ast.body[0] as ESTree.VariableDeclaration;
+    const program = parseSource('const {a} = {}', parseOption);
+    const declaration = program.body[0] as ESTree.VariableDeclaration;
     const pattern = declaration.declarations[0].id as ESTree.ObjectPattern;
     const property = pattern.properties[0] as ESTree.Property;
     assertPropety(property);
+  });
+
+  it('AssignmentPattern', () => {
+    const program = parseSource('const {a = 1} = {}', parseOption);
+    const declaration = program.body[0] as ESTree.VariableDeclaration;
+    const pattern = declaration.declarations[0].id as ESTree.ObjectPattern;
+    const property = pattern.properties[0] as ESTree.Property;
+    assertAssignmentPattern(property);
   });
 });


### PR DESCRIPTION
I'll fix the shorthand import/export specifiers soon.