### PR TITLE
chore: npm pkg delete is not necessary before npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,5 +21,4 @@ jobs:
           cache-dependency-path: ./package.json
       - run: yarn
       - run: npm run build
-      - run: npm pkg delete scripts devDependencies lint-staged
       - run: npm publish


### PR DESCRIPTION
Our package.json has "files" field, which tells "npm publish" what files to be included in the final npm package. You can verify this with "npm run build" then "npm package" (build the pkg without publish).