### PR TITLE
refactor: import version with `{type: 'json'}`

### DIFF
--- a/src/meriyah.ts
+++ b/src/meriyah.ts
@@ -1,11 +1,9 @@
-// Current version
-import { version as pkgVersion } from '../package.json';
+import packageJson from '../package.json' with { type: 'json' };
 import { type Program } from './estree.ts';
 import { type Options } from './options.ts';
 import { parseSource } from './parser.ts';
 
-// This bypass troublesome package.json in generated d.ts file.
-const version: string = pkgVersion;
+export const { version } = packageJson;
 
 /**
  * @deprecated Use `parser()` with `sourceType: 'script'` instead.
@@ -32,6 +30,6 @@ export function parse(source: string, options?: Options): Program {
   return parseSource(source, options);
 }
 
-export { type Options, version };
+export { type Options } from './options.ts';
 export type * as ESTree from './estree.ts';
 export { isParseError, type ParseError } from './errors.ts';


### PR DESCRIPTION
JS files and d.ts files have the expected result and correct type.

<details>
<summary>meriyah.d.ts</summary>

```ts
import { type Program } from './estree.ts';
import { type Options } from './options.ts';
export declare const version: string;
export declare function parseScript(source: string, options?: Omit<Options, 'sourceType'>): Program;
export declare function parseModule(source: string, options?: Omit<Options, 'sourceType'>): Program;
export declare function parse(source: string, options?: Options): Program;
export { type Options } from './options.ts';
export type * as ESTree from './estree.ts';
export { isParseError, type ParseError } from './errors.ts';
```

</details>