### PR TITLE
fix(parser): restrict decorator expressions to the decorators grammar

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -8288,9 +8288,78 @@ function parseDecoratorList(
   nextToken(parser, context | Context.AllowRegExp);
   const expressionStart = parser.tokenStart;
 
-  let expression = parsePrimaryExpression(parser, context, privateScope, BindingKind.Empty, 0, 1, 0, 1, start);
+  let expression: ESTree.Decorator['expression'];
 
-  expression = parseMemberOrUpdateExpression(parser, context, privateScope, expression, 0, 0, expressionStart);
+  if (parser.getToken() === Token.LeftParen) {
+    expression = parsePrimaryExpression(parser, context, privateScope, BindingKind.Empty, 0, 1, 0, 1, start);
+  } else {
+    const token = parser.getToken();
+
+    if (
+      ((token & Token.IsIdentifier) !== Token.IsIdentifier && !isValidIdentifier(context, token)) ||
+      (context & Context.Strict && (token & Token.FutureReserved) === Token.FutureReserved)
+    ) {
+      parser.report(Errors.UnexpectedToken, KeywordDescTable[token & Token.Type]);
+    }
+
+    if (token === Token.AwaitKeyword && context & (Context.InAwaitContext | Context.Module)) {
+      parser.report(Errors.AwaitIdentInModuleOrAsyncFunc);
+    }
+
+    if (token === Token.YieldKeyword && context & Context.InYieldContext) {
+      parser.report(Errors.DisallowedInContext, 'yield');
+    }
+
+    let memberExpression: ESTree.Identifier | ESTree.MemberExpression = parseIdentifier(
+      parser,
+      context | Context.TaggedTemplate,
+    );
+
+    parser.assignable =
+      context & Context.Strict && (token & Token.IsEvalOrArguments) === Token.IsEvalOrArguments
+        ? AssignmentTargetKind.Invalid
+        : AssignmentTargetKind.Simple;
+
+    while (parser.getToken() === Token.Period) {
+      nextToken(parser, (context | Context.AllowEscapedKeyword | Context.InGlobal) ^ Context.InGlobal);
+
+      const property = parsePropertyOrPrivatePropertyName(parser, context | Context.TaggedTemplate, privateScope);
+
+      parser.assignable = AssignmentTargetKind.Simple;
+
+      memberExpression = parser.finishNode<ESTree.MemberExpression>(
+        {
+          type: 'MemberExpression',
+          object: memberExpression,
+          computed: false,
+          property,
+          optional: false,
+        },
+        expressionStart,
+      );
+    }
+
+    expression = memberExpression;
+
+    if (parser.getToken() === Token.LeftParen) {
+      const args = parseArguments(parser, context, privateScope, 0);
+
+      parser.assignable =
+        !(context & Context.Strict) && parser.options.webcompat
+          ? AssignmentTargetKind.WebCompat
+          : AssignmentTargetKind.Invalid;
+
+      expression = parser.finishNode<ESTree.CallExpression>(
+        {
+          type: 'CallExpression',
+          callee: memberExpression,
+          arguments: args,
+          optional: false,
+        },
+        expressionStart,
+      );
+    }
+  }
 
   return parser.finishNode<ESTree.Decorator>(
     {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -193,6 +193,9 @@ function parseModuleItem(parser: Parser, context: Context, scope: Scope | undefi
       moduleItem = parseExportDeclaration(parser, context, scope);
       break;
     case Token.ImportKeyword:
+      if (parser.leadingDecorators.decorators.length) {
+        parser.report(Errors.InvalidLeadingDecorator);
+      }
       moduleItem = parseImportDeclaration(parser, context, scope);
       break;
     default:
@@ -238,6 +241,10 @@ function parseStatementListItem(
   // LexicalDeclaration[In, Yield] :
   //   LetOrConst BindingList[?In, ?Yield] ;
   const start = parser.tokenStart;
+
+  if (parser.leadingDecorators.decorators.length && parser.getToken() !== Token.ClassKeyword) {
+    parser.report(Errors.InvalidLeadingDecorator);
+  }
 
   switch (parser.getToken()) {
     //   HoistableDeclaration[?Yield, ~Default]
@@ -2951,6 +2958,15 @@ function parseExportDeclaration(
   // https://tc39.github.io/ecma262/#sec-exports
   nextToken(parser, context | Context.AllowRegExp);
 
+  if (
+    parser.leadingDecorators.decorators.length &&
+    parser.getToken() !== Token.DefaultKeyword &&
+    parser.getToken() !== Token.Decorator &&
+    parser.getToken() !== Token.ClassKeyword
+  ) {
+    parser.report(Errors.InvalidLeadingDecorator);
+  }
+
   const specifiers: ESTree.ExportSpecifier[] = [];
 
   let declaration: ESTree.ExportDeclaration | ESTree.Expression | null = null;
@@ -2961,6 +2977,14 @@ function parseExportDeclaration(
     // export default HoistableDeclaration[Default]
     // export default ClassDeclaration[Default]
     // export default [lookahead not-in {function, class}] AssignmentExpression[In] ;
+
+    if (
+      parser.leadingDecorators.decorators.length &&
+      parser.getToken() !== Token.Decorator &&
+      parser.getToken() !== Token.ClassKeyword
+    ) {
+      parser.report(Errors.InvalidLeadingDecorator);
+    }
 
     switch (parser.getToken()) {
       // export default HoistableDeclaration[Default]
@@ -8104,6 +8128,9 @@ function parseClassDeclaration(
   } else {
     start = parser.tokenStart;
     decorators = parseDecorators(parser, context, privateScope);
+    if (decorators.length && parser.getToken() !== Token.ClassKeyword) {
+      parser.report(Errors.InvalidLeadingDecorator);
+    }
   }
 
   context = (context | Context.InConstructor | Context.Strict) ^ Context.InConstructor;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -8265,7 +8265,7 @@ function parseDecorators(parser: Parser, context: Context, privateScope: Private
 
   if (parser.features & Features.Decorators) {
     while (parser.getToken() === Token.Decorator) {
-      list.push(parseDecoratorList(parser, context, privateScope));
+      list.push(parseDecorator(parser, context, privateScope));
     }
   }
 
@@ -8273,16 +8273,24 @@ function parseDecorators(parser: Parser, context: Context, privateScope: Private
 }
 
 /**
- * Parses a list of decorators
+ * Parses a decorator
  *
  * @param parser Parser object
  * @param context Context masks
  */
-function parseDecoratorList(
-  parser: Parser,
-  context: Context,
-  privateScope: PrivateScope | undefined,
-): ESTree.Decorator {
+function parseDecorator(parser: Parser, context: Context, privateScope: PrivateScope | undefined): ESTree.Decorator {
+  // Decorator[Yield, Await] :
+  //    @ DecoratorMemberExpression[?Yield, ?Await]
+  //    @ DecoratorParenthesizedExpression[?Yield, ?Await]
+  //    @ DecoratorCallExpression[?Yield, ?Await]
+  //  DecoratorMemberExpression[Yield, Await] :
+  //    IdentifierReference[?Yield, ?Await]
+  //    DecoratorMemberExpression[?Yield, ?Await] . IdentifierName
+  //    DecoratorMemberExpression[?Yield, ?Await] . PrivateIdentifier
+  //  DecoratorParenthesizedExpression[Yield, Await] :
+  //    ( Expression[+In, ?Yield, ?Await] )
+  //  DecoratorCallExpression[Yield, Await] :
+  //    DecoratorMemberExpression[?Yield, ?Await] Arguments[?Yield, ?Await]
   const start = parser.tokenStart;
 
   nextToken(parser, context | Context.AllowRegExp);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2958,12 +2958,9 @@ function parseExportDeclaration(
   // https://tc39.github.io/ecma262/#sec-exports
   nextToken(parser, context | Context.AllowRegExp);
 
-  if (
-    parser.leadingDecorators.decorators.length &&
-    parser.getToken() !== Token.DefaultKeyword &&
-    parser.getToken() !== Token.Decorator &&
-    parser.getToken() !== Token.ClassKeyword
-  ) {
+  const isDefaultExport = consumeOpt(parser, context | Context.AllowRegExp, Token.DefaultKeyword);
+
+  if (parser.leadingDecorators.decorators.length && parser.getToken() !== Token.ClassKeyword) {
     parser.report(Errors.InvalidLeadingDecorator);
   }
 
@@ -2973,18 +2970,10 @@ function parseExportDeclaration(
   let source: ESTree.StringLiteral | null = null;
   let attributes: ESTree.ImportAttribute[] = [];
 
-  if (consumeOpt(parser, context | Context.AllowRegExp, Token.DefaultKeyword)) {
+  if (isDefaultExport) {
     // export default HoistableDeclaration[Default]
     // export default ClassDeclaration[Default]
     // export default [lookahead not-in {function, class}] AssignmentExpression[In] ;
-
-    if (
-      parser.leadingDecorators.decorators.length &&
-      parser.getToken() !== Token.Decorator &&
-      parser.getToken() !== Token.ClassKeyword
-    ) {
-      parser.report(Errors.InvalidLeadingDecorator);
-    }
 
     switch (parser.getToken()) {
       // export default HoistableDeclaration[Default]

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -202,9 +202,6 @@ function parseModuleItem(parser: Parser, context: Context, scope: Scope | undefi
       moduleItem = parseStatementListItem(parser, context, scope, undefined, Origin.TopLevel, {});
   }
 
-  if (parser.leadingDecorators?.decorators.length) {
-    parser.report(Errors.InvalidLeadingDecorator);
-  }
   return moduleItem;
 }
 
@@ -8108,23 +8105,17 @@ function parseClassDeclaration(
   let start;
   let decorators;
   if (parser.leadingDecorators.decorators.length) {
-    if (parser.getToken() === Token.Decorator) {
-      parser.report(Errors.UnexpectedToken, '@');
-    }
     start = parser.leadingDecorators.start!;
     decorators = [...parser.leadingDecorators.decorators];
     parser.leadingDecorators.decorators.length = 0;
   } else {
     start = parser.tokenStart;
     decorators = parseDecorators(parser, context, privateScope);
-    if (decorators.length && parser.getToken() !== Token.ClassKeyword) {
-      parser.report(Errors.InvalidLeadingDecorator);
-    }
   }
 
   context = (context | Context.InConstructor | Context.Strict) ^ Context.InConstructor;
 
-  nextToken(parser, context);
+  consume(parser, context, Token.ClassKeyword);
   let id: ESTree.Expression | null = null;
   let superClass: ESTree.Expression | null = null;
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -8350,17 +8350,10 @@ function parseDecorator(parser: Parser, context: Context, privateScope: PrivateS
       context | Context.TaggedTemplate,
     );
 
-    parser.assignable =
-      context & Context.Strict && (token & Token.IsEvalOrArguments) === Token.IsEvalOrArguments
-        ? AssignmentTargetKind.Invalid
-        : AssignmentTargetKind.Simple;
-
     while (parser.getToken() === Token.Period) {
       nextToken(parser, (context | Context.AllowEscapedKeyword | Context.InGlobal) ^ Context.InGlobal);
 
       const property = parsePropertyOrPrivatePropertyName(parser, context | Context.TaggedTemplate, privateScope);
-
-      parser.assignable = AssignmentTargetKind.Simple;
 
       memberExpression = parser.finishNode<ESTree.MemberExpression>(
         {
@@ -8378,11 +8371,6 @@ function parseDecorator(parser: Parser, context: Context, privateScope: PrivateS
 
     if (parser.getToken() === Token.LeftParen) {
       const args = parseArguments(parser, context, privateScope, 0);
-
-      parser.assignable =
-        !(context & Context.Strict) && parser.options.webcompat
-          ? AssignmentTargetKind.WebCompat
-          : AssignmentTargetKind.Invalid;
 
       expression = parser.finishNode<ESTree.CallExpression>(
         {

--- a/test/parser/next/__snapshots__/decorators.ts.snap
+++ b/test/parser/next/__snapshots__/decorators.ts.snap
@@ -127,15 +127,15 @@ exports[`Decorators > Decorators (fail) > @decorate 1`] = `
 `;
 
 exports[`Decorators > Decorators (fail) > @foo export @bar class A {} 1`] = `
-"SyntaxError [1:12-1:13]: Unexpected token: '@'
+"SyntaxError [1:12-1:13]: Leading decorators must be attached to a class declaration
 > 1 | @foo export @bar class A {}
-    |             ^ Unexpected token: '@'"
+    |             ^ Leading decorators must be attached to a class declaration"
 `;
 
 exports[`Decorators > Decorators (fail) > @foo export default @bar class A {} 1`] = `
-"SyntaxError [1:20-1:21]: Unexpected token: '@'
+"SyntaxError [1:20-1:21]: Leading decorators must be attached to a class declaration
 > 1 | @foo export default @bar class A {}
-    |                     ^ Unexpected token: '@'"
+    |                     ^ Leading decorators must be attached to a class declaration"
 `;
 
 exports[`Decorators > Decorators (fail) > @this.x class A {} 1`] = `

--- a/test/parser/next/__snapshots__/decorators.ts.snap
+++ b/test/parser/next/__snapshots__/decorators.ts.snap
@@ -13,9 +13,9 @@ exports[`Decorators > Decorators (fail) > (@bar function foo() {}) 1`] = `
 `;
 
 exports[`Decorators > Decorators (fail) > @bar const foo = 1; 1`] = `
-"SyntaxError [1:5-1:10]: Leading decorators must be attached to a class declaration
+"SyntaxError [1:5-1:10]: Expected 'class'
 > 1 | @bar const foo = 1;
-    |      ^^^^^ Leading decorators must be attached to a class declaration"
+    |      ^^^^^ Expected 'class'"
 `;
 
 exports[`Decorators > Decorators (fail) > @bar export * from "./foo"; 1`] = `
@@ -49,27 +49,27 @@ exports[`Decorators > Decorators (fail) > @bar export default function foo() {} 
 `;
 
 exports[`Decorators > Decorators (fail) > @bar function foo() {} 1`] = `
-"SyntaxError [1:5-1:13]: Leading decorators must be attached to a class declaration
+"SyntaxError [1:5-1:13]: Expected 'class'
 > 1 | @bar function foo() {}
-    |      ^^^^^^^^ Leading decorators must be attached to a class declaration"
+    |      ^^^^^^^^ Expected 'class'"
 `;
 
 exports[`Decorators > Decorators (fail) > @bar(); 1`] = `
-"SyntaxError [1:6-1:7]: Leading decorators must be attached to a class declaration
+"SyntaxError [1:6-1:7]: Expected 'class'
 > 1 | @bar();
-    |       ^ Leading decorators must be attached to a class declaration"
+    |       ^ Expected 'class'"
 `;
 
 exports[`Decorators > Decorators (fail) > @bar; 1`] = `
-"SyntaxError [1:4-1:5]: Leading decorators must be attached to a class declaration
+"SyntaxError [1:4-1:5]: Expected 'class'
 > 1 | @bar;
-    |     ^ Leading decorators must be attached to a class declaration"
+    |     ^ Expected 'class'"
 `;
 
 exports[`Decorators > Decorators (fail) > @dec()() => {} 1`] = `
-"SyntaxError [1:6-1:7]: Leading decorators must be attached to a class declaration
+"SyntaxError [1:6-1:7]: Expected 'class'
 > 1 | @dec()() => {}
-    |       ^ Leading decorators must be attached to a class declaration"
+    |       ^ Expected 'class'"
 `;
 
 exports[`Decorators > Decorators (fail) > @dec()() => {} 2`] = `
@@ -79,9 +79,9 @@ exports[`Decorators > Decorators (fail) > @dec()() => {} 2`] = `
 `;
 
 exports[`Decorators > Decorators (fail) > @dec()() class A {} 1`] = `
-"SyntaxError [1:6-1:7]: Leading decorators must be attached to a class declaration
+"SyntaxError [1:6-1:7]: Expected 'class'
 > 1 | @dec()() class A {}
-    |       ^ Leading decorators must be attached to a class declaration"
+    |       ^ Expected 'class'"
 `;
 
 exports[`Decorators > Decorators (fail) > @dec()() class A {} 2`] = `
@@ -91,39 +91,39 @@ exports[`Decorators > Decorators (fail) > @dec()() class A {} 2`] = `
 `;
 
 exports[`Decorators > Decorators (fail) > @dec().b class A {} 1`] = `
-"SyntaxError [1:6-1:7]: Leading decorators must be attached to a class declaration
+"SyntaxError [1:6-1:7]: Expected 'class'
 > 1 | @dec().b class A {}
-    |       ^ Leading decorators must be attached to a class declaration"
+    |       ^ Expected 'class'"
 `;
 
 exports[`Decorators > Decorators (fail) > @dec?.() class A {} 1`] = `
-"SyntaxError [1:4-1:6]: Leading decorators must be attached to a class declaration
+"SyntaxError [1:4-1:6]: Expected 'class'
 > 1 | @dec?.() class A {}
-    |     ^^ Leading decorators must be attached to a class declaration"
+    |     ^^ Expected 'class'"
 `;
 
 exports[`Decorators > Decorators (fail) > @dec?.b class A {} 1`] = `
-"SyntaxError [1:4-1:6]: Leading decorators must be attached to a class declaration
+"SyntaxError [1:4-1:6]: Expected 'class'
 > 1 | @dec?.b class A {}
-    |     ^^ Leading decorators must be attached to a class declaration"
+    |     ^^ Expected 'class'"
 `;
 
 exports[`Decorators > Decorators (fail) > @dec["x"] class A {} 1`] = `
-"SyntaxError [1:4-1:5]: Leading decorators must be attached to a class declaration
+"SyntaxError [1:4-1:5]: Expected 'class'
 > 1 | @dec["x"] class A {}
-    |     ^ Leading decorators must be attached to a class declaration"
+    |     ^ Expected 'class'"
 `;
 
 exports[`Decorators > Decorators (fail) > @dec[0] class A {} 1`] = `
-"SyntaxError [1:4-1:5]: Leading decorators must be attached to a class declaration
+"SyntaxError [1:4-1:5]: Expected 'class'
 > 1 | @dec[0] class A {}
-    |     ^ Leading decorators must be attached to a class declaration"
+    |     ^ Expected 'class'"
 `;
 
 exports[`Decorators > Decorators (fail) > @decorate 1`] = `
-"SyntaxError [1:1-1:9]: Leading decorators must be attached to a class declaration
+"SyntaxError [1:1-1:9]: Expected 'class'
 > 1 | @decorate
-    |  ^^^^^^^^ Leading decorators must be attached to a class declaration"
+    |  ^^^^^^^^ Expected 'class'"
 `;
 
 exports[`Decorators > Decorators (fail) > @foo export @bar class A {} 1`] = `
@@ -235,9 +235,9 @@ exports[`Decorators > Decorators (fail) > class Foo {@abc constructor(){} 1`] = 
 `;
 
 exports[`Decorators > Decorators (fail) > export default @decorator class Foo {} 1`] = `
-"SyntaxError [1:26-1:31]: Expected '{'
+"SyntaxError [1:15-1:16]: Expected 'class'
 > 1 | export default @decorator class Foo {}
-    |                           ^^^^^ Expected '{'"
+    |                ^ Expected 'class'"
 `;
 
 exports[`Decorators > Decorators (fail) > var obj = { method(@foo x) {} }; 1`] = `

--- a/test/parser/next/__snapshots__/decorators.ts.snap
+++ b/test/parser/next/__snapshots__/decorators.ts.snap
@@ -66,6 +66,42 @@ exports[`Decorators > Decorators (fail) > @bar; 1`] = `
     |     ^ Class declaration must have a name in this context"
 `;
 
+exports[`Decorators > Decorators (fail) > @dec()() class A {} 1`] = `
+"SyntaxError [1:7-1:8]: Class declaration must have a name in this context
+> 1 | @dec()() class A {}
+    |        ^ Class declaration must have a name in this context"
+`;
+
+exports[`Decorators > Decorators (fail) > @dec().b class A {} 1`] = `
+"SyntaxError [1:9-1:14]: Expected '{'
+> 1 | @dec().b class A {}
+    |          ^^^^^ Expected '{'"
+`;
+
+exports[`Decorators > Decorators (fail) > @dec?.() class A {} 1`] = `
+"SyntaxError [1:6-1:7]: Class declaration must have a name in this context
+> 1 | @dec?.() class A {}
+    |       ^ Class declaration must have a name in this context"
+`;
+
+exports[`Decorators > Decorators (fail) > @dec?.b class A {} 1`] = `
+"SyntaxError [1:8-1:13]: Expected '{'
+> 1 | @dec?.b class A {}
+    |         ^^^^^ Expected '{'"
+`;
+
+exports[`Decorators > Decorators (fail) > @dec["x"] class A {} 1`] = `
+"SyntaxError [1:5-1:8]: Class declaration must have a name in this context
+> 1 | @dec["x"] class A {}
+    |      ^^^ Class declaration must have a name in this context"
+`;
+
+exports[`Decorators > Decorators (fail) > @dec[0] class A {} 1`] = `
+"SyntaxError [1:5-1:6]: Class declaration must have a name in this context
+> 1 | @dec[0] class A {}
+    |      ^ Class declaration must have a name in this context"
+`;
+
 exports[`Decorators > Decorators (fail) > @decorate 1`] = `
 "SyntaxError [1:1-1:9]: Class declaration must have a name in this context
 > 1 | @decorate
@@ -82,6 +118,12 @@ exports[`Decorators > Decorators (fail) > @foo export default @bar class A {} 1`
 "SyntaxError [1:20-1:21]: Unexpected token: '@'
 > 1 | @foo export default @bar class A {}
     |                     ^ Unexpected token: '@'"
+`;
+
+exports[`Decorators > Decorators (fail) > @this.x class A {} 1`] = `
+"SyntaxError [1:1-1:5]: Unexpected token: 'this'
+> 1 | @this.x class A {}
+    |  ^^^^ Unexpected token: 'this'"
 `;
 
 exports[`Decorators > Decorators (fail) > class A {  constructor(@foo x) {} } 1`] = `
@@ -112,6 +154,12 @@ exports[`Decorators > Decorators (fail) > class A { @dec accessor a() {}} 1`] = 
 "SyntaxError [1:25-1:26]: Unexpected token: '('
 > 1 | class A { @dec accessor a() {}}
     |                          ^ Unexpected token: '('"
+`;
+
+exports[`Decorators > Decorators (fail) > class A { @dec[0] m() {} } 1`] = `
+"SyntaxError [1:18-1:19]: Unexpected token: 'identifier'
+> 1 | class A { @dec[0] m() {} }
+    |                   ^ Unexpected token: 'identifier'"
 `;
 
 exports[`Decorators > Decorators (fail) > class A { @foo && bar method() {}  } 1`] = `

--- a/test/parser/next/__snapshots__/decorators.ts.snap
+++ b/test/parser/next/__snapshots__/decorators.ts.snap
@@ -13,99 +13,117 @@ exports[`Decorators > Decorators (fail) > (@bar function foo() {}) 1`] = `
 `;
 
 exports[`Decorators > Decorators (fail) > @bar const foo = 1; 1`] = `
-"SyntaxError [1:15-1:16]: Expected '{'
+"SyntaxError [1:5-1:10]: Leading decorators must be attached to a class declaration
 > 1 | @bar const foo = 1;
-    |                ^ Expected '{'"
+    |      ^^^^^ Leading decorators must be attached to a class declaration"
 `;
 
 exports[`Decorators > Decorators (fail) > @bar export * from "./foo"; 1`] = `
-"SyntaxError [1:26-1:27]: Leading decorators must be attached to a class declaration
+"SyntaxError [1:12-1:13]: Leading decorators must be attached to a class declaration
 > 1 | @bar export * from "./foo";
-    |                           ^ Leading decorators must be attached to a class declaration"
+    |             ^ Leading decorators must be attached to a class declaration"
 `;
 
 exports[`Decorators > Decorators (fail) > @bar export {Foo}; 1`] = `
-"SyntaxError [1:17-1:18]: Leading decorators must be attached to a class declaration
+"SyntaxError [1:12-1:13]: Leading decorators must be attached to a class declaration
 > 1 | @bar export {Foo};
-    |                  ^ Leading decorators must be attached to a class declaration"
+    |             ^ Leading decorators must be attached to a class declaration"
 `;
 
 exports[`Decorators > Decorators (fail) > @bar export const foo = 1; 1`] = `
-"SyntaxError [1:25-1:26]: Leading decorators must be attached to a class declaration
+"SyntaxError [1:12-1:17]: Leading decorators must be attached to a class declaration
 > 1 | @bar export const foo = 1;
-    |                          ^ Leading decorators must be attached to a class declaration"
+    |             ^^^^^ Leading decorators must be attached to a class declaration"
 `;
 
 exports[`Decorators > Decorators (fail) > @bar export const lo = {a: class Foo {}}; 1`] = `
-"SyntaxError [1:40-1:41]: Leading decorators must be attached to a class declaration
+"SyntaxError [1:12-1:17]: Leading decorators must be attached to a class declaration
 > 1 | @bar export const lo = {a: class Foo {}};
-    |                                         ^ Leading decorators must be attached to a class declaration"
+    |             ^^^^^ Leading decorators must be attached to a class declaration"
 `;
 
 exports[`Decorators > Decorators (fail) > @bar export default function foo() {} 1`] = `
-"SyntaxError [1:36-1:37]: Leading decorators must be attached to a class declaration
+"SyntaxError [1:20-1:28]: Leading decorators must be attached to a class declaration
 > 1 | @bar export default function foo() {}
-    |                                     ^ Leading decorators must be attached to a class declaration"
+    |                     ^^^^^^^^ Leading decorators must be attached to a class declaration"
 `;
 
 exports[`Decorators > Decorators (fail) > @bar function foo() {} 1`] = `
-"SyntaxError [1:17-1:18]: Expected '{'
+"SyntaxError [1:5-1:13]: Leading decorators must be attached to a class declaration
 > 1 | @bar function foo() {}
-    |                  ^ Expected '{'"
+    |      ^^^^^^^^ Leading decorators must be attached to a class declaration"
 `;
 
 exports[`Decorators > Decorators (fail) > @bar(); 1`] = `
-"SyntaxError [1:6-1:7]: Class declaration must have a name in this context
+"SyntaxError [1:6-1:7]: Leading decorators must be attached to a class declaration
 > 1 | @bar();
-    |       ^ Class declaration must have a name in this context"
+    |       ^ Leading decorators must be attached to a class declaration"
 `;
 
 exports[`Decorators > Decorators (fail) > @bar; 1`] = `
-"SyntaxError [1:4-1:5]: Class declaration must have a name in this context
+"SyntaxError [1:4-1:5]: Leading decorators must be attached to a class declaration
 > 1 | @bar;
-    |     ^ Class declaration must have a name in this context"
+    |     ^ Leading decorators must be attached to a class declaration"
+`;
+
+exports[`Decorators > Decorators (fail) > @dec()() => {} 1`] = `
+"SyntaxError [1:6-1:7]: Leading decorators must be attached to a class declaration
+> 1 | @dec()() => {}
+    |       ^ Leading decorators must be attached to a class declaration"
+`;
+
+exports[`Decorators > Decorators (fail) > @dec()() => {} 2`] = `
+"SyntaxError [1:6-1:7]: Leading decorators must be attached to a class declaration
+> 1 | @dec()() => {}
+    |       ^ Leading decorators must be attached to a class declaration"
 `;
 
 exports[`Decorators > Decorators (fail) > @dec()() class A {} 1`] = `
-"SyntaxError [1:7-1:8]: Class declaration must have a name in this context
+"SyntaxError [1:6-1:7]: Leading decorators must be attached to a class declaration
 > 1 | @dec()() class A {}
-    |        ^ Class declaration must have a name in this context"
+    |       ^ Leading decorators must be attached to a class declaration"
+`;
+
+exports[`Decorators > Decorators (fail) > @dec()() class A {} 2`] = `
+"SyntaxError [1:6-1:7]: Leading decorators must be attached to a class declaration
+> 1 | @dec()() class A {}
+    |       ^ Leading decorators must be attached to a class declaration"
 `;
 
 exports[`Decorators > Decorators (fail) > @dec().b class A {} 1`] = `
-"SyntaxError [1:9-1:14]: Expected '{'
+"SyntaxError [1:6-1:7]: Leading decorators must be attached to a class declaration
 > 1 | @dec().b class A {}
-    |          ^^^^^ Expected '{'"
+    |       ^ Leading decorators must be attached to a class declaration"
 `;
 
 exports[`Decorators > Decorators (fail) > @dec?.() class A {} 1`] = `
-"SyntaxError [1:6-1:7]: Class declaration must have a name in this context
+"SyntaxError [1:4-1:6]: Leading decorators must be attached to a class declaration
 > 1 | @dec?.() class A {}
-    |       ^ Class declaration must have a name in this context"
+    |     ^^ Leading decorators must be attached to a class declaration"
 `;
 
 exports[`Decorators > Decorators (fail) > @dec?.b class A {} 1`] = `
-"SyntaxError [1:8-1:13]: Expected '{'
+"SyntaxError [1:4-1:6]: Leading decorators must be attached to a class declaration
 > 1 | @dec?.b class A {}
-    |         ^^^^^ Expected '{'"
+    |     ^^ Leading decorators must be attached to a class declaration"
 `;
 
 exports[`Decorators > Decorators (fail) > @dec["x"] class A {} 1`] = `
-"SyntaxError [1:5-1:8]: Class declaration must have a name in this context
+"SyntaxError [1:4-1:5]: Leading decorators must be attached to a class declaration
 > 1 | @dec["x"] class A {}
-    |      ^^^ Class declaration must have a name in this context"
+    |     ^ Leading decorators must be attached to a class declaration"
 `;
 
 exports[`Decorators > Decorators (fail) > @dec[0] class A {} 1`] = `
-"SyntaxError [1:5-1:6]: Class declaration must have a name in this context
+"SyntaxError [1:4-1:5]: Leading decorators must be attached to a class declaration
 > 1 | @dec[0] class A {}
-    |      ^ Class declaration must have a name in this context"
+    |     ^ Leading decorators must be attached to a class declaration"
 `;
 
 exports[`Decorators > Decorators (fail) > @decorate 1`] = `
-"SyntaxError [1:1-1:9]: Class declaration must have a name in this context
+"SyntaxError [1:1-1:9]: Leading decorators must be attached to a class declaration
 > 1 | @decorate
-    |  ^^^^^^^^ Class declaration must have a name in this context"
+    |  ^^^^^^^^ Leading decorators must be attached to a class declaration"
 `;
 
 exports[`Decorators > Decorators (fail) > @foo export @bar class A {} 1`] = `

--- a/test/parser/next/decorators.ts
+++ b/test/parser/next/decorators.ts
@@ -126,7 +126,132 @@ describe('Decorators', () => {
     { code: '@bar();', options: { features: Features.Decorators } },
     { code: '@foo export @bar class A {}', options: { features: Features.Decorators, sourceType: 'module' } },
     { code: '@foo export default @bar class A {}', options: { features: Features.Decorators, sourceType: 'module' } },
+    { code: '@dec[0] class A {}', options: { features: Features.Decorators } },
+    { code: '@dec["x"] class A {}', options: { features: Features.Decorators } },
+    { code: '@dec?.b class A {}', options: { features: Features.Decorators } },
+    { code: '@dec?.() class A {}', options: { features: Features.Decorators } },
+    { code: '@dec().b class A {}', options: { features: Features.Decorators } },
+    { code: '@dec()() class A {}', options: { features: Features.Decorators } },
+    { code: '@this.x class A {}', options: { features: Features.Decorators } },
+    { code: 'class A { @dec[0] m() {} }', options: { features: Features.Decorators } },
   ]);
+
+  describe('Decorator class element boundaries', () => {
+    for (const [keySource, key] of [
+      ['0', { type: 'Literal', value: 0 }],
+      ['first', { type: 'Identifier', name: 'first' }],
+    ] as const) {
+      it(`splits a computed [${keySource}] field from the following method`, () => {
+        const program = parseSource(
+          outdent`
+            class A {
+              @decorators
+              [${keySource}]
+              method() {}
+            }
+          `,
+          { features: Features.Decorators },
+        );
+        const declaration = program.body[0];
+
+        t.equal(declaration.type, 'ClassDeclaration');
+        if (declaration.type !== 'ClassDeclaration') return;
+
+        t.deepEqual(declaration.body.body, [
+          {
+            type: 'PropertyDefinition',
+            key,
+            value: null,
+            static: false,
+            computed: true,
+            decorators: [
+              {
+                type: 'Decorator',
+                expression: {
+                  type: 'Identifier',
+                  name: 'decorators',
+                },
+              },
+            ],
+          },
+          {
+            type: 'MethodDefinition',
+            kind: 'method',
+            static: false,
+            computed: false,
+            key: {
+              type: 'Identifier',
+              name: 'method',
+            },
+            value: {
+              type: 'FunctionExpression',
+              params: [],
+              body: {
+                type: 'BlockStatement',
+                body: [],
+              },
+              async: false,
+              generator: false,
+              id: null,
+            },
+            decorators: [],
+          },
+        ]);
+      });
+    }
+
+    it('preserves the computed key in the #407 field shape', () => {
+      const program = parseSource(
+        outdent`
+          class A {
+            @decorators
+            [x] = 1
+          }
+        `,
+        { features: Features.Decorators },
+      );
+      const declaration = program.body[0];
+
+      t.equal(declaration.type, 'ClassDeclaration');
+      if (declaration.type !== 'ClassDeclaration') return;
+
+      t.deepEqual(declaration.body.body, [
+        {
+          type: 'PropertyDefinition',
+          key: {
+            type: 'Identifier',
+            name: 'x',
+          },
+          value: {
+            type: 'Literal',
+            value: 1,
+          },
+          static: false,
+          computed: true,
+          decorators: [
+            {
+              type: 'Decorator',
+              expression: {
+                type: 'Identifier',
+                name: 'decorators',
+              },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('keeps grammar-legal member, call, private, and parenthesized forms', () => {
+      for (const source of [
+        'class A { @dec.a.b m() {} }',
+        'class A { @dec() m() {} }',
+        'class A { @dec.#x m() {} #x; }',
+        'class A { @(dec?.[0]().x) m() {} }',
+      ]) {
+        t.doesNotThrow(() => parseSource(source, { features: Features.Decorators, lexical: true }));
+      }
+    });
+  });
 
   pass('Decorators (pass)', [
     { code: 'class A { @dec name = 0; }', options: { features: Features.Decorators, ranges: true, loc: true } },

--- a/test/parser/next/decorators.ts
+++ b/test/parser/next/decorators.ts
@@ -132,6 +132,15 @@ describe('Decorators', () => {
     { code: '@dec?.() class A {}', options: { features: Features.Decorators } },
     { code: '@dec().b class A {}', options: { features: Features.Decorators } },
     { code: '@dec()() class A {}', options: { features: Features.Decorators } },
+    {
+      code: '@dec()() class A {}',
+      options: { features: Features.Decorators, sourceType: 'module' },
+    },
+    { code: '@dec()() => {}', options: { features: Features.Decorators } },
+    {
+      code: '@dec()() => {}',
+      options: { features: Features.Decorators, sourceType: 'module' },
+    },
     { code: '@this.x class A {}', options: { features: Features.Decorators } },
     { code: 'class A { @dec[0] m() {} }', options: { features: Features.Decorators } },
   ]);


### PR DESCRIPTION
Fixes #408, fixes #407.

`parseDecoratorList` now implements the decorator grammar directly instead of running the general member/call machinery: an identifier head, `.` identifier / `.#private` steps, and at most one terminal argument list, with `@( Expression )` unchanged as the escape hatch.

Unparenthesized `@dec[0]`, `@dec["x"]`, `@dec?.b`, `@dec?.()`, `@dec().b`, `@dec()()`, and `@this.x` are now syntax errors — babel rejects all seven. The tokens freed by stopping at `[` flow to the class-element parser, so the multi-line forms from #408 parse the way babel/flow/TS/hermes parse them (`@decorators` attaches to a computed field `[0]`; the method is a separate, undecorated element), and #407's repro yields a `PropertyDefinition` with `computed: true` and key `x` instead of `key: null`.

Tests: fail cases for all seven forms plus the one-line `class A { @dec[0] m() {} }` (no line terminator, so the computed field cannot end before `m`), full AST assertions for the split shapes and the #407 repro, and controls keeping dotted chains, single calls, private-name steps, and every parenthesized form green. `TEST262=1 npx vitest run`: 143 files / 91,310 tests, whitelist untouched.

Downstream note: prettier's format suite currently disables `js/decorators/member-expression.js` for meriyah over exactly this divergence — with this change that fixture parses structurally identical to babel, so the disable can be dropped after the next release.