### PR TITLE
fix: `import` removed from export map

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "exports": {
     "types": "./dist/types/meriyah.d.ts",
     "module-sync": "./dist/meriyah.mjs",
+    "import": "./dist/meriyah.mjs",
     "require": "./dist/meriyah.cjs",
     "default": "./dist/meriyah.mjs"
   },


### PR DESCRIPTION
6.1.0 dropped the `import` condition that 5.0.0/6.0.0 had. While `module-sync`/`default` still point at the identical file, tools that don't yet recognize `module-sync` (confirmed: `@rollup/plugin-commonjs`, and by extension Nitro/Vinxi's standalone-output tracing) silently fail to resolve the package.

I am attempting to fix this in `@rollup/plugin-commonjs` but including `import` will fix this for users before the root cause fix trickles down.