### PR TITLE
fix: reject empty unicode code point escape \u{}

### DIFF
--- a/src/lexer/string.ts
+++ b/src/lexer/string.ts
@@ -188,12 +188,14 @@ export function parseEscape(parser: Parser, context: Context, first: number, isT
 
       if (parser.currentChar === Chars.LeftBrace) {
         let code = 0;
+        let digits = 0;
         while ((CharTypes[advanceChar(parser)] & CharFlags.Hex) !== 0) {
           code = (code << 4) | toHex(parser.currentChar);
           if (code > Chars.NonBMPMax) return Escape.OutOfRange;
+          digits++;
         }
 
-        if (parser.currentChar < 1 || (parser.currentChar as number) !== Chars.RightBrace) {
+        if (digits === 0 || parser.currentChar < 1 || (parser.currentChar as number) !== Chars.RightBrace) {
           return Escape.InvalidHex;
         }
         return code;

--- a/test/lexer/strings.ts
+++ b/test/lexer/strings.ts
@@ -216,7 +216,7 @@ describe('Lexer - String', () => {
   fail('fails on "foo', '"foo', Context.None);
   fail(String.raw`fails on "\u{1F_639}"`, String.raw`"\u{1F_639}"`, Context.None, { next: true });
   fail(String.raw`fails on "\u007Xvwxyz"`, String.raw`"\u007Xvwxyz"`, Context.None, { next: true });
-  //fail('fails on "abc\\u{}"', '"abc\\u{}"', Context.None, { next: true });
+  fail(String.raw`fails on "abc\u{}"`, String.raw`"abc\u{}"`, Context.None, { next: true });
   fail(String.raw`fails on "abc\u}"`, String.raw`"abc\u}"`, Context.None, { next: true });
   fail(String.raw`fails on "abc\u{`, String.raw`"abc\u{"`, Context.None, { next: true });
   fail(String.raw`fails on "\u{70bc"`, String.raw`"\u{70bc"`, Context.None, { next: true });

--- a/test/parser/expressions/__snapshots__/template.ts.snap
+++ b/test/parser/expressions/__snapshots__/template.ts.snap
@@ -168,6 +168,12 @@ exports[`Expressions - Template > Expressions - Template (fail) > \`\\30\` 1`] =
     | ^^ Octal escape sequences are not allowed in template strings"
 `;
 
+exports[`Expressions - Template > Expressions - Template (fail) > \`\\u{}\` 1`] = `
+"SyntaxError [1:0-1:4]: Invalid hexadecimal escape sequence
+> 1 | \`\\u{}\`
+    | ^^^^ Invalid hexadecimal escape sequence"
+`;
+
 exports[`Expressions - Template > Expressions - Template (fail) > \`\\u{11ffff}\${ 1`] = `
 "SyntaxError [1:0-1:9]: Unicode codepoint must not be greater than 0x10FFFF
 > 1 | \`\\u{11ffff}\${

--- a/test/parser/expressions/template.ts
+++ b/test/parser/expressions/template.ts
@@ -439,6 +439,7 @@ describe('Expressions - Template', () => {
     '`\\001`',
     '`a${await foo}d`',
     '`\\u{g}`',
+    '`\\u{}`',
     '`\\u00g0`',
     '`\\ufffg${',
     '`\\uAA`',


### PR DESCRIPTION
A delimited unicode escape must contain at least one hex digit, so `\u{}` is not a valid escape. The lexer read it as code point 0, which made `"\u{}"` and an untagged `` `\u{}` `` parse as valid and gave a tagged template a `cooked` value of the null character instead of `null`. V8 and acorn both reject `\u{}`.

This requires at least one hex digit in the `\u{...}` form. The repo already had a disabled test for this exact case in `test/lexer/strings.ts`, which this re-enables.
