### PR TITLE
fix: treat let as identifier before in and instanceof

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1534,7 +1534,7 @@ function parseLetIdentOrVarDeclarationStatement(
   const token = parser.getToken();
   let expr: ESTree.Identifier | ESTree.Expression = parseIdentifier(parser, context);
 
-  if (parser.getToken() & (Token.IsIdentifier | Token.IsPatternStart)) {
+  if (parser.getToken() & (Token.IsIdentifier | Token.IsPatternStart) && (parser.getToken() & Token.IsBinaryOp) === 0) {
     /* VariableDeclarations ::
      *  ('let') (Identifier ('=' AssignmentExpression)?)+[',']
      */

--- a/test/parser/declarations/__snapshots__/let.ts.snap
+++ b/test/parser/declarations/__snapshots__/let.ts.snap
@@ -4021,6 +4021,54 @@ exports[`Declarations - Let > Declarations - Let (pass) > let foo; 1`] = `
 }
 `;
 
+exports[`Declarations - Let > Declarations - Let (pass) > let in x 1`] = `
+{
+  "body": [
+    {
+      "expression": {
+        "left": {
+          "name": "let",
+          "type": "Identifier",
+        },
+        "operator": "in",
+        "right": {
+          "name": "x",
+          "type": "Identifier",
+        },
+        "type": "BinaryExpression",
+      },
+      "type": "ExpressionStatement",
+    },
+  ],
+  "sourceType": "script",
+  "type": "Program",
+}
+`;
+
+exports[`Declarations - Let > Declarations - Let (pass) > let instanceof x 1`] = `
+{
+  "body": [
+    {
+      "expression": {
+        "left": {
+          "name": "let",
+          "type": "Identifier",
+        },
+        "operator": "instanceof",
+        "right": {
+          "name": "x",
+          "type": "Identifier",
+        },
+        "type": "BinaryExpression",
+      },
+      "type": "ExpressionStatement",
+    },
+  ],
+  "sourceType": "script",
+  "type": "Program",
+}
+`;
+
 exports[`Declarations - Let > Declarations - Let (pass) > let(); 1`] = `
 {
   "body": [

--- a/test/parser/declarations/let.ts
+++ b/test/parser/declarations/let.ts
@@ -579,6 +579,8 @@ describe('Declarations - Let', () => {
   ]);
 
   pass('Declarations - Let (pass)', [
+    'let in x',
+    'let instanceof x',
     'for (let {[x]: y = z} of obj);',
     '[x = true] = y',
     'let [,] = x;',


### PR DESCRIPTION
At statement start in sloppy mode, `let in x` and `let instanceof x` are expressions where `let` is an identifier reference, which V8 and acorn accept. The disambiguation test matched on the keyword bit that `in` and `instanceof` share with binding identifiers, so the parser entered the variable declaration branch and reported the operator as an invalid binding name.

This skips the declaration branch when the token after `let` is a binary operator, mirroring the for-statement head, which already treats `let in` as an expression. Adds pass cases for both operators.
