### PR TITLE
fix(parser): fix class keyword check after decorator for class expression

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -8218,7 +8218,7 @@ function parseClassExpression(
 
   context = (context | Context.Strict | Context.InConstructor) ^ Context.InConstructor;
 
-  nextToken(parser, context);
+  consume(parser, context, Token.ClassKeyword);
 
   if (parser.getToken() & Token.Keyword && parser.getToken() !== Token.ExtendsKeyword) {
     if (isStrictReservedWord(parser, context, parser.getToken())) parser.report(Errors.UnexpectedStrictReserved);

--- a/test/parser/next/__snapshots__/decorators.ts.snap
+++ b/test/parser/next/__snapshots__/decorators.ts.snap
@@ -1,15 +1,21 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Decorators > Decorators (fail) > (@bar const foo = 1); 1`] = `
-"SyntaxError [1:16-1:17]: Expected '{'
+"SyntaxError [1:6-1:11]: Expected 'class'
 > 1 | (@bar const foo = 1);
-    |                 ^ Expected '{'"
+    |       ^^^^^ Expected 'class'"
 `;
 
 exports[`Decorators > Decorators (fail) > (@bar function foo() {}) 1`] = `
-"SyntaxError [1:18-1:19]: Expected '{'
+"SyntaxError [1:6-1:14]: Expected 'class'
 > 1 | (@bar function foo() {})
-    |                   ^ Expected '{'"
+    |       ^^^^^^^^ Expected 'class'"
+`;
+
+exports[`Decorators > Decorators (fail) > (@dec a) 1`] = `
+"SyntaxError [1:6-1:7]: Expected 'class'
+> 1 | (@dec a)
+    |       ^ Expected 'class'"
 `;
 
 exports[`Decorators > Decorators (fail) > @bar const foo = 1; 1`] = `

--- a/test/parser/next/decorators.ts
+++ b/test/parser/next/decorators.ts
@@ -79,6 +79,7 @@ describe('Decorators', () => {
     '(class { @a.b accessor = 1})',
     '(class { @dec accessor x})',
     '(class { @dec accessor x = 1})',
+    '(@dec class {})',
   ]) {
     it(text, () => {
       t.doesNotThrow(() => {
@@ -143,6 +144,8 @@ describe('Decorators', () => {
     },
     { code: '@this.x class A {}', options: { features: Features.Decorators } },
     { code: 'class A { @dec[0] m() {} }', options: { features: Features.Decorators } },
+    // decorators in parseClassExpression
+    { code: '(@dec a)', options: { features: Features.Decorators } },
   ]);
 
   describe('Decorator class element boundaries', () => {


### PR DESCRIPTION
This follows the same fix in #612.

cc @morgan-coded 