### PR TITLE
fix: forbid `}` and `>` in JSX element children

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -182,6 +182,7 @@ export const enum Errors {
   InvalidEscapedImportMeta,
   InvalidAwaitAsIdentifier,
   InvalidAwaitInStaticBlock,
+  UnexpectedRightBraceInJSXText,
 }
 
 const errorMessages: {
@@ -375,6 +376,7 @@ const errorMessages: {
   [Errors.InvalidEscapedImportMeta]: "'import.meta' must not contain escaped characters",
   [Errors.InvalidAwaitAsIdentifier]: 'cannot use "await" as identifier inside an async function',
   [Errors.InvalidAwaitInStaticBlock]: 'cannot use "await" in static blocks',
+  [Errors.UnexpectedRightBraceInJSXText]: 'Unexpected token `}`. Did you mean `&rbrace;` or `{\'}\'}`?',
 };
 
 export class ParseError extends SyntaxError implements _Node {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -377,8 +377,8 @@ const errorMessages: {
   [Errors.InvalidEscapedImportMeta]: "'import.meta' must not contain escaped characters",
   [Errors.InvalidAwaitAsIdentifier]: 'cannot use "await" as identifier inside an async function',
   [Errors.InvalidAwaitInStaticBlock]: 'cannot use "await" in static blocks',
-  [Errors.UnexpectedRightBraceInJSXText]: 'Unexpected token `}`. Did you mean `&rbrace;` or `{\'}\'}`?',
-  [Errors.UnexpectedGreaterThanInJSXText]: 'Unexpected token `>`. Did you mean `&gt;` or `{\'>\'}`?',
+  [Errors.UnexpectedRightBraceInJSXText]: "Unexpected token `}`. Did you mean `&rbrace;` or `{'}'}`?",
+  [Errors.UnexpectedGreaterThanInJSXText]: "Unexpected token `>`. Did you mean `&gt;` or `{'>'}`?",
 };
 
 export class ParseError extends SyntaxError implements _Node {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -183,6 +183,7 @@ export const enum Errors {
   InvalidAwaitAsIdentifier,
   InvalidAwaitInStaticBlock,
   UnexpectedRightBraceInJSXText,
+  UnexpectedGreaterThanInJSXText,
 }
 
 const errorMessages: {
@@ -377,6 +378,7 @@ const errorMessages: {
   [Errors.InvalidAwaitAsIdentifier]: 'cannot use "await" as identifier inside an async function',
   [Errors.InvalidAwaitInStaticBlock]: 'cannot use "await" in static blocks',
   [Errors.UnexpectedRightBraceInJSXText]: 'Unexpected token `}`. Did you mean `&rbrace;` or `{\'}\'}`?',
+  [Errors.UnexpectedGreaterThanInJSXText]: 'Unexpected token `>`. Did you mean `&gt;` or `{\'>\'}`?',
 };
 
 export class ParseError extends SyntaxError implements _Node {

--- a/src/lexer/charClassifier.ts
+++ b/src/lexer/charClassifier.ts
@@ -148,10 +148,10 @@ export const CharTypes = [
   CharFlags.IdentifierStart | CharFlags.IdentifierPart | CharFlags.KeywordCandidate /* 0x78 x */,
   CharFlags.IdentifierStart | CharFlags.IdentifierPart | CharFlags.KeywordCandidate /* 0x79 y */,
   CharFlags.IdentifierStart | CharFlags.IdentifierPart | CharFlags.KeywordCandidate /* 0x7A z */,
-  CharFlags.JSXToken /* 0x7B */,
-  CharFlags.None /* 0x7C */,
-  CharFlags.None /* 0x7D */,
-  CharFlags.None /* 0x7E */,
+  CharFlags.JSXToken /* 0x7B { */,
+  CharFlags.None /* 0x7C | */,
+  CharFlags.JSXToken /* 0x7D } */,
+  CharFlags.None /* 0x7E ~ */,
   CharFlags.None /* 0x7F */
 ];
 

--- a/src/lexer/charClassifier.ts
+++ b/src/lexer/charClassifier.ts
@@ -87,7 +87,7 @@ export const CharTypes = [
   CharFlags.None /* 0x3B   */,
   CharFlags.JSXToken /* 0x3C < */,
   CharFlags.None /* 0x3D = */,
-  CharFlags.None /* 0x3E > */,
+  CharFlags.JSXToken /* 0x3E > */,
   CharFlags.None /* 0x3F   */,
   CharFlags.None /* 0x40 @ */,
   CharFlags.IdentifierStart | CharFlags.IdentifierPart | CharFlags.Hex /* 0x41 A */,

--- a/src/lexer/jsx.ts
+++ b/src/lexer/jsx.ts
@@ -79,6 +79,10 @@ export function nextJSXToken(parser: Parser) {
     parser.report(Errors.UnexpectedRightBraceInJSXText);
   }
 
+  if (parser.currentChar === Chars.GreaterThan) {
+    parser.report(Errors.UnexpectedGreaterThanInJSXText);
+  }
+
   let state = LexerState.None;
 
   while (parser.index < parser.end) {

--- a/src/lexer/jsx.ts
+++ b/src/lexer/jsx.ts
@@ -75,6 +75,10 @@ export function nextJSXToken(parser: Parser) {
     return;
   }
 
+  if (parser.currentChar === Chars.RightBrace) {
+    parser.report(Errors.UnexpectedRightBraceInJSXText);
+  }
+
   let state = LexerState.None;
 
   while (parser.index < parser.end) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -9208,7 +9208,6 @@ function parseJSXChildOrClosingFragment(
  * Parses JSX Text
  *
  * @param parser Parser object
- * @param context  Context masks
  */
 function parseJSXText(parser: Parser): ESTree.JSXText {
   const start = parser.tokenStart;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -9166,7 +9166,7 @@ function parseJSXChildOrClosingElement(
   privateScope: PrivateScope | undefined,
   inJSXChild: 0 | 1,
 ) {
-  if (parser.getToken() === Token.JSXText) return parseJSXText(parser, context);
+  if (parser.getToken() === Token.JSXText) return parseJSXText(parser);
   if (parser.getToken() === Token.LeftBrace)
     return parseJSXExpressionContainer(parser, context, privateScope, /*inJSXChild*/ 1, /* isAttr */ 0);
   if (parser.getToken() === Token.LessThan) {
@@ -9191,7 +9191,7 @@ function parseJSXChildOrClosingFragment(
   privateScope: PrivateScope | undefined,
   inJSXChild: 0 | 1,
 ) {
-  if (parser.getToken() === Token.JSXText) return parseJSXText(parser, context);
+  if (parser.getToken() === Token.JSXText) return parseJSXText(parser);
   if (parser.getToken() === Token.LeftBrace)
     return parseJSXExpressionContainer(parser, context, privateScope, /*inJSXChild*/ 1, /* isAttr */ 0);
   if (parser.getToken() === Token.LessThan) {
@@ -9210,7 +9210,7 @@ function parseJSXChildOrClosingFragment(
  * @param parser Parser object
  * @param context  Context masks
  */
-function parseJSXText(parser: Parser, context: Context): ESTree.JSXText {
+function parseJSXText(parser: Parser): ESTree.JSXText {
   const start = parser.tokenStart;
 
   nextJSXToken(parser);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -9213,7 +9213,7 @@ function parseJSXChildOrClosingFragment(
 function parseJSXText(parser: Parser, context: Context): ESTree.JSXText {
   const start = parser.tokenStart;
 
-  nextToken(parser, context);
+  nextJSXToken(parser);
 
   const node = {
     type: 'JSXText',

--- a/test/parser/miscellaneous/__snapshots__/jsx.ts.snap
+++ b/test/parser/miscellaneous/__snapshots__/jsx.ts.snap
@@ -330,6 +330,18 @@ exports[`Miscellaneous - JSX > Miscellaneous - JSX (fail) > <div=div></div> 1`] 
     |     ^ Unexpected token: '='"
 `;
 
+exports[`Miscellaneous - JSX > Miscellaneous - JSX (fail) > <div>}</div> 1`] = `
+"SyntaxError [1:5-1:5]: Unexpected token \`}\`. Did you mean \`&rbrace;\` or \`{'}'}\`?
+> 1 | <div>}</div>
+    |      ^ Unexpected token \`}\`. Did you mean \`&rbrace;\` or \`{'}'}\`?"
+`;
+
+exports[`Miscellaneous - JSX > Miscellaneous - JSX (fail) > <div>foo}bar</div> 1`] = `
+"SyntaxError [1:8-1:9]: Unexpected token
+> 1 | <div>foo}bar</div>
+    |         ^ Unexpected token"
+`;
+
 exports[`Miscellaneous - JSX > Miscellaneous - JSX (fail) > <div>one</div><div>two</div> 1`] = `
 "SyntaxError [1:23-1:28]: Unterminated regular expression
 > 1 | <div>one</div><div>two</div>

--- a/test/parser/miscellaneous/__snapshots__/jsx.ts.snap
+++ b/test/parser/miscellaneous/__snapshots__/jsx.ts.snap
@@ -330,16 +330,28 @@ exports[`Miscellaneous - JSX > Miscellaneous - JSX (fail) > <div=div></div> 1`] 
     |     ^ Unexpected token: '='"
 `;
 
+exports[`Miscellaneous - JSX > Miscellaneous - JSX (fail) > <div>></div> 1`] = `
+"SyntaxError [1:4-1:6]: Unexpected token: '>>'
+> 1 | <div>></div>
+    |     ^^ Unexpected token: '>>'"
+`;
+
 exports[`Miscellaneous - JSX > Miscellaneous - JSX (fail) > <div>}</div> 1`] = `
 "SyntaxError [1:5-1:5]: Unexpected token \`}\`. Did you mean \`&rbrace;\` or \`{'}'}\`?
 > 1 | <div>}</div>
     |      ^ Unexpected token \`}\`. Did you mean \`&rbrace;\` or \`{'}'}\`?"
 `;
 
+exports[`Miscellaneous - JSX > Miscellaneous - JSX (fail) > <div>foo>bar</div> 1`] = `
+"SyntaxError [1:8-1:8]: Unexpected token \`>\`. Did you mean \`&gt;\` or \`{'>'}\`?
+> 1 | <div>foo>bar</div>
+    |         ^ Unexpected token \`>\`. Did you mean \`&gt;\` or \`{'>'}\`?"
+`;
+
 exports[`Miscellaneous - JSX > Miscellaneous - JSX (fail) > <div>foo}bar</div> 1`] = `
-"SyntaxError [1:8-1:9]: Unexpected token
+"SyntaxError [1:8-1:8]: Unexpected token \`}\`. Did you mean \`&rbrace;\` or \`{'}'}\`?
 > 1 | <div>foo}bar</div>
-    |         ^ Unexpected token"
+    |         ^ Unexpected token \`}\`. Did you mean \`&rbrace;\` or \`{'}'}\`?"
 `;
 
 exports[`Miscellaneous - JSX > Miscellaneous - JSX (fail) > <div>one</div><div>two</div> 1`] = `

--- a/test/parser/miscellaneous/jsx.ts
+++ b/test/parser/miscellaneous/jsx.ts
@@ -56,6 +56,8 @@ describe('Miscellaneous - JSX', () => {
     { code: '<p></>', options: { jsx: true } },
     { code: '<p><q></p>', options: { jsx: true } },
     { code: '<1/>', options: { jsx: true } },
+    { code: '<div>}</div>', options: { jsx: true } },
+    { code: '<div>foo}bar</div>', options: { jsx: true } },
     { code: '<div id={}></div>', options: { jsx: true } },
     { code: '<div>one</div><div>two</div>', options: { jsx: true } },
     { code: '</>', options: { jsx: true } },

--- a/test/parser/miscellaneous/jsx.ts
+++ b/test/parser/miscellaneous/jsx.ts
@@ -58,6 +58,8 @@ describe('Miscellaneous - JSX', () => {
     { code: '<1/>', options: { jsx: true } },
     { code: '<div>}</div>', options: { jsx: true } },
     { code: '<div>foo}bar</div>', options: { jsx: true } },
+    { code: '<div>></div>', options: { jsx: true } },
+    { code: '<div>foo>bar</div>', options: { jsx: true } },
     { code: '<div id={}></div>', options: { jsx: true } },
     { code: '<div>one</div><div>two</div>', options: { jsx: true } },
     { code: '</>', options: { jsx: true } },


### PR DESCRIPTION
fixes #619

this fixes an issue where a stray `}` in JSX text (like `<div>}</div>`) was silently ignored instead of throwing an error. 

the problem was that `}` wasn't marked as a JSX token boundary in the character classifier, so the lexer just ate it up as normal JSX text. this adds the correct flag for `}` so the lexer stops at it and correctly throws an unexpected token error like babel and espree do. also fixed a small issue where `parseJSXText` was calling the normal `nextToken` instead of `nextJSXToken` which was causing the wrong error message to show up.