### PR TITLE
Do we need this? chore: improve error message on "@" when next flag is off

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -259,6 +259,10 @@ function parseStatementListItem(
       );
 
     case Token.Decorator: // @decorator
+      if (!(parser.features & Features.Decorators)) {
+        parser.report(Errors.UnexpectedToken, '@');
+      }
+    // fall through to parseClassDeclaration which handles decorators
     case Token.ClassKeyword: // ClassDeclaration[?Yield, ~Default]
       return parseClassDeclaration(parser, context, scope, privateScope, HoistedClassFlags.None);
     // LexicalDeclaration[In, ?Yield]
@@ -2991,6 +2995,10 @@ function parseExportDeclaration(
       // export default ClassDeclaration[Default]
       // export default  @decl ClassDeclaration[Default]
       case Token.Decorator:
+        if (!(parser.features & Features.Decorators)) {
+          parser.report(Errors.UnexpectedToken, '@');
+        }
+      // fall through to parseClassDeclaration which handles decorators
       case Token.ClassKeyword:
         declaration = parseClassDeclaration(parser, context, scope, undefined, HoistedClassFlags.Hoisted);
         break;
@@ -3199,6 +3207,10 @@ function parseExportDeclaration(
     }
 
     case Token.Decorator:
+      if (!(parser.features & Features.Decorators)) {
+        parser.report(Errors.UnexpectedToken, '@');
+      }
+    // fall through to parseClassDeclaration which handles decorators
     case Token.ClassKeyword:
       declaration = parseClassDeclaration(parser, context, scope, undefined, HoistedClassFlags.Export);
       break;
@@ -4513,6 +4525,10 @@ function parsePrimaryExpression(
     case Token.RegularExpression:
       return parseRegExpLiteral(parser, context);
     case Token.Decorator:
+      if (!(parser.features & Features.Decorators)) {
+        parser.report(Errors.UnexpectedToken, '@');
+      }
+    // fall through to parseClassExpression which handles decorators
     case Token.ClassKeyword:
       return parseClassExpression(parser, context, privateScope, inGroup, start);
     case Token.SuperKeyword:

--- a/test/parser/next/__snapshots__/decorators.ts.snap
+++ b/test/parser/next/__snapshots__/decorators.ts.snap
@@ -235,9 +235,9 @@ exports[`Decorators > Decorators (fail) > class Foo {@abc constructor(){} 1`] = 
 `;
 
 exports[`Decorators > Decorators (fail) > export default @decorator class Foo {} 1`] = `
-"SyntaxError [1:15-1:16]: Expected 'class'
+"SyntaxError [1:15-1:16]: Unexpected token: '@'
 > 1 | export default @decorator class Foo {}
-    |                ^ Expected 'class'"
+    |                ^ Unexpected token: '@'"
 `;
 
 exports[`Decorators > Decorators (fail) > var obj = { method(@foo x) {} }; 1`] = `


### PR DESCRIPTION
I am not convinced whether we need to add these few lines just to make the error message better.

On the other side, not like other stage 3 features, the decorator could stay on stage 3 for a long long time as it has been for the last decade.

cc @morgan-coded 