### PR TITLE
fix: fix start location of `HTMLClose` comment

### DIFF
--- a/src/lexer/scan.ts
+++ b/src/lexer/scan.ts
@@ -184,9 +184,6 @@ export function scanSingleToken(parser: Parser, context: Context, state: LexerSt
 
   const { source } = parser;
 
-  // These three are only for HTMLClose comment
-  let start = parser.currentLocation;
-
   while (parser.index < parser.end) {
     parser.tokenIndex = parser.index;
     parser.tokenColumn = parser.column;
@@ -280,7 +277,6 @@ export function scanSingleToken(parser: Parser, context: Context, state: LexerSt
                 parser.column += 3;
                 parser.currentChar = source.charCodeAt((parser.index += 3));
                 state = skipSingleHTMLComment(parser, source, state, context, CommentType.HTMLOpen, parser.tokenStart);
-                start = parser.tokenStart;
                 continue;
               }
               return Token.LessThan;
@@ -385,8 +381,7 @@ export function scanSingleToken(parser: Parser, context: Context, state: LexerSt
             if ((state & LexerState.NewLine || isStartOfLine) && parser.currentChar === Chars.GreaterThan) {
               if (!parser.options.webcompat) parser.report(Errors.HtmlCommentInWebCompat);
               advanceChar(parser);
-              state = skipSingleHTMLComment(parser, source, state, context, CommentType.HTMLClose, start);
-              start = parser.tokenStart;
+              state = skipSingleHTMLComment(parser, source, state, context, CommentType.HTMLClose, parser.tokenStart);
               continue;
             }
 
@@ -409,13 +404,11 @@ export function scanSingleToken(parser: Parser, context: Context, state: LexerSt
             if (ch === Chars.Slash) {
               advanceChar(parser);
               state = skipSingleLineComment(parser, source, state, CommentType.Single, parser.tokenStart);
-              start = parser.tokenStart;
               continue;
             }
             if (ch === Chars.Asterisk) {
               advanceChar(parser);
               state = skipMultiLineComment(parser, source, state) as LexerState;
-              start = parser.tokenStart;
               continue;
             }
             if (context & Context.AllowRegExp) {

--- a/test/parser/miscellaneous/onComment.ts
+++ b/test/parser/miscellaneous/onComment.ts
@@ -455,11 +455,11 @@ describe('Miscellaneous - onComment', () => {
       {
         type: 'HTMLClose',
         value: ' comment #2',
-        start: 14,
+        start: 15,
         end: 29,
-        range: [14, 29],
+        range: [15, 29],
         loc: {
-          start: { line: 1, column: 14 },
+          start: { line: 2, column: 0 },
           end: { line: 2, column: 14 },
         },
       },
@@ -501,11 +501,11 @@ describe('Miscellaneous - onComment', () => {
       {
         type: 'HTMLClose',
         value: ' comment #2',
-        start: 2,
+        start: 3,
         end: 17,
-        range: [2, 17],
+        range: [3, 17],
         loc: {
-          start: { line: 1, column: 2 },
+          start: { line: 2, column: 0 },
           end: { line: 2, column: 14 },
         },
       },
@@ -535,11 +535,11 @@ describe('Miscellaneous - onComment', () => {
       {
         type: 'HTMLClose',
         value: ' comment #2',
-        start: 7,
+        start: 8,
         end: 22,
-        range: [7, 22],
+        range: [8, 22],
         loc: {
-          start: { line: 3, column: 2 },
+          start: { line: 4, column: 0 },
           end: { line: 4, column: 14 },
         },
       },

--- a/test/test262-parser-tests/ast-alignment-test.ts
+++ b/test/test262-parser-tests/ast-alignment-test.ts
@@ -88,10 +88,6 @@ function parseMeriyah(text: string, sourceType: 'module' | 'script') {
     preserveParens: true,
   }) as MeriyahAst;
 
-  for (const comment of comments) {
-    removeHtmlCloseCommentLocation(comment);
-  }
-
   ast.comments = comments;
   return ast;
 }
@@ -135,18 +131,6 @@ const getSingleLineCommentType = (comment: acorn.Comment, text: string): ESTree.
   return 'SingleLine';
 };
 
-// Acorn and Meriayh can't agree with each other
-// https://github.com/meriyah/meriyah/issues/154
-function removeHtmlCloseCommentLocation(comment: ESTree.Comment) {
-  if (comment.type === 'HTMLClose') {
-    delete comment.start;
-    delete comment.range;
-    delete comment.loc;
-  }
-
-  return comment;
-}
-
 function fixAcornAst(ast: acorn.Program, text: string): MeriyahAst {
   return visitNode(ast, (node: Record<string, any>) => {
     // Convert to plain object
@@ -161,7 +145,7 @@ function fixAcornAst(ast: acorn.Program, text: string): MeriyahAst {
       case 'Line': {
         const type = getSingleLineCommentType(node as acorn.Comment, text);
 
-        return removeHtmlCloseCommentLocation(Object.assign(node, { type }) as ESTree.Comment);
+        return Object.assign(node, { type }) as ESTree.Comment;
       }
       case 'FunctionExpression':
       case 'FunctionDeclaration':


### PR DESCRIPTION
Align location information with Acorn.