### PR TITLE
Fix the error range for strict reserved parameters

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3424,7 +3424,16 @@ function parseFunctionBody(
         }
       }
       if (parser.flags & Flags.StrictEvalArguments) parser.report(Errors.StrictEvalArguments);
-      if (parser.flags & Flags.HasStrictReserved) parser.report(Errors.UnexpectedStrictReserved);
+      if (parser.flags & Flags.HasStrictReserved) {
+        if (parser.strictReservedRange) {
+          throw new ParseError(
+            parser.strictReservedRange[0],
+            parser.strictReservedRange[1],
+            Errors.UnexpectedStrictReserved,
+          );
+        }
+        parser.report(Errors.UnexpectedStrictReserved);
+      }
     }
   }
 
@@ -6310,6 +6319,7 @@ function parseMethodFormals(
   const params: (ESTree.AssignmentPattern | ESTree.Parameter)[] = [];
 
   parser.flags = (parser.flags | Flags.NonSimpleParameterList) ^ Flags.NonSimpleParameterList;
+  parser.strictReservedRange = null;
 
   if (parser.getToken() === Token.RightParen) {
     if (kind & PropertyKind.Setter) {
@@ -6339,6 +6349,7 @@ function parseMethodFormals(
       if ((context & Context.Strict) === 0) {
         if ((parser.getToken() & Token.FutureReserved) === Token.FutureReserved) {
           parser.flags |= Flags.HasStrictReserved;
+          parser.strictReservedRange ??= [tokenStart, parser.currentLocation];
         }
 
         if ((parser.getToken() & Token.IsEvalOrArguments) === Token.IsEvalOrArguments) {
@@ -6952,6 +6963,7 @@ function parseFormalParametersOrFormalList(
   consume(parser, context, Token.LeftParen);
 
   parser.flags = (parser.flags | Flags.NonSimpleParameterList) ^ Flags.NonSimpleParameterList;
+  parser.strictReservedRange = null;
 
   const params: ESTree.Parameter[] = [];
 
@@ -6971,6 +6983,7 @@ function parseFormalParametersOrFormalList(
       if ((context & Context.Strict) === 0) {
         if ((token & Token.FutureReserved) === Token.FutureReserved) {
           parser.flags |= Flags.HasStrictReserved;
+          parser.strictReservedRange ??= [tokenStart, parser.currentLocation];
         }
         if ((token & Token.IsEvalOrArguments) === Token.IsEvalOrArguments) {
           parser.flags |= Flags.StrictEvalArguments;

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -111,6 +111,14 @@ export class Parser {
   destructible = DestructuringKind.None;
 
   /**
+   * Source range of the first strict-mode reserved word seen in a parameter
+   * list while strict mode was not yet known (e.g. a future-reserved parameter
+   * name). Used to report a later `"use strict"` directive error at the
+   * offending parameter instead of the current token. Reset per parameter list.
+   */
+  strictReservedRange: [Location, Location] | null = null;
+
+  /**
    * Holds leading decorators before "export" or "class" keywords
    */
   leadingDecorators: {

--- a/test/parser/declarations/__snapshots__/functions.ts.snap
+++ b/test/parser/declarations/__snapshots__/functions.ts.snap
@@ -3015,9 +3015,9 @@ exports[`Declarations - Function > Declarations - Functions (fail) > function fo
 `;
 
 exports[`Declarations - Function > Declarations - Functions (fail) > function foo(p\\u0061ckage) { "use strict"; } 1`] = `
-"SyntaxError [1:43-1:44]: Unexpected strict mode reserved word
+"SyntaxError [1:13-1:25]: Unexpected strict mode reserved word
 > 1 | function foo(p\\u0061ckage) { "use strict"; }
-    |                                            ^ Unexpected strict mode reserved word"
+    |              ^^^^^^^^^^^^ Unexpected strict mode reserved word"
 `;
 
 exports[`Declarations - Function > Declarations - Functions (fail) > function foo(p\\x61ckage) { "use strict"; } 1`] = `
@@ -3033,9 +3033,15 @@ exports[`Declarations - Function > Declarations - Functions (fail) > function fo
 `;
 
 exports[`Declarations - Function > Declarations - Functions (fail) > function foo(package) { "use strict"; } 1`] = `
-"SyntaxError [1:38-1:39]: Unexpected strict mode reserved word
+"SyntaxError [1:13-1:20]: Unexpected strict mode reserved word
 > 1 | function foo(package) { "use strict"; }
-    |                                       ^ Unexpected strict mode reserved word"
+    |              ^^^^^^^ Unexpected strict mode reserved word"
+`;
+
+exports[`Declarations - Function > Declarations - Functions (fail) > function foo(package, public) { "use strict"; } 1`] = `
+"SyntaxError [1:13-1:20]: Unexpected strict mode reserved word
+> 1 | function foo(package, public) { "use strict"; }
+    |              ^^^^^^^ Unexpected strict mode reserved word"
 `;
 
 exports[`Declarations - Function > Declarations - Functions (fail) > function super() {"use strict";} 1`] = `
@@ -3078,6 +3084,12 @@ exports[`Declarations - Function > Declarations - Functions (fail) > function w(
 "SyntaxError [1:25-1:33]: Without web compatibility enabled functions can not be declared at top level, inside a block, or as the body of an if statement
 > 1 | function w(casecase){y:j:function casecase(){}}
     |                          ^^^^^^^^ Without web compatibility enabled functions can not be declared at top level, inside a block, or as the body of an if statement"
+`;
+
+exports[`Declarations - Function > Declarations - Functions (fail) > o = {foo(package){ "use strict"; }} 1`] = `
+"SyntaxError [1:9-1:16]: Unexpected strict mode reserved word
+> 1 | o = {foo(package){ "use strict"; }}
+    |          ^^^^^^^ Unexpected strict mode reserved word"
 `;
 
 exports[`Declarations - Function > Declarations - Functions (fail) > o = {foo(x = implements = y){ "use strict"; }} 1`] = `

--- a/test/parser/declarations/functions.ts
+++ b/test/parser/declarations/functions.ts
@@ -156,6 +156,8 @@ describe('Declarations - Function', () => {
     { code: 'function await() {}', options: { sourceType: 'module' } },
     { code: 'function *await() {}', options: { sourceType: 'module' } },
     'function foo(package) { "use strict"; }',
+    'function foo(package, public) { "use strict"; }',
+    'o = {foo(package){ "use strict"; }}',
     String.raw`function foo(p\x61ckage) { }`,
     String.raw`function foo(p\x61ckage) { "use strict"; }`,
     String.raw`function foo(p\141ckage) { }`,


### PR DESCRIPTION
When a `"use strict"` directive appeared inside a function body, Meriyah could report a strict reserved parameter error near the end of the body instead of at the parameter itself.
The parser now keeps the first future-reserved parameter range while strictness is still unknown and uses that range if the later directive makes it invalid. I checked the red-to-green repro, 981 focused parser tests, the full suite with 94,304 passing, Unicode tests, lint, build, and `git diff --check`.
Fixes #470