### PR TITLE
test: fail tests if previously failed tests get fixed

### DIFF
--- a/test/conformance/ast-alignment-test.ts
+++ b/test/conformance/ast-alignment-test.ts
@@ -13,8 +13,6 @@ const notAlignedTests = new Set([
   'language/expressions/template-literal/tv-line-continuation.js',
   'language/expressions/template-literal/tv-line-terminator-sequence.js',
   'built-ins/String/raw/special-characters.js',
-
-  'staging/sm/Function/function-name-computed-01.js',
 ]);
 
 it(

--- a/test/conformance/ast-alignment-test.ts
+++ b/test/conformance/ast-alignment-test.ts
@@ -13,6 +13,8 @@ const notAlignedTests = new Set([
   'language/expressions/template-literal/tv-line-continuation.js',
   'language/expressions/template-literal/tv-line-terminator-sequence.js',
   'built-ins/String/raw/special-characters.js',
+
+  'staging/sm/Function/function-name-computed-01.js',
 ]);
 
 it(
@@ -49,13 +51,11 @@ function runTest(testCase: TestCase) {
   const meriyahAst = parseMeriyah(testCase.contents, testCase.sourceType);
 
   const isNotAlignedTest = notAlignedTests.has(testCase.file);
+  let passed;
 
   try {
     t.deepEqual(meriyahAst, acornAst);
-
-    if (isNotAlignedTest) {
-      console.log(`'${testCase.file}' now have the same AST shape as Acorn, please remove from the 'notAlignedTests'.`);
-    }
+    passed = true;
   } catch (error) {
     if (isNotAlignedTest) {
       return;
@@ -67,6 +67,12 @@ function runTest(testCase: TestCase) {
       );
     console.error(testCase);
     throw error;
+  }
+
+  if (isNotAlignedTest && passed) {
+    throw new Error(
+      `'${testCase.file}' now have the same AST shape as Acorn, please remove from the 'notAlignedTests'.`,
+    );
   }
 }
 

--- a/test/conformance/jsx-ast-alignment-test.ts
+++ b/test/conformance/jsx-ast-alignment-test.ts
@@ -41,13 +41,11 @@ function runTest(testCase: (typeof jsxTestSuite)[number]) {
   const meriyahAst = parseMeriyah(testCase.input);
 
   const isNotAlignedTest = notAlignedTests.has(testCase.name);
+  let passed;
 
   try {
     t.deepEqual(meriyahAst, acornAst);
-
-    if (isNotAlignedTest) {
-      console.log(`'${testCase.name}' now have the same AST shape as Acorn, please remove from the 'notAlignedTests'.`);
-    }
+    passed = true;
   } catch (error) {
     if (isNotAlignedTest) {
       return;
@@ -59,6 +57,12 @@ function runTest(testCase: (typeof jsxTestSuite)[number]) {
       );
     console.error(testCase);
     throw error;
+  }
+
+  if (isNotAlignedTest && passed) {
+    throw new Error(
+      `'${testCase.name}' now have the same AST shape as Acorn, please remove from the 'notAlignedTests'.`,
+    );
   }
 }
 


### PR DESCRIPTION
Work as expected 

```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  test/conformance/ast-alignment-test.ts > AST alignment with Acorn
Error: 'staging/sm/Function/function-name-computed-01.js' now have the same AST shape as Acorn, please remove from the 'notAlignedTests'.
 ❯ runTest test/conformance/ast-alignment-test.ts:73:11
     71|
     72|   if (isNotAlignedTest && passed) {
     73|     throw new Error(
       |           ^
     74|       `'${testCase.file}' now have the same AST shape as Acorn, please…
     75|     );

 ❯ test/conformance/ast-alignment-test.ts:34:7

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯

 Test Files  1 failed | 141 passed (142)
      Tests  1 failed | 94326 passed (94327)
   Start at  08:36:12
   Duration  103.70s (transform 3.86s, setup 0ms, import 23.42s, tests 155.26s, environment 24ms)
```

https://github.com/meriyah/meriyah/actions/runs/29146350683/job/86528457601?pr=578#step:8:176