### PR TITLE
chore: enable `unicorn/prefer-bigint-literals` rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -81,6 +81,9 @@ export default [
           ],
         },
       ],
+
+      // `eslint-plugin-unicorn`
+      'unicorn/prefer-bigint-literals': 'error',
       'unicorn/prefer-export-from': ['error', { ignoreUsedVariables: true }],
       'unicorn/template-indent': 'error',
 

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "eslint-plugin-import-x": "^4.16.1",
     "eslint-plugin-n": "^17.20.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
-    "eslint-plugin-unicorn": "^59.0.1",
+    "eslint-plugin-unicorn": "^61.0.0",
     "globals": "^16.2.0",
     "husky": "^9.1.7",
     "knip": "^5.61.3",

--- a/test/lexer/numbers.ts
+++ b/test/lexer/numbers.ts
@@ -160,20 +160,20 @@ describe('Lexer - Numberic literals', () => {
     [Context.None, Token.NumericLiteral, '0000000000234567454548', 234567454548],
 
     // BigInt
-    [Context.None, Token.BigIntLiteral, '1n', BigInt(1)],
-    [Context.None, Token.BigIntLiteral, '0o45n', BigInt(37)],
-    [Context.None, Token.BigIntLiteral, '0b10n', BigInt(2)],
-    [Context.None, Token.BigIntLiteral, '0x9an', BigInt(154)],
-    [Context.None, Token.BigIntLiteral, '9007199254740991n', BigInt(9007199254740991)],
-    [Context.None, Token.BigIntLiteral, '100000000000000000n', BigInt(100000000000000000)],
-    [Context.None, Token.BigIntLiteral, '123456789000000000000000n', BigInt('123456789000000000000000'), { raw: true }],
-    [Context.None, Token.BigIntLiteral, '0xfn', BigInt(15)],
-    [Context.None, Token.BigIntLiteral, '0n', BigInt(0)],
+    [Context.None, Token.BigIntLiteral, '1n', 1n],
+    [Context.None, Token.BigIntLiteral, '0o45n', 37n],
+    [Context.None, Token.BigIntLiteral, '0b10n', 2n],
+    [Context.None, Token.BigIntLiteral, '0x9an', 154n],
+    [Context.None, Token.BigIntLiteral, '9007199254740991n', 9007199254740991n],
+    [Context.None, Token.BigIntLiteral, '100000000000000000n', 100000000000000000n],
+    [Context.None, Token.BigIntLiteral, '123456789000000000000000n', 123456789000000000000000n, { raw: true }],
+    [Context.None, Token.BigIntLiteral, '0xfn', 15n],
+    [Context.None, Token.BigIntLiteral, '0n', 0n],
     [
       Context.None,
       Token.BigIntLiteral,
       '0x12300000000000000000000000000000000n',
-      BigInt('99022168773993092867842010762644549533696'),
+      99022168773993092867842010762644549533696n,
     ],
 
     // Numeric separators


### PR DESCRIPTION
[unicorn/prefer-bigint-literals](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-bigint-literals.md)

This is actually how I came up with the idea for this rule.