### PR TITLE
fix: allow top-level `using` declarations in commonjs source type

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1744,7 +1744,12 @@ function parseUsingDeclarationOrExpressionStatement(
   const expression = parseIdentifier(parser, context);
 
   if ((parser.flags & Flags.NewLine) === 0 && isResourceBindingStart(parser.getToken())) {
-    if (origin & Origin.TopLevel && context & Context.InGlobal && (context & Context.Module) === 0) {
+    if (
+      origin & Origin.TopLevel &&
+      context & Context.InGlobal &&
+      (context & Context.Module) === 0 &&
+      (context & Context.InReturnContext) === 0
+    ) {
       parser.report(Errors.UnexpectedToken, KeywordDescTable[parser.getToken() & Token.Type]);
     }
 

--- a/test/parser/miscellaneous/__snapshots__/commonjs.ts.snap
+++ b/test/parser/miscellaneous/__snapshots__/commonjs.ts.snap
@@ -18,12 +18,6 @@ exports[`Statements - Return > Commonjs (fail) > return 1`] = `
     | ^^^^^^ Illegal return statement"
 `;
 
-exports[`Statements - Return > Commonjs (fail) > using foo = null 1`] = `
-"SyntaxError [1:6-1:9]: Unexpected token: 'identifier'
-> 1 | using foo = null
-    |       ^^^ Unexpected token: 'identifier'"
-`;
-
 exports[`Statements - Return > Commonjs (pass) > new.target 1`] = `
 {
   "body": [
@@ -53,6 +47,32 @@ exports[`Statements - Return > Commonjs (pass) > return 1`] = `
     {
       "argument": null,
       "type": "ReturnStatement",
+    },
+  ],
+  "sourceType": "script",
+  "type": "Program",
+}
+`;
+
+exports[`Statements - Return > Commonjs (pass) > using foo = null 1`] = `
+{
+  "body": [
+    {
+      "declarations": [
+        {
+          "id": {
+            "name": "foo",
+            "type": "Identifier",
+          },
+          "init": {
+            "type": "Literal",
+            "value": null,
+          },
+          "type": "VariableDeclarator",
+        },
+      ],
+      "kind": "using",
+      "type": "VariableDeclaration",
     },
   ],
   "sourceType": "script",

--- a/test/parser/miscellaneous/commonjs.ts
+++ b/test/parser/miscellaneous/commonjs.ts
@@ -7,13 +7,12 @@ describe('Statements - Return', () => {
     'new.target',
     // https://github.com/acornjs/acorn/issues/1376#issuecomment-2960924476
     { code: 'class X { static { return; } }', options: { sourceType: 'commonjs' } },
-    // The following should be allowed in CommonJS
-    // https://github.com/acornjs/acorn/issues/1376#issuecomment-2960396571
-    { code: 'using foo = null', options: { sourceType: 'commonjs' } },
   ]);
 
   pass('Commonjs (pass)', [
     { code: 'return', options: { sourceType: 'commonjs' } },
     { code: 'new.target', options: { sourceType: 'commonjs' } },
+    // https://github.com/acornjs/acorn/issues/1376#issuecomment-2960396571
+    { code: 'using foo = null', options: { sourceType: 'commonjs' } },
   ]);
 });

--- a/test/parser/statements/using/using.ts
+++ b/test/parser/statements/using/using.ts
@@ -3,6 +3,8 @@ import { type Options } from '../../../../src/options.ts';
 import { parseSource } from '../../../../src/parser.ts';
 
 const moduleOptions: Options = { sourceType: 'module' };
+const commonjsOptions: Options = { sourceType: 'commonjs' };
+const title = (code: string, options?: Options) => (options?.sourceType ? `${code} (${options.sourceType})` : code);
 
 describe('Statements - using declarations', () => {
   const declarations: Array<{
@@ -17,10 +19,11 @@ describe('Statements - using declarations', () => {
     { code: 'async function f() { await using resource = acquire(); }', kind: 'await using' },
     { code: 'async function f() { await /* no line break */ using resource = acquire(); }', kind: 'await using' },
     { code: '{ using first = a, second = b; }', kind: 'using' },
+    { code: 'using resource = acquire();', kind: 'using', options: commonjsOptions },
   ];
 
   for (const { code, kind, options } of declarations) {
-    it(code, () => {
+    it(title(code, options), () => {
       const program = parseSource(code, options);
       const declaration =
         program.body[0].type === 'BlockStatement'
@@ -159,6 +162,8 @@ describe('Statements - using declarations', () => {
 
   const invalidDeclarations: Array<{ code: string; options?: Options }> = [
     { code: 'using resource = acquire();' },
+    { code: 'using resource = acquire();', options: { sourceType: 'script' } },
+    { code: 'await using resource = acquire();', options: commonjsOptions },
     { code: 'await using resource = acquire();' },
     { code: 'function f() { await using resource = acquire(); }' },
     { code: '{ using { resource } = acquire(); }' },
@@ -179,7 +184,7 @@ describe('Statements - using declarations', () => {
   ];
 
   for (const { code, options } of invalidDeclarations) {
-    it(`rejects ${code}`, () => {
+    it(`rejects ${title(code, options)}`, () => {
       expect(() => parseSource(code, options)).toThrow();
     });
   }


### PR DESCRIPTION
Fixes #626

Node accepts a top-level `using` declaration in a `.cjs` wrapper, while `vm.Script` rejects the same declaration under the Script goal; test262's early error permits `UsingDeclaration` inside a `FunctionBody`.

Meriyah already models CommonJS top level as a function body for `return` and `new.target`, so this exempts that context from the top-level Script guard.

Script goal still rejects top-level `using`, and CommonJS still rejects top-level `await using`; both have new negative coverage.

The case was already parked in `test/parser/miscellaneous/commonjs.ts` from #524 as the third row of JLHwung's acorn table after `return` and `new.target`.

I ran the 139-file suite (91,499 tests), the 142-file test262 suite (91,502 tests), production tests, build, lint, and conformance under Node 20, 22, 24, and 26.
