### PR TITLE
fix: accept \8 and \9 escapes in sloppy mode

### DIFF
--- a/src/lexer/string.ts
+++ b/src/lexer/string.ts
@@ -218,7 +218,7 @@ export function parseEscape(parser: Parser, context: Context, first: number, isT
     // `8`, `9` (invalid escapes)
     case Chars.Eight:
     case Chars.Nine:
-      if (isTemplate || !parser.options.webcompat || context & Context.Strict) return Escape.EightOrNine;
+      if (isTemplate || context & Context.Strict) return Escape.EightOrNine;
       parser.flags |= Flags.EightAndNine;
     // fallthrough
     default:

--- a/test/lexer/strings.ts
+++ b/test/lexer/strings.ts
@@ -140,10 +140,14 @@ describe('Lexer - String', () => {
     [Context.None, Token.StringLiteral, String.raw`"\104"`, 'D'],
     [Context.None, Token.StringLiteral, String.raw`"\221"`, ''],
 
-    // \8 \9 are acceptable in web compatibility mode
+    // \8 \9 (NonOctalDecimalEscapeSequence) are acceptable in sloppy mode (Annex B.1.2)
     [Context.None, Token.StringLiteral, String.raw`"\8"`, '8', { webcompat: true }],
     [Context.None, Token.StringLiteral, String.raw`"\9"`, '9', { webcompat: true }],
     [Context.None, Token.StringLiteral, String.raw`"a\9999"`, 'a9999', { webcompat: true }],
+    [Context.None, Token.StringLiteral, String.raw`"\8"`, '8'],
+    [Context.None, Token.StringLiteral, String.raw`"\9"`, '9'],
+    [Context.None, Token.StringLiteral, String.raw`"\9999"`, '9999'],
+    [Context.None, Token.StringLiteral, String.raw`"\9b"`, '9b'],
 
     // Line continuation
     [Context.None, Token.StringLiteral, '"a\\\nb"', 'ab'],
@@ -206,7 +210,6 @@ describe('Lexer - String', () => {
     });
   }
 
-  fail(String.raw`fails on "\9999"`, String.raw`"\9999"`, Context.None);
   // fail('fails on "\\08"', '"\\08"', Context.Strict);
   fail(String.raw`fails on "\1"`, String.raw`"\1"`, Context.Strict);
   fail('fails on "foo', '"foo', Context.None);
@@ -220,8 +223,6 @@ describe('Lexer - String', () => {
   fail(String.raw`fails on "\u{70"`, String.raw`"\u{70"`, Context.None, { next: true });
   fail(String.raw`fails on "\u{!"`, String.raw`"\u{!"`, Context.None);
   fail(String.raw`fails on "\u"`, String.raw`"\u"`, Context.None);
-  fail(String.raw`fails on "\8"`, String.raw`"\8"`, Context.None);
-  fail(String.raw`fails on "\9`, String.raw`"\9"`, Context.None);
   fail(String.raw`fails on "\"`, String.raw`"\"`, Context.None);
   fail(String.raw`fails on "\u{10401"`, String.raw`"\u{10401"`, Context.None);
   fail(String.raw`fails on "\u{110000}"`, String.raw`"\u{110000}"`, Context.None);
@@ -251,7 +252,6 @@ describe('Lexer - String', () => {
   fail(String.raw`fails on "\6"`, String.raw`"\6"`, Context.Strict);
   fail(String.raw`fails on "\8"`, String.raw`"\8"`, Context.Strict);
   fail(String.raw`fails on "\9b"`, String.raw`"\9b"`, Context.Strict);
-  fail(String.raw`fails on "\9b"`, String.raw`"\9b"`, Context.None);
   fail(String.raw`fails on "\1"`, String.raw`"\1"`, Context.Strict);
   fail(String.raw`fails on "\01"`, String.raw`"\01"`, Context.Strict);
   fail(String.raw`fails on "\21"`, String.raw`"\21"`, Context.Strict);

--- a/test/lexer/template.ts
+++ b/test/lexer/template.ts
@@ -166,7 +166,6 @@ describe('Lexer - Template', () => {
     });
   }
 
-  fail(String.raw`fails on "\9999"`, String.raw`"\9999"`, Context.None);
   fail('fails on "foo', '"foo', Context.None);
   fail(String.raw`fails on "\u007"`, String.raw`"\u007"`, Context.None, { next: true });
   fail(String.raw`fails on "\u007Xvwxyz"`, String.raw`"\u007Xvwxyz"`, Context.None, { next: true });
@@ -177,8 +176,6 @@ describe('Lexer - Template', () => {
   fail(String.raw`fails on "\u{70"`, String.raw`"\u{70"`, Context.None, { next: true });
   fail(String.raw`fails on "\u{!"`, String.raw`"\u{!"`, Context.None);
   fail(String.raw`fails on "\u"`, String.raw`"\u"`, Context.None);
-  fail(String.raw`fails on "\8"`, String.raw`"\8"`, Context.None);
-  fail(String.raw`fails on "\9`, String.raw`"\9"`, Context.None);
   fail(String.raw`fails on "\"`, String.raw`"\"`, Context.None);
   fail(String.raw`fails on "\u{10401"`, String.raw`"\u{10401"`, Context.None);
   fail(String.raw`fails on "\u{110000}"`, String.raw`"\u{110000}"`, Context.None);
@@ -208,7 +205,6 @@ describe('Lexer - Template', () => {
   fail(String.raw`fails on "\6"`, String.raw`"\6"`, Context.Strict);
   fail(String.raw`fails on "\8"`, String.raw`"\8"`, Context.Strict);
   fail(String.raw`fails on "\9b"`, String.raw`"\9b"`, Context.Strict);
-  fail(String.raw`fails on "\9b"`, String.raw`"\9b"`, Context.None);
   fail(String.raw`fails on "\1"`, String.raw`"\1"`, Context.Strict);
   fail(String.raw`fails on "\01"`, String.raw`"\01"`, Context.Strict);
   fail(String.raw`fails on "\21"`, String.raw`"\21"`, Context.Strict);


### PR DESCRIPTION
## Problem

In sloppy mode under default options (`webcompat: false`), meriyah throws on `\8` and `\9` escapes in string literals, while accepting every other Annex B escape (`\7`, `\07`, `0777`, `08`, `09`).

ES2026 Annex B.1.2 places `\1`-`\7` (LegacyOctalEscapeSequence) and `\8`/`\9` (NonOctalDecimalEscapeSequence) in one `EscapeSequence` production, governed by a single early-error rule that is a Syntax Error only in strict mode. V8 (Node) and acorn both accept all of `\1`-`\9` in sloppy mode and reject them in strict mode. meriyah was uniquely gating `\8`/`\9` behind the `webcompat` option, diverging from that production.

## Fix

Drop the `!parser.options.webcompat` term in `src/lexer/string.ts` so `\8`/`\9` follow the same sloppy path as `\1`-`\7`. Strict-mode rejection still happens via the existing `context & Context.Strict` check, and template literals still reject via `isTemplate`.

## Behavior after fix

- sloppy `"\8"` / `"\9"` accepted (was rejected)
- strict `"\8"` / `"\9"` still rejected
- module (implicit strict) still rejects
- template `` `\8` `` still rejects

## Tests

Added positive sloppy-accept cases for `\8`, `\9`, `\9999`, `\9b` and removed the eight now-obsolete sloppy negative cases in `test/lexer/strings.ts` and `test/lexer/template.ts`. The strict negative cases are untouched.

Verified red before / green after: with the source line reverted the new positive cases fail; with the fix the full suite passes (94302 tests).
