### PR TITLE
feat!: remove `uniqueKeyInPattern` option, nodes are always unique in shorthand pattern

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -57,8 +57,6 @@ export interface Options {
   onInsertedSemicolon?: OnInsertedSemicolon;
   // Allows token extraction. Accepts either a callback function or an array
   onToken?: Token[] | OnToken;
-  // Creates unique key for in ObjectPattern when key value are same
-  uniqueKeyInPattern?: boolean;
 }
 
 export type NormalizedOptions = Omit<Options, 'onComment' | 'onToken'> & {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -5692,7 +5692,7 @@ function parseObjectLiteralOrPattern(
             value = parser.finishNode<ESTree.AssignmentPattern>(
               {
                 type: 'AssignmentPattern',
-                left: parser.options.uniqueKeyInPattern ? parser.cloneIdentifier(key) : key,
+                left: parser.cloneIdentifier(key),
                 right,
               },
               tokenStart,
@@ -5701,7 +5701,7 @@ function parseObjectLiteralOrPattern(
             destructible |=
               (token === Token.AwaitKeyword ? DestructuringKind.Await : 0) |
               (token === Token.EscapedReserved ? DestructuringKind.CannotDestruct : 0);
-            value = parser.options.uniqueKeyInPattern ? parser.cloneIdentifier(key) : key;
+            value = parser.cloneIdentifier(key);
           }
         } else if (consumeOpt(parser, context | Context.AllowRegExp, Token.Colon)) {
           const { tokenStart } = parser;

--- a/test/parser/miscellaneous/unique-node.ts
+++ b/test/parser/miscellaneous/unique-node.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type * as ESTree from '../../../src/estree';
 import { parseSource } from '../../../src/parser';
 
-const parseOption = { source: 'foo.js', uniqueKeyInPattern: true, loc: true, ranges: true };
+const parseOption = { source: 'foo.js', loc: true, ranges: true };
 
 const assertClone = (nodeA: ESTree.Node, nodeB: ESTree.Node) => {
   // Same struct


### PR DESCRIPTION
Users should use `Property.shorthand` instead of comparing the reference.

Fixes https://github.com/meriyah/meriyah/issues/509