### PR TITLE
fix(parser): fix error location for duplicate binding

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2789,6 +2789,7 @@ function parseImportSpecifierOrNamedImports(
 
   while (parser.getToken() & Token.IsIdentifier || parser.getToken() === Token.StringLiteral) {
     let { tokenValue, tokenStart, currentLocation } = parser;
+    const start = tokenStart;
     const token = parser.getToken();
     const imported = parseModuleExportName(parser, context);
     let local: ESTree.Identifier;
@@ -2803,6 +2804,8 @@ function parseImportSpecifierOrNamedImports(
         validateBindingIdentifier(parser, context, BindingKind.Const, parser.getToken(), 0);
       }
       tokenValue = parser.tokenValue;
+      tokenStart = parser.tokenStart;
+      currentLocation = parser.currentLocation;
       local = parseIdentifier(parser, context);
     } else if (imported.type === 'Identifier') {
       // Keywords cannot be bound to themselves, so an import name
@@ -2825,7 +2828,7 @@ function parseImportSpecifierOrNamedImports(
           local,
           imported,
         },
-        tokenStart,
+        start,
       ),
     );
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1560,7 +1560,7 @@ function parseLetIdentOrVarDeclarationStatement(
   privateScope: PrivateScope | undefined,
   origin: Origin,
 ): ESTree.VariableDeclaration | ESTree.LabeledStatement | ESTree.ExpressionStatement {
-  const { tokenValue, tokenStart } = parser;
+  const { tokenValue, tokenStart, currentLocation } = parser;
   const token = parser.getToken();
   let expr: ESTree.Identifier | ESTree.Expression = parseIdentifier(parser, context);
 
@@ -1628,7 +1628,8 @@ function parseLetIdentOrVarDeclarationStatement(
   if (parser.getToken() === Token.Arrow) {
     let scope: Scope | undefined = void 0;
 
-    if (parser.options.lexical) scope = createArrowHeadParsingScope(parser, context, tokenValue);
+    if (parser.options.lexical)
+      scope = createArrowHeadParsingScope(parser, context, tokenValue, tokenStart, currentLocation);
 
     parser.flags = (parser.flags | Flags.NonSimpleParameterList) ^ Flags.NonSimpleParameterList;
 
@@ -2152,6 +2153,7 @@ function parseForStatement(
         init = parseMemberOrUpdateExpression(parser, context, privateScope, usingIdentifier, 0, 0, tokenStart);
       } else if (parser.getToken() === Token.OfKeyword) {
         const ofStart = parser.tokenStart;
+        const ofEnd = parser.currentLocation;
         const ofToken = parser.getToken();
         const ofValue = parser.tokenValue;
         const ofIdentifier = parseIdentifier(parser, context);
@@ -2169,7 +2171,7 @@ function parseForStatement(
         } else {
           resourceDeclarationKind = 'using';
           validateBindingIdentifier(parser, context, BindingKind.Const, ofToken, 0);
-          scope?.addBlockName(context, ofValue, BindingKind.Const, Origin.ForStatement);
+          scope?.addBlockName(context, ofValue, BindingKind.Const, ofStart, ofEnd, Origin.ForStatement);
 
           let declarationInitializer: ESTree.Expression | null = null;
           if (parser.getToken() === Token.Assign) {
@@ -2501,7 +2503,7 @@ function parseRestrictedIdentifier(parser: Parser, context: Context, scope: Scop
   if (!isValidIdentifier(context, parser.getToken())) parser.report(Errors.UnexpectedStrictReserved);
   if ((parser.getToken() & Token.IsEvalOrArguments) === Token.IsEvalOrArguments)
     parser.report(Errors.StrictEvalArguments);
-  scope?.addBlockName(context, parser.tokenValue, BindingKind.Let);
+  scope?.addBlockName(context, parser.tokenValue, BindingKind.Let, parser.tokenStart, parser.currentLocation);
   return parseIdentifier(parser, context);
 }
 
@@ -2551,7 +2553,7 @@ function parseImportDeclaration(
   } else {
     if (parser.getToken() & Token.IsIdentifier) {
       const token = parser.getToken();
-      const { tokenValue } = parser;
+      const { tokenValue, tokenStart: start, currentLocation } = parser;
       const isPhaseDefer =
         parser.features & Features.ImportDefer && (token & Token.IsEscaped) === 0 && tokenValue == 'defer';
       const isPhaseSource =
@@ -2565,7 +2567,7 @@ function parseImportDeclaration(
             phase = 'defer';
             specifiers = [parseImportNamespaceSpecifier(parser, context, scope)];
           } else if (parser.getToken() === Token.FromKeyword || parser.getToken() === Token.Comma) {
-            scope?.addBlockName(context, tokenValue, BindingKind.Let);
+            scope?.addBlockName(context, tokenValue, BindingKind.Let, start, currentLocation);
             specifiers = [
               parser.finishNode<ESTree.ImportDefaultSpecifier>(
                 {
@@ -2581,11 +2583,12 @@ function parseImportDeclaration(
         } else if (parser.getToken() === Token.FromKeyword) {
           const fromToken = parser.getToken();
           const fromStart = parser.tokenStart;
+          const fromEnd = parser.currentLocation;
           const fromLocal = parseIdentifier(parser, context);
 
           if (parser.getToken() === Token.FromKeyword) {
             validateBindingIdentifier(parser, context, BindingKind.Const, fromToken, 0);
-            scope?.addBlockName(context, fromLocal.name, BindingKind.Let);
+            scope?.addBlockName(context, fromLocal.name, BindingKind.Let, fromStart, fromEnd);
             phase = 'source';
             specifiers = [
               parser.finishNode<ESTree.ImportDefaultSpecifier>(
@@ -2597,7 +2600,7 @@ function parseImportDeclaration(
               ),
             ];
           } else {
-            scope?.addBlockName(context, tokenValue, BindingKind.Let);
+            scope?.addBlockName(context, tokenValue, BindingKind.Let, start, currentLocation);
             specifiers = [
               parser.finishNode<ESTree.ImportDefaultSpecifier>(
                 {
@@ -2625,7 +2628,7 @@ function parseImportDeclaration(
             ),
           ];
         } else if (parser.getToken() === Token.Comma) {
-          scope?.addBlockName(context, tokenValue, BindingKind.Let);
+          scope?.addBlockName(context, tokenValue, BindingKind.Let, start, currentLocation);
           specifiers = [
             parser.finishNode<ESTree.ImportDefaultSpecifier>(
               {
@@ -2785,7 +2788,7 @@ function parseImportSpecifierOrNamedImports(
   nextToken(parser, context);
 
   while (parser.getToken() & Token.IsIdentifier || parser.getToken() === Token.StringLiteral) {
-    let { tokenValue, tokenStart } = parser;
+    let { tokenValue, tokenStart, currentLocation } = parser;
     const token = parser.getToken();
     const imported = parseModuleExportName(parser, context);
     let local: ESTree.Identifier;
@@ -2813,7 +2816,7 @@ function parseImportSpecifierOrNamedImports(
       parser.report(Errors.ExpectedToken, KeywordDescTable[Token.AsKeyword & Token.Type]);
     }
 
-    scope?.addBlockName(context, tokenValue, BindingKind.Let);
+    scope?.addBlockName(context, tokenValue, BindingKind.Let, tokenStart, currentLocation);
 
     specifiers.push(
       parser.finishNode<ESTree.ImportSpecifier>(
@@ -3048,7 +3051,14 @@ function parseExportDeclaration(
               declaration = parseMemberOrUpdateExpression(parser, context, undefined, declaration, 0, 0, tokenStart);
               declaration = parseAssignmentExpression(parser, context, undefined, 0, 0, tokenStart, declaration as any);
             } else if (parser.getToken() & Token.IsIdentifier) {
-              if (scope) scope = createArrowHeadParsingScope(parser, context, parser.tokenValue);
+              if (scope)
+                scope = createArrowHeadParsingScope(
+                  parser,
+                  context,
+                  parser.tokenValue,
+                  parser.tokenStart,
+                  parser.currentLocation,
+                );
 
               declaration = parseIdentifier(parser, context);
               declaration = parseArrowFunctionExpression(
@@ -5250,11 +5260,7 @@ function parseFunctionDeclaration(
     validateFunctionName(parser, context, parser.getToken());
 
     if (scope) {
-      if (kind & BindingKind.Variable) {
-        scope.addVarName(context, parser.tokenValue, kind);
-      } else {
-        scope.addBlockName(context, parser.tokenValue, kind, origin);
-      }
+      scope.addVarOrBlock(context, parser.tokenValue, kind, parser.tokenStart, parser.currentLocation, origin);
 
       functionScope = functionScope?.createChildScope(ScopeKind.FunctionRoot);
 
@@ -5558,7 +5564,7 @@ function parseArrayExpressionOrPattern(
     } else {
       let left: any;
 
-      const { tokenStart, tokenValue } = parser;
+      const { tokenStart, tokenValue, currentLocation } = parser;
       const token = parser.getToken();
 
       if (token & Token.IsIdentifier) {
@@ -5569,7 +5575,7 @@ function parseArrayExpressionOrPattern(
 
           nextToken(parser, context | Context.AllowRegExp);
 
-          scope?.addVarOrBlock(context, tokenValue, kind, origin);
+          scope?.addVarOrBlock(context, tokenValue, kind, tokenStart, currentLocation, origin);
 
           const right = parseExpression(parser, context, privateScope, 1, inGroup, parser.tokenStart);
 
@@ -5599,7 +5605,7 @@ function parseArrayExpressionOrPattern(
           if (parser.assignable & AssignmentTargetKind.Invalid) {
             destructible |= DestructuringKind.CannotDestruct;
           } else {
-            scope?.addVarOrBlock(context, tokenValue, kind, origin);
+            scope?.addVarOrBlock(context, tokenValue, kind, tokenStart, currentLocation, origin);
           }
           destructible |=
             parser.destructible & DestructuringKind.Yield
@@ -5823,7 +5829,7 @@ function parseSpreadOrRestElement(
   let argument: ESTree.Expression | null = null;
   let destructible = DestructuringKind.None;
 
-  const { tokenValue, tokenStart } = parser;
+  const { tokenValue, tokenStart, currentLocation } = parser;
   let token = parser.getToken();
 
   if (token & Token.IsIdentifier) {
@@ -5855,7 +5861,7 @@ function parseSpreadOrRestElement(
     if (parser.assignable & AssignmentTargetKind.Invalid) {
       destructible |= DestructuringKind.CannotDestruct;
     } else if (token === closingToken || token === Token.Comma) {
-      scope?.addVarOrBlock(context, tokenValue, kind, origin);
+      scope?.addVarOrBlock(context, tokenValue, kind, tokenStart, currentLocation, origin);
     } else {
       destructible |= DestructuringKind.Assignable;
     }
@@ -6203,7 +6209,7 @@ function parseObjectLiteralOrPattern(
   context = (context | Context.DisallowIn) ^ Context.DisallowIn;
 
   while (parser.getToken() !== Token.RightBrace) {
-    const { tokenValue, tokenStart } = parser;
+    const { tokenValue, tokenStart, currentLocation } = parser;
     const token = parser.getToken();
 
     if (token === Token.Ellipsis) {
@@ -6247,7 +6253,7 @@ function parseObjectLiteralOrPattern(
             validateBindingIdentifier(parser, context, kind, token, 0);
           }
 
-          scope?.addVarOrBlock(context, tokenValue, kind, origin);
+          scope?.addVarOrBlock(context, tokenValue, kind, tokenStart, currentLocation, origin);
 
           if (consumeOpt(parser, context | Context.AllowRegExp, Token.Assign)) {
             destructible |= DestructuringKind.HasToDestruct;
@@ -6276,7 +6282,7 @@ function parseObjectLiteralOrPattern(
             value = parser.cloneIdentifier(key);
           }
         } else if (consumeOpt(parser, context | Context.AllowRegExp, Token.Colon)) {
-          const { tokenStart } = parser;
+          const { tokenStart, currentLocation } = parser;
 
           if (tokenValue === '__proto__') prototypeCount++;
 
@@ -6296,7 +6302,7 @@ function parseObjectLiteralOrPattern(
                 if (parser.assignable & AssignmentTargetKind.Invalid) {
                   destructible |= DestructuringKind.CannotDestruct;
                 } else if ((tokenAfterColon & Token.IsIdentifier) === Token.IsIdentifier) {
-                  scope?.addVarOrBlock(context, valueAfterColon, kind, origin);
+                  scope?.addVarOrBlock(context, valueAfterColon, kind, tokenStart, currentLocation, origin);
                 }
               } else {
                 destructible |=
@@ -6310,7 +6316,7 @@ function parseObjectLiteralOrPattern(
               } else if (token !== Token.Assign) {
                 destructible |= DestructuringKind.Assignable;
               } else {
-                scope?.addVarOrBlock(context, valueAfterColon, kind, origin);
+                scope?.addVarOrBlock(context, valueAfterColon, kind, tokenStart, currentLocation, origin);
               }
               value = parseAssignmentExpression(parser, context, privateScope, inGroup, isPattern, tokenStart, value);
             } else {
@@ -6502,7 +6508,7 @@ function parseObjectLiteralOrPattern(
           if (parser.getToken() & Token.IsIdentifier) {
             value = parsePrimaryExpression(parser, context, privateScope, kind, 0, 1, inGroup, 1, tokenStart);
 
-            const { tokenValue: valueAfterColon } = parser;
+            const { tokenValue: valueAfterColon, tokenStart: start, currentLocation } = parser;
             const token = parser.getToken();
 
             value = parseMemberOrUpdateExpression(parser, context, privateScope, value, inGroup, 0, tokenStart);
@@ -6512,7 +6518,7 @@ function parseObjectLiteralOrPattern(
                 if (parser.assignable & AssignmentTargetKind.Invalid) {
                   destructible |= DestructuringKind.CannotDestruct;
                 } else {
-                  scope?.addVarOrBlock(context, valueAfterColon, kind, origin);
+                  scope?.addVarOrBlock(context, valueAfterColon, kind, start, currentLocation, origin);
                 }
               } else {
                 destructible |=
@@ -6631,7 +6637,7 @@ function parseObjectLiteralOrPattern(
         if (parser.getToken() === Token.Colon) {
           nextToken(parser, context | Context.AllowRegExp); // skip ':'
 
-          const { tokenStart, tokenValue } = parser;
+          const { tokenStart, tokenValue, currentLocation } = parser;
           const tokenAfterColon = parser.getToken();
 
           if (parser.getToken() & Token.IsIdentifier) {
@@ -6662,7 +6668,7 @@ function parseObjectLiteralOrPattern(
                 if (parser.assignable & AssignmentTargetKind.Invalid) {
                   destructible |= DestructuringKind.CannotDestruct;
                 } else if ((tokenAfterColon & Token.IsIdentifier) === Token.IsIdentifier) {
-                  scope?.addVarOrBlock(context, tokenValue, kind, origin);
+                  scope?.addVarOrBlock(context, tokenValue, kind, tokenStart, currentLocation, origin);
                 }
               } else {
                 destructible |=
@@ -7072,11 +7078,11 @@ function parseParenthesizedExpression(
   parser.assignable = AssignmentTargetKind.Simple;
 
   while (parser.getToken() !== Token.RightParen) {
-    const { tokenStart } = parser;
+    const { tokenStart, currentLocation } = parser;
     const token = parser.getToken();
 
     if (token & Token.IsIdentifier) {
-      scope?.addBlockName(context, parser.tokenValue, BindingKind.ArgumentList);
+      scope?.addBlockName(context, parser.tokenValue, BindingKind.ArgumentList, tokenStart, currentLocation);
 
       if ((token & Token.IsEvalOrArguments) === Token.IsEvalOrArguments) {
         isNonSimpleParameterList = 1;
@@ -7312,8 +7318,7 @@ function parseIdentifierOrArrow(
   context: Context,
   privateScope: PrivateScope | undefined,
 ): ESTree.Identifier | ESTree.ArrowFunctionExpression {
-  const { tokenStart: start } = parser;
-  const { tokenValue } = parser;
+  const { tokenValue, tokenStart, currentLocation } = parser;
 
   let isNonSimpleParameterList: 0 | 1 = 0;
   let hasStrictReserved: 0 | 1 = 0;
@@ -7327,12 +7332,14 @@ function parseIdentifierOrArrow(
   const expr = parseIdentifier(parser, context);
   parser.assignable = AssignmentTargetKind.Simple;
   if (parser.getToken() === Token.Arrow) {
-    const scope = parser.options.lexical ? createArrowHeadParsingScope(parser, context, tokenValue) : undefined;
+    const scope = parser.options.lexical
+      ? createArrowHeadParsingScope(parser, context, tokenValue, tokenStart, currentLocation)
+      : undefined;
 
     if (isNonSimpleParameterList) parser.flags |= Flags.NonSimpleParameterList;
     if (hasStrictReserved) parser.flags |= Flags.HasStrictReserved;
 
-    return parseArrowFunctionExpression(parser, context, scope, privateScope, [expr], /* isAsync */ 0, start);
+    return parseArrowFunctionExpression(parser, context, scope, privateScope, [expr], /* isAsync */ 0, tokenStart);
   }
   return expr;
 }
@@ -7366,7 +7373,9 @@ function parseArrowFromIdentifier(
   if (!canAssign) parser.report(Errors.InvalidAssignmentTarget);
   if (inNew) parser.report(Errors.InvalidAsyncArrow);
   parser.flags &= ~Flags.NonSimpleParameterList;
-  const scope = parser.options.lexical ? createArrowHeadParsingScope(parser, context, value) : void 0;
+  const scope = parser.options.lexical
+    ? createArrowHeadParsingScope(parser, context, value, start, parser.currentLocation)
+    : void 0;
 
   return parseArrowFunctionExpression(parser, context, scope, privateScope, [expr], isAsync, start, origin);
 }
@@ -7969,11 +7978,11 @@ function parseAsyncArrowOrCallExpression(
   // const previousContext = context;
   // context = context | Context.InArgumentList;
   while (parser.getToken() !== Token.RightParen) {
-    const { tokenStart } = parser;
+    const { tokenStart, currentLocation } = parser;
     const token = parser.getToken();
 
     if (token & Token.IsIdentifier) {
-      scope?.addBlockName(context, parser.tokenValue, kind);
+      scope?.addBlockName(context, parser.tokenValue, kind, tokenStart, currentLocation);
 
       if ((token & Token.IsEvalOrArguments) === Token.IsEvalOrArguments) {
         parser.flags |= Flags.StrictEvalArguments;
@@ -8213,7 +8222,7 @@ function parseClassDeclaration(
   let id: ESTree.Expression | null = null;
   let superClass: ESTree.Expression | null = null;
 
-  const { tokenValue } = parser;
+  const { tokenValue, tokenStart, currentLocation } = parser;
 
   if (parser.getToken() & Token.Keyword && parser.getToken() !== Token.ExtendsKeyword) {
     if (isStrictReservedWord(parser, context, parser.getToken())) {
@@ -8227,7 +8236,7 @@ function parseClassDeclaration(
     if (scope) {
       // A named class creates a new lexical scope with a const binding of the
       // class name for the "inner name".
-      scope.addBlockName(context, tokenValue, BindingKind.Class);
+      scope.addBlockName(context, tokenValue, BindingKind.Class, tokenStart, currentLocation);
 
       if (flags) {
         if (flags & HoistedClassFlags.Export) {
@@ -9020,17 +9029,17 @@ function parseAndClassifyIdentifier(
     if (context & Context.Module) parser.report(Errors.AwaitIdentInModuleOrAsyncFunc);
   }
 
-  const { tokenValue, tokenStart: start } = parser;
+  const { tokenValue, tokenStart, currentLocation } = parser;
   nextToken(parser, context);
 
-  scope?.addVarOrBlock(context, tokenValue, kind, origin);
+  scope?.addVarOrBlock(context, tokenValue, kind, tokenStart, currentLocation, origin);
 
   return parser.finishNode<ESTree.Identifier>(
     {
       type: 'Identifier',
       name: tokenValue,
     },
-    start,
+    tokenStart,
   );
 }
 

--- a/src/parser/scope.ts
+++ b/src/parser/scope.ts
@@ -190,6 +190,10 @@ export class Scope {
    * @param type Errors type
    */
   recordScopeError(type: Errors, tokenStart: Location, tokenEnd: Location, ...params: string[]) {
+    // Only record the first error, subsequent errors will be ignored
+    if (this.scopeError) {
+      return;
+    }
     this.scopeError = {
       type,
       params,

--- a/src/parser/scope.ts
+++ b/src/parser/scope.ts
@@ -54,11 +54,18 @@ export class Scope {
    * @param type Binding kind
    * @param origin Binding Origin
    */
-  addVarOrBlock(context: Context, name: string, kind: BindingKind, origin: Origin) {
+  addVarOrBlock(
+    context: Context,
+    name: string,
+    kind: BindingKind,
+    tokenStart: Location,
+    tokenEnd: Location,
+    origin: Origin,
+  ) {
     if (kind & BindingKind.Variable) {
-      this.addVarName(context, name, kind);
+      this.addVarName(context, name, kind, tokenStart, tokenEnd);
     } else {
-      this.addBlockName(context, name, kind, origin);
+      this.addBlockName(context, name, kind, tokenStart, tokenEnd, origin);
     }
     if (origin & Origin.Export) {
       this.parser.declareUnboundVariable(name);
@@ -71,8 +78,10 @@ export class Scope {
    * @param context Context masks
    * @param name Binding name
    * @param type Binding kind
+   * @param tokenStart Token start location
+   * @param tokenEnd Token end location
    */
-  addVarName(context: Context, name: string, kind: BindingKind): void {
+  addVarName(context: Context, name: string, kind: BindingKind, tokenStart: Location, tokenEnd: Location): void {
     const { parser } = this;
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     let currentScope: Scope | undefined = this;
@@ -90,19 +99,19 @@ export class Scope {
         ) {
           // No op
         } else {
-          parser.report(Errors.DuplicateBinding, name);
+          throw new ParseError(tokenStart, tokenEnd, Errors.DuplicateBinding, name);
         }
       }
       if (currentScope === this) {
         if (value && value & BindingKind.ArgumentList && kind & BindingKind.ArgumentList) {
-          currentScope.recordScopeError(Errors.DuplicateBinding, name);
+          currentScope.recordScopeError(Errors.DuplicateBinding, tokenStart, tokenEnd, name);
         }
       }
       if (
         value &&
         (value & BindingKind.CatchPattern || (value & BindingKind.CatchIdentifier && !parser.options.webcompat))
       ) {
-        parser.report(Errors.DuplicateBinding, name);
+        throw new ParseError(tokenStart, tokenEnd, Errors.DuplicateBinding, name);
       }
 
       currentScope.variableBindings.set(name, kind);
@@ -121,15 +130,24 @@ export class Scope {
    * @param context Context masks
    * @param name Binding name
    * @param type Binding kind
+   * @param tokenStart Token start location
+   * @param tokenEnd Token end location
    * @param origin Binding Origin
    */
-  addBlockName(context: Context, name: string, kind: BindingKind, origin: Origin = Origin.None): void {
+  addBlockName(
+    context: Context,
+    name: string,
+    kind: BindingKind,
+    tokenStart: Location,
+    tokenEnd: Location,
+    origin: Origin = Origin.None,
+  ): void {
     const { parser } = this;
     const value = this.variableBindings.get(name);
 
     if (value && (value & BindingKind.Empty) === 0) {
       if (kind & BindingKind.ArgumentList) {
-        this.recordScopeError(Errors.DuplicateBinding, name);
+        this.recordScopeError(Errors.DuplicateBinding, tokenStart, tokenEnd, name);
       } else if (
         parser.options.webcompat &&
         (context & Context.Strict) === 0 &&
@@ -139,7 +157,7 @@ export class Scope {
       ) {
         // No op
       } else {
-        parser.report(Errors.DuplicateBinding, name);
+        throw new ParseError(tokenStart, tokenEnd, Errors.DuplicateBinding, name);
       }
     }
 
@@ -148,18 +166,18 @@ export class Scope {
       this.parent?.hasVariable(name) &&
       (this.parent.variableBindings.get(name)! & BindingKind.Empty) === 0
     ) {
-      parser.report(Errors.DuplicateBinding, name);
+      throw new ParseError(tokenStart, tokenEnd, Errors.DuplicateBinding, name);
     }
 
     if (this.type & ScopeKind.ArrowParams && value && (value & BindingKind.Empty) === 0) {
       if (kind & BindingKind.ArgumentList) {
-        this.recordScopeError(Errors.DuplicateBinding, name);
+        this.recordScopeError(Errors.DuplicateBinding, tokenStart, tokenEnd, name);
       }
     }
 
     if (this.type & ScopeKind.CatchBlock) {
       if (this.parent!.variableBindings.get(name)! & BindingKind.CatchIdentifierOrPattern)
-        parser.report(Errors.ShadowedCatchClause, name);
+        throw new ParseError(tokenStart, tokenEnd, Errors.ShadowedCatchClause, name);
     }
 
     this.variableBindings.set(name, kind);
@@ -171,12 +189,12 @@ export class Scope {
    * @param parser Parser state
    * @param type Errors type
    */
-  recordScopeError(type: Errors, ...params: string[]) {
+  recordScopeError(type: Errors, tokenStart: Location, tokenEnd: Location, ...params: string[]) {
     this.scopeError = {
       type,
       params,
-      start: this.parser.tokenStart,
-      end: this.parser.currentLocation,
+      start: tokenStart,
+      end: tokenEnd,
     };
   }
 
@@ -196,9 +214,18 @@ export class Scope {
  * @param parser Parser state
  * @param context Context masks
  * @param value Binding name to be declared
+ * @param tokenStart Token start location
+ * @param tokenEnd Token end location
+ * @returns Scope
  */
-export function createArrowHeadParsingScope(parser: Parser, context: Context, value: string): Scope {
+export function createArrowHeadParsingScope(
+  parser: Parser,
+  context: Context,
+  value: string,
+  tokenStart: Location,
+  tokenEnd: Location,
+): Scope {
   const scope = parser.createScope().createChildScope(ScopeKind.ArrowParams);
-  scope.addBlockName(context, value, BindingKind.ArgumentList);
+  scope.addBlockName(context, value, BindingKind.ArgumentList, tokenStart, tokenEnd);
   return scope;
 }

--- a/src/parser/scope.ts
+++ b/src/parser/scope.ts
@@ -191,10 +191,7 @@ export class Scope {
    */
   recordScopeError(type: Errors, tokenStart: Location, tokenEnd: Location, ...params: string[]) {
     // Only record the first error, subsequent errors will be ignored
-    if (this.scopeError) {
-      return;
-    }
-    this.scopeError = {
+    this.scopeError ??= {
       type,
       params,
       start: tokenStart,

--- a/test/parser/lexical/__snapshots__/annexb.ts.snap
+++ b/test/parser/lexical/__snapshots__/annexb.ts.snap
@@ -43,13 +43,13 @@ exports[`Lexical - AnnexB > Lexical - AnnexB (fail) > function f(){ var f = 123;
 `;
 
 exports[`Lexical - AnnexB > Lexical - AnnexB (fail) > let x; var x; 1`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'x'
+"SyntaxError [1:11-1:12]: Duplicate binding 'x'
 > 1 | let x; var x;
-    |             ^ Duplicate binding 'x'"
+    |            ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - AnnexB > Lexical - AnnexB (fail) > var x; let x; 1`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'x'
+"SyntaxError [1:11-1:12]: Duplicate binding 'x'
 > 1 | var x; let x;
-    |             ^ Duplicate binding 'x'"
+    |            ^ Duplicate binding 'x'"
 `;

--- a/test/parser/lexical/__snapshots__/arrow.ts.snap
+++ b/test/parser/lexical/__snapshots__/arrow.ts.snap
@@ -145,21 +145,21 @@ exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([b, a, a]) => {} 1`] = `
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([b, a, b, a]) => {} 1`] = `
-"SyntaxError [1:11-1:12]: Duplicate binding 'a'
+"SyntaxError [1:8-1:9]: Duplicate binding 'b'
 > 1 | ([b, a, b, a]) => {}
-    |            ^ Duplicate binding 'a'"
+    |         ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([b, a, b, a]) => {} 2`] = `
-"SyntaxError [1:11-1:12]: Duplicate binding 'a'
+"SyntaxError [1:8-1:9]: Duplicate binding 'b'
 > 1 | ([b, a, b, a]) => {}
-    |            ^ Duplicate binding 'a'"
+    |         ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([b, a, b, a]) => {} 3`] = `
-"SyntaxError [1:11-1:12]: Duplicate binding 'a'
+"SyntaxError [1:8-1:9]: Duplicate binding 'b'
 > 1 | ([b, a, b, a]) => {}
-    |            ^ Duplicate binding 'a'"
+    |         ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([b, a], ...b) => {} 1`] = `
@@ -433,57 +433,57 @@ exports[`Lexical - Arrows > Lexical - Arrows (fail) > (b, a, a) => {} 1`] = `
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (b, a, b, ...a) => {} 1`] = `
-"SyntaxError [1:13-1:14]: Duplicate binding 'a'
+"SyntaxError [1:7-1:8]: Duplicate binding 'b'
 > 1 | (b, a, b, ...a) => {}
-    |              ^ Duplicate binding 'a'"
+    |        ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (b, a, b, a = x) => {} 1`] = `
-"SyntaxError [1:10-1:11]: Duplicate binding 'a'
+"SyntaxError [1:7-1:8]: Duplicate binding 'b'
 > 1 | (b, a, b, a = x) => {}
-    |           ^ Duplicate binding 'a'"
+    |        ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (b, a, b, a = x) => {} 2`] = `
-"SyntaxError [1:10-1:11]: Duplicate binding 'a'
+"SyntaxError [1:7-1:8]: Duplicate binding 'b'
 > 1 | (b, a, b, a = x) => {}
-    |           ^ Duplicate binding 'a'"
+    |        ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (b, a, b, a = x) => {} 3`] = `
-"SyntaxError [1:10-1:11]: Duplicate binding 'a'
+"SyntaxError [1:7-1:8]: Duplicate binding 'b'
 > 1 | (b, a, b, a = x) => {}
-    |           ^ Duplicate binding 'a'"
+    |        ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (b, a, b, a) => {} 1`] = `
-"SyntaxError [1:10-1:11]: Duplicate binding 'a'
+"SyntaxError [1:7-1:8]: Duplicate binding 'b'
 > 1 | (b, a, b, a) => {}
-    |           ^ Duplicate binding 'a'"
+    |        ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (b, a, b, a) => {} 2`] = `
-"SyntaxError [1:10-1:11]: Duplicate binding 'a'
+"SyntaxError [1:7-1:8]: Duplicate binding 'b'
 > 1 | (b, a, b, a) => {}
-    |           ^ Duplicate binding 'a'"
+    |        ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (b, a, b, a, [x]) => {} 1`] = `
-"SyntaxError [1:10-1:11]: Duplicate binding 'a'
+"SyntaxError [1:7-1:8]: Duplicate binding 'b'
 > 1 | (b, a, b, a, [x]) => {}
-    |           ^ Duplicate binding 'a'"
+    |        ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (b, a, b, a, [x]) => {} 2`] = `
-"SyntaxError [1:10-1:11]: Duplicate binding 'a'
+"SyntaxError [1:7-1:8]: Duplicate binding 'b'
 > 1 | (b, a, b, a, [x]) => {}
-    |           ^ Duplicate binding 'a'"
+    |        ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (b, a, b, a, [x]) => {} 3`] = `
-"SyntaxError [1:10-1:11]: Duplicate binding 'a'
+"SyntaxError [1:7-1:8]: Duplicate binding 'b'
 > 1 | (b, a, b, a, [x]) => {}
-    |           ^ Duplicate binding 'a'"
+    |        ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (x) => { const x = y } 1`] = `

--- a/test/parser/lexical/__snapshots__/arrow.ts.snap
+++ b/test/parser/lexical/__snapshots__/arrow.ts.snap
@@ -1,15 +1,15 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > () => { let a; var a; } 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'a'
+"SyntaxError [1:19-1:20]: Duplicate binding 'a'
 > 1 | () => { let a; var a; }
-    |                     ^ Duplicate binding 'a'"
+    |                    ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > () => { let x; var x; } 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'x'
+"SyntaxError [1:19-1:20]: Duplicate binding 'x'
 > 1 | () => { let x; var x; }
-    |                     ^ Duplicate binding 'x'"
+    |                    ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > () => { return {}; }; let {x:foo()} = {}; 1`] = `
@@ -19,9 +19,9 @@ exports[`Lexical - Arrows > Lexical - Arrows (fail) > () => { return {}; }; let 
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > () => { var x; let x; } 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'x'
+"SyntaxError [1:19-1:20]: Duplicate binding 'x'
 > 1 | () => { var x; let x; }
-    |                     ^ Duplicate binding 'x'"
+    |                    ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (...a = x,) => x 1`] = `
@@ -43,75 +43,75 @@ exports[`Lexical - Arrows > Lexical - Arrows (fail) > (...a,) 1`] = `
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([{foo}] = x, [{foo}]) => {} 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'foo'
+"SyntaxError [1:16-1:19]: Duplicate binding 'foo'
 > 1 | ([{foo}] = x, [{foo}]) => {}
-    |                    ^ Duplicate binding 'foo'"
+    |                 ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([{foo}] = x, {foo}) => {} 1`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'foo'
+"SyntaxError [1:15-1:18]: Duplicate binding 'foo'
 > 1 | ([{foo}] = x, {foo}) => {}
-    |                   ^ Duplicate binding 'foo'"
+    |                ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([a, a, b]) => {} 1`] = `
-"SyntaxError [1:6-1:7]: Duplicate binding 'a'
+"SyntaxError [1:5-1:6]: Duplicate binding 'a'
 > 1 | ([a, a, b]) => {}
-    |       ^ Duplicate binding 'a'"
+    |      ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([a, a]) => {} 1`] = `
-"SyntaxError [1:6-1:7]: Duplicate binding 'a'
+"SyntaxError [1:5-1:6]: Duplicate binding 'a'
 > 1 | ([a, a]) => {}
-    |       ^ Duplicate binding 'a'"
+    |      ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([a, a]) => 0; 1`] = `
-"SyntaxError [1:6-1:7]: Duplicate binding 'a'
+"SyntaxError [1:5-1:6]: Duplicate binding 'a'
 > 1 | ([a, a]) => 0;
-    |       ^ Duplicate binding 'a'"
+    |      ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([a, b, a]) => {} 1`] = `
-"SyntaxError [1:9-1:10]: Duplicate binding 'a'
+"SyntaxError [1:8-1:9]: Duplicate binding 'a'
 > 1 | ([a, b, a]) => {}
-    |          ^ Duplicate binding 'a'"
+    |         ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([a,b,c]) => { const c = x; } 1`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'c'
+"SyntaxError [1:21-1:22]: Duplicate binding 'c'
 > 1 | ([a,b,c]) => { const c = x; }
-    |                        ^ Duplicate binding 'c'"
+    |                      ^ Duplicate binding 'c'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([a,b,c]) => { const c = x; } 2`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'c'
+"SyntaxError [1:21-1:22]: Duplicate binding 'c'
 > 1 | ([a,b,c]) => { const c = x; }
-    |                        ^ Duplicate binding 'c'"
+    |                      ^ Duplicate binding 'c'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([a,b,c]) => { const c = x; } 3`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'c'
+"SyntaxError [1:21-1:22]: Duplicate binding 'c'
 > 1 | ([a,b,c]) => { const c = x; }
-    |                        ^ Duplicate binding 'c'"
+    |                      ^ Duplicate binding 'c'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([a,b,c]) => { const c = x; } 4`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'c'
+"SyntaxError [1:21-1:22]: Duplicate binding 'c'
 > 1 | ([a,b,c]) => { const c = x; }
-    |                        ^ Duplicate binding 'c'"
+    |                      ^ Duplicate binding 'c'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([a]) => { const a = 0; } 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'a'
 > 1 | ([a]) => { const a = 0; }
-    |                    ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([a]) => { let a; } 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'a'
+"SyntaxError [1:15-1:16]: Duplicate binding 'a'
 > 1 | ([a]) => { let a; }
-    |                 ^ Duplicate binding 'a'"
+    |                ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([a], a, ...b) => {} 1`] = `
@@ -127,69 +127,69 @@ exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([a], a, ...b) => {} 2`] =
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([a],...a)=>0 1`] = `
-"SyntaxError [1:9-1:10]: Duplicate binding 'a'
+"SyntaxError [1:8-1:9]: Duplicate binding 'a'
 > 1 | ([a],...a)=>0
-    |          ^ Duplicate binding 'a'"
+    |         ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([a],...a)=>0 2`] = `
-"SyntaxError [1:9-1:10]: Duplicate binding 'a'
+"SyntaxError [1:8-1:9]: Duplicate binding 'a'
 > 1 | ([a],...a)=>0
-    |          ^ Duplicate binding 'a'"
+    |         ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([b, a, a]) => {} 1`] = `
-"SyntaxError [1:9-1:10]: Duplicate binding 'a'
+"SyntaxError [1:8-1:9]: Duplicate binding 'a'
 > 1 | ([b, a, a]) => {}
-    |          ^ Duplicate binding 'a'"
+    |         ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([b, a, b, a]) => {} 1`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'a'
+"SyntaxError [1:11-1:12]: Duplicate binding 'a'
 > 1 | ([b, a, b, a]) => {}
-    |             ^ Duplicate binding 'a'"
+    |            ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([b, a, b, a]) => {} 2`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'a'
+"SyntaxError [1:11-1:12]: Duplicate binding 'a'
 > 1 | ([b, a, b, a]) => {}
-    |             ^ Duplicate binding 'a'"
+    |            ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([b, a, b, a]) => {} 3`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'a'
+"SyntaxError [1:11-1:12]: Duplicate binding 'a'
 > 1 | ([b, a, b, a]) => {}
-    |             ^ Duplicate binding 'a'"
+    |            ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([b, a], ...b) => {} 1`] = `
-"SyntaxError [1:13-1:14]: Duplicate binding 'b'
+"SyntaxError [1:12-1:13]: Duplicate binding 'b'
 > 1 | ([b, a], ...b) => {}
-    |              ^ Duplicate binding 'b'"
+    |             ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([b, a], ...b) => {} 2`] = `
-"SyntaxError [1:13-1:14]: Duplicate binding 'b'
+"SyntaxError [1:12-1:13]: Duplicate binding 'b'
 > 1 | ([b, a], ...b) => {}
-    |              ^ Duplicate binding 'b'"
+    |             ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([b, a], {b}) => {} 1`] = `
-"SyntaxError [1:11-1:12]: Duplicate binding 'b'
+"SyntaxError [1:10-1:11]: Duplicate binding 'b'
 > 1 | ([b, a], {b}) => {}
-    |            ^ Duplicate binding 'b'"
+    |           ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([b, a], {b}) => {} 2`] = `
-"SyntaxError [1:11-1:12]: Duplicate binding 'b'
+"SyntaxError [1:10-1:11]: Duplicate binding 'b'
 > 1 | ([b, a], {b}) => {}
-    |            ^ Duplicate binding 'b'"
+    |           ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([b, a], {b}) => {} 3`] = `
-"SyntaxError [1:11-1:12]: Duplicate binding 'b'
+"SyntaxError [1:10-1:11]: Duplicate binding 'b'
 > 1 | ([b, a], {b}) => {}
-    |            ^ Duplicate binding 'b'"
+    |           ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([b, a], b) => {} 1`] = `
@@ -229,33 +229,33 @@ exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([b, a], b=x) => {} 3`] = 
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([foo] = x, [foo] = y) => {} 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'foo'
+"SyntaxError [1:13-1:16]: Duplicate binding 'foo'
 > 1 | ([foo] = x, [foo] = y) => {}
-    |                 ^ Duplicate binding 'foo'"
+    |              ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([foo], [foo]) => {} 1`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'foo'
+"SyntaxError [1:9-1:12]: Duplicate binding 'foo'
 > 1 | ([foo], [foo]) => {}
-    |             ^ Duplicate binding 'foo'"
+    |          ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([x, x]) => {} 1`] = `
-"SyntaxError [1:6-1:7]: Duplicate binding 'x'
+"SyntaxError [1:5-1:6]: Duplicate binding 'x'
 > 1 | ([x, x]) => {}
-    |       ^ Duplicate binding 'x'"
+    |      ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([x], [x]) => {} 1`] = `
-"SyntaxError [1:8-1:9]: Duplicate binding 'x'
+"SyntaxError [1:7-1:8]: Duplicate binding 'x'
 > 1 | ([x], [x]) => {}
-    |         ^ Duplicate binding 'x'"
+    |        ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([x], {x:x}) => {} 1`] = `
-"SyntaxError [1:10-1:11]: Duplicate binding 'x'
+"SyntaxError [1:9-1:10]: Duplicate binding 'x'
 > 1 | ([x], {x:x}) => {}
-    |           ^ Duplicate binding 'x'"
+    |          ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([x], x) => {} 1`] = `
@@ -265,15 +265,15 @@ exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([x], x) => {} 1`] = `
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({"x": x, x: x}) => a 1`] = `
-"SyntaxError [1:14-1:15]: Duplicate binding 'x'
+"SyntaxError [1:13-1:14]: Duplicate binding 'x'
 > 1 | ({"x": x, x: x}) => a
-    |               ^ Duplicate binding 'x'"
+    |              ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({"x": y, x: x = y}) => { let y; } 1`] = `
-"SyntaxError [1:31-1:32]: Duplicate binding 'y'
+"SyntaxError [1:30-1:31]: Duplicate binding 'y'
 > 1 | ({"x": y, x: x = y}) => { let y; }
-    |                                ^ Duplicate binding 'y'"
+    |                               ^ Duplicate binding 'y'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({1: x, 2: x}) => a 1`] = `
@@ -283,111 +283,111 @@ exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({1: x, 2: x}) => a 1`] = 
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({2: y, "x": x = y}) => { let y; } 1`] = `
-"SyntaxError [1:31-1:32]: Duplicate binding 'y'
+"SyntaxError [1:30-1:31]: Duplicate binding 'y'
 > 1 | ({2: y, "x": x = y}) => { let y; }
-    |                                ^ Duplicate binding 'y'"
+    |                               ^ Duplicate binding 'y'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({a, a}) => 0; 1`] = `
-"SyntaxError [1:6-1:7]: Duplicate binding 'a'
+"SyntaxError [1:5-1:6]: Duplicate binding 'a'
 > 1 | ({a, a}) => 0;
-    |       ^ Duplicate binding 'a'"
+    |      ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({a}) => { const a = 0; } 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'a'
-> 1 | ({a}) => { const a = 0; }
-    |                    ^ Duplicate binding 'a'"
-`;
-
-exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({a}) => { let a; } 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'a'
-> 1 | ({a}) => { let a; }
-    |                 ^ Duplicate binding 'a'"
-`;
-
-exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({a}) => { let a; } 2`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'a'
-> 1 | ({a}) => { let a; }
-    |                 ^ Duplicate binding 'a'"
-`;
-
-exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({foo} = x, {foo}) => {} 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'foo'
-> 1 | ({foo} = x, {foo}) => {}
-    |                 ^ Duplicate binding 'foo'"
-`;
-
-exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({x: x, x: x}) => a 1`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'x'
-> 1 | ({x: x, x: x}) => a
-    |             ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({x: x, x: x}) => a 2`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'x'
-> 1 | ({x: x, x: x}) => a
-    |             ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({x: y, x: x = y}) => { let y; } 1`] = `
-"SyntaxError [1:29-1:30]: Duplicate binding 'y'
-> 1 | ({x: y, x: x = y}) => { let y; }
-    |                              ^ Duplicate binding 'y'"
-`;
-
-exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({x:x, x:x}) => {} 1`] = `
-"SyntaxError [1:10-1:11]: Duplicate binding 'x'
-> 1 | ({x:x, x:x}) => {}
-    |           ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({y: x, x}) => 1; 1`] = `
-"SyntaxError [1:9-1:10]: Duplicate binding 'x'
-> 1 | ({y: x, x}) => 1;
-    |          ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({y: x, x}) => 1; 2`] = `
-"SyntaxError [1:9-1:10]: Duplicate binding 'x'
-> 1 | ({y: x, x}) => 1;
-    |          ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({y: x}, ...x) => 1; 1`] = `
-"SyntaxError [1:13-1:14]: Duplicate binding 'x'
-> 1 | ({y: x}, ...x) => 1;
-    |              ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({y: x}, ...x) => 1; 2`] = `
-"SyntaxError [1:13-1:14]: Duplicate binding 'x'
-> 1 | ({y: x}, ...x) => 1;
-    |              ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - Arrows > Lexical - Arrows (fail) > (a = b => { let b; }) 1`] = `
-"SyntaxError [1:17-1:18]: Duplicate binding 'b'
-> 1 | (a = b => { let b; })
-    |                  ^ Duplicate binding 'b'"
-`;
-
-exports[`Lexical - Arrows > Lexical - Arrows (fail) > (a = b => { let b; }) 2`] = `
-"SyntaxError [1:17-1:18]: Duplicate binding 'b'
-> 1 | (a = b => { let b; })
-    |                  ^ Duplicate binding 'b'"
-`;
-
-exports[`Lexical - Arrows > Lexical - Arrows (fail) > (a) => { const a = 0; } 1`] = `
 "SyntaxError [1:17-1:18]: Duplicate binding 'a'
-> 1 | (a) => { const a = 0; }
+> 1 | ({a}) => { const a = 0; }
     |                  ^ Duplicate binding 'a'"
 `;
 
+exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({a}) => { let a; } 1`] = `
+"SyntaxError [1:15-1:16]: Duplicate binding 'a'
+> 1 | ({a}) => { let a; }
+    |                ^ Duplicate binding 'a'"
+`;
+
+exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({a}) => { let a; } 2`] = `
+"SyntaxError [1:15-1:16]: Duplicate binding 'a'
+> 1 | ({a}) => { let a; }
+    |                ^ Duplicate binding 'a'"
+`;
+
+exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({foo} = x, {foo}) => {} 1`] = `
+"SyntaxError [1:13-1:16]: Duplicate binding 'foo'
+> 1 | ({foo} = x, {foo}) => {}
+    |              ^^^ Duplicate binding 'foo'"
+`;
+
+exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({x: x, x: x}) => a 1`] = `
+"SyntaxError [1:11-1:12]: Duplicate binding 'x'
+> 1 | ({x: x, x: x}) => a
+    |            ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({x: x, x: x}) => a 2`] = `
+"SyntaxError [1:11-1:12]: Duplicate binding 'x'
+> 1 | ({x: x, x: x}) => a
+    |            ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({x: y, x: x = y}) => { let y; } 1`] = `
+"SyntaxError [1:28-1:29]: Duplicate binding 'y'
+> 1 | ({x: y, x: x = y}) => { let y; }
+    |                             ^ Duplicate binding 'y'"
+`;
+
+exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({x:x, x:x}) => {} 1`] = `
+"SyntaxError [1:9-1:10]: Duplicate binding 'x'
+> 1 | ({x:x, x:x}) => {}
+    |          ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({y: x, x}) => 1; 1`] = `
+"SyntaxError [1:8-1:9]: Duplicate binding 'x'
+> 1 | ({y: x, x}) => 1;
+    |         ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({y: x, x}) => 1; 2`] = `
+"SyntaxError [1:8-1:9]: Duplicate binding 'x'
+> 1 | ({y: x, x}) => 1;
+    |         ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({y: x}, ...x) => 1; 1`] = `
+"SyntaxError [1:12-1:13]: Duplicate binding 'x'
+> 1 | ({y: x}, ...x) => 1;
+    |             ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - Arrows > Lexical - Arrows (fail) > ({y: x}, ...x) => 1; 2`] = `
+"SyntaxError [1:12-1:13]: Duplicate binding 'x'
+> 1 | ({y: x}, ...x) => 1;
+    |             ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - Arrows > Lexical - Arrows (fail) > (a = b => { let b; }) 1`] = `
+"SyntaxError [1:16-1:17]: Duplicate binding 'b'
+> 1 | (a = b => { let b; })
+    |                 ^ Duplicate binding 'b'"
+`;
+
+exports[`Lexical - Arrows > Lexical - Arrows (fail) > (a = b => { let b; }) 2`] = `
+"SyntaxError [1:16-1:17]: Duplicate binding 'b'
+> 1 | (a = b => { let b; })
+    |                 ^ Duplicate binding 'b'"
+`;
+
+exports[`Lexical - Arrows > Lexical - Arrows (fail) > (a) => { const a = 0; } 1`] = `
+"SyntaxError [1:15-1:16]: Duplicate binding 'a'
+> 1 | (a) => { const a = 0; }
+    |                ^ Duplicate binding 'a'"
+`;
+
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (a) => { let a; } 1`] = `
-"SyntaxError [1:14-1:15]: Duplicate binding 'a'
+"SyntaxError [1:13-1:14]: Duplicate binding 'a'
 > 1 | (a) => { let a; }
-    |               ^ Duplicate binding 'a'"
+    |              ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (a, a = b) => {} 1`] = `
@@ -421,9 +421,9 @@ exports[`Lexical - Arrows > Lexical - Arrows (fail) > (a, b, a) => {} 2`] = `
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (a,...a)=>0 1`] = `
-"SyntaxError [1:7-1:8]: Duplicate binding 'a'
+"SyntaxError [1:6-1:7]: Duplicate binding 'a'
 > 1 | (a,...a)=>0
-    |        ^ Duplicate binding 'a'"
+    |       ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (b, a, a) => {} 1`] = `
@@ -433,9 +433,9 @@ exports[`Lexical - Arrows > Lexical - Arrows (fail) > (b, a, a) => {} 1`] = `
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (b, a, b, ...a) => {} 1`] = `
-"SyntaxError [1:14-1:15]: Duplicate binding 'a'
+"SyntaxError [1:13-1:14]: Duplicate binding 'a'
 > 1 | (b, a, b, ...a) => {}
-    |               ^ Duplicate binding 'a'"
+    |              ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (b, a, b, a = x) => {} 1`] = `
@@ -487,123 +487,123 @@ exports[`Lexical - Arrows > Lexical - Arrows (fail) > (b, a, b, a, [x]) => {} 3`
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (x) => { const x = y } 1`] = `
-"SyntaxError [1:17-1:18]: Duplicate binding 'x'
+"SyntaxError [1:15-1:16]: Duplicate binding 'x'
 > 1 | (x) => { const x = y }
-    |                  ^ Duplicate binding 'x'"
+    |                ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (x) => { const x = y } 2`] = `
-"SyntaxError [1:17-1:18]: Duplicate binding 'x'
+"SyntaxError [1:15-1:16]: Duplicate binding 'x'
 > 1 | (x) => { const x = y }
-    |                  ^ Duplicate binding 'x'"
+    |                ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (x) => { let x } 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'x'
+"SyntaxError [1:13-1:14]: Duplicate binding 'x'
 > 1 | (x) => { let x }
-    |                ^ Duplicate binding 'x'"
+    |              ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (x) => { let x } 2`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'x'
+"SyntaxError [1:13-1:14]: Duplicate binding 'x'
 > 1 | (x) => { let x }
-    |                ^ Duplicate binding 'x'"
+    |              ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (x, [x]) => {} 1`] = `
-"SyntaxError [1:6-1:7]: Duplicate binding 'x'
+"SyntaxError [1:5-1:6]: Duplicate binding 'x'
 > 1 | (x, [x]) => {}
-    |       ^ Duplicate binding 'x'"
+    |      ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (x, {y: x}) => 1; 1`] = `
-"SyntaxError [1:9-1:10]: Duplicate binding 'x'
+"SyntaxError [1:8-1:9]: Duplicate binding 'x'
 > 1 | (x, {y: x}) => 1;
-    |          ^ Duplicate binding 'x'"
+    |         ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (x, {y: x}) => 1; 2`] = `
-"SyntaxError [1:9-1:10]: Duplicate binding 'x'
+"SyntaxError [1:8-1:9]: Duplicate binding 'x'
 > 1 | (x, {y: x}) => 1;
-    |          ^ Duplicate binding 'x'"
+    |         ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (x, {y: x}) => 1; 3`] = `
-"SyntaxError [1:9-1:10]: Duplicate binding 'x'
+"SyntaxError [1:8-1:9]: Duplicate binding 'x'
 > 1 | (x, {y: x}) => 1;
-    |          ^ Duplicate binding 'x'"
+    |         ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > a = b => { let b; } 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'b'
+"SyntaxError [1:15-1:16]: Duplicate binding 'b'
 > 1 | a = b => { let b; }
-    |                 ^ Duplicate binding 'b'"
+    |                ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > a = b => { let b; } 2`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'b'
+"SyntaxError [1:15-1:16]: Duplicate binding 'b'
 > 1 | a = b => { let b; }
-    |                 ^ Duplicate binding 'b'"
+    |                ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > a => {  const a = y; function x(){}  } 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'a'
+"SyntaxError [1:14-1:15]: Duplicate binding 'a'
 > 1 | a => {  const a = y; function x(){}  }
-    |                 ^ Duplicate binding 'a'"
+    |               ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > a => { const a } 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'a'
+"SyntaxError [1:13-1:14]: Duplicate binding 'a'
 > 1 | a => { const a }
-    |                ^ Duplicate binding 'a'"
+    |              ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > a => { const a } 2`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'a'
+"SyntaxError [1:13-1:14]: Duplicate binding 'a'
 > 1 | a => { const a }
-    |                ^ Duplicate binding 'a'"
+    |              ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > a => { let [a] = x; } 1`] = `
-"SyntaxError [1:13-1:14]: Duplicate binding 'a'
+"SyntaxError [1:12-1:13]: Duplicate binding 'a'
 > 1 | a => { let [a] = x; }
-    |              ^ Duplicate binding 'a'"
+    |             ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > a => { let [a] = x; } 2`] = `
-"SyntaxError [1:13-1:14]: Duplicate binding 'a'
+"SyntaxError [1:12-1:13]: Duplicate binding 'a'
 > 1 | a => { let [a] = x; }
-    |              ^ Duplicate binding 'a'"
+    |             ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > a => { let {a} = x } 1`] = `
-"SyntaxError [1:13-1:14]: Duplicate binding 'a'
+"SyntaxError [1:12-1:13]: Duplicate binding 'a'
 > 1 | a => { let {a} = x }
-    |              ^ Duplicate binding 'a'"
+    |             ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > a => { let {a} = x } 2`] = `
-"SyntaxError [1:13-1:14]: Duplicate binding 'a'
+"SyntaxError [1:12-1:13]: Duplicate binding 'a'
 > 1 | a => { let {a} = x }
-    |              ^ Duplicate binding 'a'"
+    |             ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > a => { let a } 1`] = `
-"SyntaxError [1:13-1:14]: Duplicate binding 'a'
+"SyntaxError [1:11-1:12]: Duplicate binding 'a'
 > 1 | a => { let a }
-    |              ^ Duplicate binding 'a'"
+    |            ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > a => { let a } 2`] = `
-"SyntaxError [1:13-1:14]: Duplicate binding 'a'
+"SyntaxError [1:11-1:12]: Duplicate binding 'a'
 > 1 | a => { let a }
-    |              ^ Duplicate binding 'a'"
+    |            ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > a => { let a; } 1`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'a'
+"SyntaxError [1:11-1:12]: Duplicate binding 'a'
 > 1 | a => { let a; }
-    |             ^ Duplicate binding 'a'"
+    |            ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > a => const [a] 1`] = `
@@ -649,9 +649,9 @@ exports[`Lexical - Arrows > Lexical - Arrows (fail) > a => let {a} 2`] = `
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > async ({x: y, x: x = y}) => { let y; } 1`] = `
-"SyntaxError [1:35-1:36]: Duplicate binding 'y'
+"SyntaxError [1:34-1:35]: Duplicate binding 'y'
 > 1 | async ({x: y, x: x = y}) => { let y; }
-    |                                    ^ Duplicate binding 'y'"
+    |                                   ^ Duplicate binding 'y'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > async a => let {a} 1`] = `
@@ -667,15 +667,15 @@ exports[`Lexical - Arrows > Lexical - Arrows (fail) > async a => let {a} 2`] = `
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > await => { let await; } 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'await'
+"SyntaxError [1:15-1:20]: Duplicate binding 'await'
 > 1 | await => { let await; }
-    |                     ^ Duplicate binding 'await'"
+    |                ^^^^^ Duplicate binding 'await'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > yield => { let yield; } 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'yield'
+"SyntaxError [1:15-1:20]: Duplicate binding 'yield'
 > 1 | yield => { let yield; }
-    |                     ^ Duplicate binding 'yield'"
+    |                ^^^^^ Duplicate binding 'yield'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > yield => { let yield; } 2`] = `

--- a/test/parser/lexical/__snapshots__/async-arrow.ts.snap
+++ b/test/parser/lexical/__snapshots__/async-arrow.ts.snap
@@ -1,33 +1,33 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([a, a, b]) => {} 1`] = `
-"SyntaxError [1:6-1:7]: Duplicate binding 'a'
+"SyntaxError [1:5-1:6]: Duplicate binding 'a'
 > 1 | ([a, a, b]) => {}
-    |       ^ Duplicate binding 'a'"
+    |      ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([a, a]) => {} 1`] = `
-"SyntaxError [1:6-1:7]: Duplicate binding 'a'
+"SyntaxError [1:5-1:6]: Duplicate binding 'a'
 > 1 | ([a, a]) => {}
-    |       ^ Duplicate binding 'a'"
+    |      ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([a, b, a]) => {} 1`] = `
-"SyntaxError [1:9-1:10]: Duplicate binding 'a'
+"SyntaxError [1:8-1:9]: Duplicate binding 'a'
 > 1 | ([a, b, a]) => {}
-    |          ^ Duplicate binding 'a'"
+    |         ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([a,b,c]) => { const c = x; } 1`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'c'
+"SyntaxError [1:21-1:22]: Duplicate binding 'c'
 > 1 | ([a,b,c]) => { const c = x; }
-    |                        ^ Duplicate binding 'c'"
+    |                      ^ Duplicate binding 'c'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([a,b,c]) => { const c = x; } 2`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'c'
+"SyntaxError [1:21-1:22]: Duplicate binding 'c'
 > 1 | ([a,b,c]) => { const c = x; }
-    |                        ^ Duplicate binding 'c'"
+    |                      ^ Duplicate binding 'c'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([a], a, ...b) => {} 1`] = `
@@ -37,21 +37,21 @@ exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([a], a, ...b) => {} 1`] =
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([b, a, a]) => {} 1`] = `
-"SyntaxError [1:9-1:10]: Duplicate binding 'a'
+"SyntaxError [1:8-1:9]: Duplicate binding 'a'
 > 1 | ([b, a, a]) => {}
-    |          ^ Duplicate binding 'a'"
+    |         ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([b, a, b, a]) => {} 1`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'a'
+"SyntaxError [1:11-1:12]: Duplicate binding 'a'
 > 1 | ([b, a, b, a]) => {}
-    |             ^ Duplicate binding 'a'"
+    |            ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([b, a], {b}) => {} 1`] = `
-"SyntaxError [1:11-1:12]: Duplicate binding 'b'
+"SyntaxError [1:10-1:11]: Duplicate binding 'b'
 > 1 | ([b, a], {b}) => {}
-    |            ^ Duplicate binding 'b'"
+    |           ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([b, a], b) => {} 1`] = `
@@ -85,15 +85,15 @@ exports[`Lexical - Arrows > Lexical - Arrows (fail) > (a, b, a) => {} 1`] = `
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (async (a = b => { let b; })) 1`] = `
-"SyntaxError [1:24-1:25]: Duplicate binding 'b'
+"SyntaxError [1:23-1:24]: Duplicate binding 'b'
 > 1 | (async (a = b => { let b; }))
-    |                         ^ Duplicate binding 'b'"
+    |                        ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (async => { let async; }) 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'async'
+"SyntaxError [1:16-1:21]: Duplicate binding 'async'
 > 1 | (async => { let async; })
-    |                      ^ Duplicate binding 'async'"
+    |                 ^^^^^ Duplicate binding 'async'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (async await => { let await; }) 1`] = `
@@ -103,9 +103,9 @@ exports[`Lexical - Arrows > Lexical - Arrows (fail) > (async await => { let awai
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (async yield => { let yield; }) 1`] = `
-"SyntaxError [1:27-1:28]: Duplicate binding 'yield'
+"SyntaxError [1:22-1:27]: Duplicate binding 'yield'
 > 1 | (async yield => { let yield; })
-    |                            ^ Duplicate binding 'yield'"
+    |                       ^^^^^ Duplicate binding 'yield'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (b, a, a) => {} 1`] = `
@@ -115,9 +115,9 @@ exports[`Lexical - Arrows > Lexical - Arrows (fail) > (b, a, a) => {} 1`] = `
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (b, a, b, ...a) => {} 1`] = `
-"SyntaxError [1:14-1:15]: Duplicate binding 'a'
+"SyntaxError [1:13-1:14]: Duplicate binding 'a'
 > 1 | (b, a, b, ...a) => {}
-    |               ^ Duplicate binding 'a'"
+    |              ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (b, a, b, a = x) => {} 1`] = `
@@ -139,21 +139,21 @@ exports[`Lexical - Arrows > Lexical - Arrows (fail) > (b, a, b, a, [fine]) => {}
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (x) => { const x = y } 1`] = `
-"SyntaxError [1:17-1:18]: Duplicate binding 'x'
-> 1 | (x) => { const x = y }
-    |                  ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - Arrows > Lexical - Arrows (fail) > (x) => { let x } 1`] = `
 "SyntaxError [1:15-1:16]: Duplicate binding 'x'
-> 1 | (x) => { let x }
+> 1 | (x) => { const x = y }
     |                ^ Duplicate binding 'x'"
 `;
 
+exports[`Lexical - Arrows > Lexical - Arrows (fail) > (x) => { let x } 1`] = `
+"SyntaxError [1:13-1:14]: Duplicate binding 'x'
+> 1 | (x) => { let x }
+    |              ^ Duplicate binding 'x'"
+`;
+
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > a(async (a, [a]) => { let a; }) 1`] = `
-"SyntaxError [1:14-1:15]: Duplicate binding 'a'
+"SyntaxError [1:13-1:14]: Duplicate binding 'a'
 > 1 | a(async (a, [a]) => { let a; })
-    |               ^ Duplicate binding 'a'"
+    |              ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > a(async (a, a) => { let a; }) 1`] = `
@@ -163,33 +163,33 @@ exports[`Lexical - Arrows > Lexical - Arrows (fail) > a(async (a, a) => { let a;
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > a(async a => { let a; }) 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'a'
+"SyntaxError [1:19-1:20]: Duplicate binding 'a'
 > 1 | a(async a => { let a; })
-    |                     ^ Duplicate binding 'a'"
+    |                    ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > async ([a,b,c]) => { const c = x; } 1`] = `
-"SyntaxError [1:29-1:30]: Duplicate binding 'c'
+"SyntaxError [1:27-1:28]: Duplicate binding 'c'
 > 1 | async ([a,b,c]) => { const c = x; }
-    |                              ^ Duplicate binding 'c'"
+    |                            ^ Duplicate binding 'c'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > async ([b, a, b, a]) => {} 1`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'a'
 > 1 | async ([b, a, b, a]) => {}
-    |                   ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > async ([b, a], ...b) => {} 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'b'
+"SyntaxError [1:18-1:19]: Duplicate binding 'b'
 > 1 | async ([b, a], ...b) => {}
-    |                    ^ Duplicate binding 'b'"
+    |                   ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > async ({"x": x, x: x}) => a 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'x'
+"SyntaxError [1:19-1:20]: Duplicate binding 'x'
 > 1 | async ({"x": x, x: x}) => a
-    |                     ^ Duplicate binding 'x'"
+    |                    ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > async ({3: x, 4: x}) => a 1`] = `
@@ -199,27 +199,27 @@ exports[`Lexical - Arrows > Lexical - Arrows (fail) > async ({3: x, 4: x}) => a 
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > async ({x: x, x: x}) => a 1`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'x'
+"SyntaxError [1:17-1:18]: Duplicate binding 'x'
 > 1 | async ({x: x, x: x}) => a
-    |                   ^ Duplicate binding 'x'"
+    |                  ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > async ({x: y, "x": x = y}) => { let y; } 1`] = `
-"SyntaxError [1:37-1:38]: Duplicate binding 'y'
+"SyntaxError [1:36-1:37]: Duplicate binding 'y'
 > 1 | async ({x: y, "x": x = y}) => { let y; }
-    |                                      ^ Duplicate binding 'y'"
+    |                                     ^ Duplicate binding 'y'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > async ({x: y, "x": x = y}) => { let y; } 2`] = `
-"SyntaxError [1:37-1:38]: Duplicate binding 'y'
+"SyntaxError [1:36-1:37]: Duplicate binding 'y'
 > 1 | async ({x: y, "x": x = y}) => { let y; }
-    |                                      ^ Duplicate binding 'y'"
+    |                                     ^ Duplicate binding 'y'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > async (a = b => { let b; }) 1`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'b'
+"SyntaxError [1:22-1:23]: Duplicate binding 'b'
 > 1 | async (a = b => { let b; })
-    |                        ^ Duplicate binding 'b'"
+    |                       ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > async (a, a) => {} 1`] = `
@@ -241,15 +241,15 @@ exports[`Lexical - Arrows > Lexical - Arrows (fail) > async (b, a, b, a, [fine])
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > async (x) => { const x = y } 1`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'x'
+"SyntaxError [1:21-1:22]: Duplicate binding 'x'
 > 1 | async (x) => { const x = y }
-    |                        ^ Duplicate binding 'x'"
+    |                      ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > async (x) => { let x } 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'x'
+"SyntaxError [1:19-1:20]: Duplicate binding 'x'
 > 1 | async (x) => { let x }
-    |                      ^ Duplicate binding 'x'"
+    |                    ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > async (ā,食,食) => { /* 𢭃 */ } 1`] = `
@@ -259,21 +259,21 @@ exports[`Lexical - Arrows > Lexical - Arrows (fail) > async (ā,食,食) => { /*
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > async => { let async; } 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'async'
+"SyntaxError [1:15-1:20]: Duplicate binding 'async'
 > 1 | async => { let async; }
-    |                     ^ Duplicate binding 'async'"
+    |                ^^^^^ Duplicate binding 'async'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > async => { let async; } 2`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'async'
+"SyntaxError [1:15-1:20]: Duplicate binding 'async'
 > 1 | async => { let async; }
-    |                     ^ Duplicate binding 'async'"
+    |                ^^^^^ Duplicate binding 'async'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > async a => { let a; } 1`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'a'
 > 1 | async a => { let a; }
-    |                   ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > async await => { let await; } 1`] = `
@@ -283,25 +283,25 @@ exports[`Lexical - Arrows > Lexical - Arrows (fail) > async await => { let await
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > async b => { let b; } 1`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'b'
+"SyntaxError [1:17-1:18]: Duplicate binding 'b'
 > 1 | async b => { let b; }
-    |                   ^ Duplicate binding 'b'"
+    |                  ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > async yield => { let yield; } 1`] = `
-"SyntaxError [1:26-1:27]: Duplicate binding 'yield'
+"SyntaxError [1:21-1:26]: Duplicate binding 'yield'
 > 1 | async yield => { let yield; }
-    |                           ^ Duplicate binding 'yield'"
+    |                      ^^^^^ Duplicate binding 'yield'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > x = async => { let async; } 1`] = `
-"SyntaxError [1:24-1:25]: Duplicate binding 'async'
+"SyntaxError [1:19-1:24]: Duplicate binding 'async'
 > 1 | x = async => { let async; }
-    |                         ^ Duplicate binding 'async'"
+    |                    ^^^^^ Duplicate binding 'async'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > x = async yield => { let yield; } 1`] = `
-"SyntaxError [1:30-1:31]: Duplicate binding 'yield'
+"SyntaxError [1:25-1:30]: Duplicate binding 'yield'
 > 1 | x = async yield => { let yield; }
-    |                               ^ Duplicate binding 'yield'"
+    |                          ^^^^^ Duplicate binding 'yield'"
 `;

--- a/test/parser/lexical/__snapshots__/async-arrow.ts.snap
+++ b/test/parser/lexical/__snapshots__/async-arrow.ts.snap
@@ -43,9 +43,9 @@ exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([b, a, a]) => {} 1`] = `
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([b, a, b, a]) => {} 1`] = `
-"SyntaxError [1:11-1:12]: Duplicate binding 'a'
+"SyntaxError [1:8-1:9]: Duplicate binding 'b'
 > 1 | ([b, a, b, a]) => {}
-    |            ^ Duplicate binding 'a'"
+    |         ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > ([b, a], {b}) => {} 1`] = `
@@ -115,27 +115,27 @@ exports[`Lexical - Arrows > Lexical - Arrows (fail) > (b, a, a) => {} 1`] = `
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (b, a, b, ...a) => {} 1`] = `
-"SyntaxError [1:13-1:14]: Duplicate binding 'a'
+"SyntaxError [1:7-1:8]: Duplicate binding 'b'
 > 1 | (b, a, b, ...a) => {}
-    |              ^ Duplicate binding 'a'"
+    |        ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (b, a, b, a = x) => {} 1`] = `
-"SyntaxError [1:10-1:11]: Duplicate binding 'a'
+"SyntaxError [1:7-1:8]: Duplicate binding 'b'
 > 1 | (b, a, b, a = x) => {}
-    |           ^ Duplicate binding 'a'"
+    |        ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (b, a, b, a) => {} 1`] = `
-"SyntaxError [1:10-1:11]: Duplicate binding 'a'
+"SyntaxError [1:7-1:8]: Duplicate binding 'b'
 > 1 | (b, a, b, a) => {}
-    |           ^ Duplicate binding 'a'"
+    |        ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (b, a, b, a, [fine]) => {} 1`] = `
-"SyntaxError [1:10-1:11]: Duplicate binding 'a'
+"SyntaxError [1:7-1:8]: Duplicate binding 'b'
 > 1 | (b, a, b, a, [fine]) => {}
-    |           ^ Duplicate binding 'a'"
+    |        ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > (x) => { const x = y } 1`] = `
@@ -175,9 +175,9 @@ exports[`Lexical - Arrows > Lexical - Arrows (fail) > async ([a,b,c]) => { const
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > async ([b, a, b, a]) => {} 1`] = `
-"SyntaxError [1:17-1:18]: Duplicate binding 'a'
+"SyntaxError [1:14-1:15]: Duplicate binding 'b'
 > 1 | async ([b, a, b, a]) => {}
-    |                  ^ Duplicate binding 'a'"
+    |               ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > async ([b, a], ...b) => {} 1`] = `
@@ -235,9 +235,9 @@ exports[`Lexical - Arrows > Lexical - Arrows (fail) > async (b, a, a) => {} 1`] 
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > async (b, a, b, a, [fine]) => {} 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'a'
+"SyntaxError [1:13-1:14]: Duplicate binding 'b'
 > 1 | async (b, a, b, a, [fine]) => {}
-    |                 ^ Duplicate binding 'a'"
+    |              ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Arrows > Lexical - Arrows (fail) > async (x) => { const x = y } 1`] = `

--- a/test/parser/lexical/__snapshots__/block.ts.snap
+++ b/test/parser/lexical/__snapshots__/block.ts.snap
@@ -16,11 +16,11 @@ exports[`Lexical - Block > Lexical - Block (fail) > {
   for (var x;;);
   const x = 1
 } 1`] = `
-"SyntaxError [3:10-3:11]: Duplicate binding 'x'
+"SyntaxError [3:8-3:9]: Duplicate binding 'x'
   1 | {
   2 |   for (var x;;);
 > 3 |   const x = 1
-    |           ^ Duplicate binding 'x'
+    |         ^ Duplicate binding 'x'
   4 | }"
 `;
 
@@ -61,9 +61,9 @@ exports[`Lexical - Block > Lexical - Block (fail) > { { var f; } class f {}; } 2
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { { var f; } const f = 0; } 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'f'
+"SyntaxError [1:19-1:20]: Duplicate binding 'f'
 > 1 | { { var f; } const f = 0; }
-    |                      ^ Duplicate binding 'f'"
+    |                    ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { { var f; } function f() {} } 1`] = `
@@ -79,15 +79,15 @@ exports[`Lexical - Block > Lexical - Block (fail) > { { var f; } function* f() {
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { { var f; } let f; } 1`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'f'
+"SyntaxError [1:17-1:18]: Duplicate binding 'f'
 > 1 | { { var f; } let f; }
-    |                   ^ Duplicate binding 'f'"
+    |                  ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { { var f; } let f; } 2`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'f'
+"SyntaxError [1:17-1:18]: Duplicate binding 'f'
 > 1 | { { var f; } let f; }
-    |                   ^ Duplicate binding 'f'"
+    |                  ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { async function *f(){} class f {} } 1`] = `
@@ -97,15 +97,15 @@ exports[`Lexical - Block > Lexical - Block (fail) > { async function *f(){} clas
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { async function *f(){} const f = x } 1`] = `
-"SyntaxError [1:32-1:33]: Duplicate binding 'f'
+"SyntaxError [1:30-1:31]: Duplicate binding 'f'
 > 1 | { async function *f(){} const f = x }
-    |                                 ^ Duplicate binding 'f'"
+    |                               ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { async function *f(){} let f } 1`] = `
-"SyntaxError [1:30-1:31]: Duplicate binding 'f'
+"SyntaxError [1:28-1:29]: Duplicate binding 'f'
 > 1 | { async function *f(){} let f }
-    |                               ^ Duplicate binding 'f'"
+    |                             ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { async function a() {} async function a() {} } 1`] = `
@@ -145,21 +145,21 @@ exports[`Lexical - Block > Lexical - Block (fail) > { async function f() {} clas
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { async function f() {} const f = 0 } 1`] = `
-"SyntaxError [1:32-1:33]: Duplicate binding 'f'
+"SyntaxError [1:30-1:31]: Duplicate binding 'f'
 > 1 | { async function f() {} const f = 0 }
-    |                                 ^ Duplicate binding 'f'"
+    |                               ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { async function f() {} const f = 0; } 1`] = `
-"SyntaxError [1:32-1:33]: Duplicate binding 'f'
+"SyntaxError [1:30-1:31]: Duplicate binding 'f'
 > 1 | { async function f() {} const f = 0; }
-    |                                 ^ Duplicate binding 'f'"
+    |                               ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { async function f() {} const f = 0; } 2`] = `
-"SyntaxError [1:32-1:33]: Duplicate binding 'f'
+"SyntaxError [1:30-1:31]: Duplicate binding 'f'
 > 1 | { async function f() {} const f = 0; }
-    |                                 ^ Duplicate binding 'f'"
+    |                               ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { async function f() {} function f() {} } 1`] = `
@@ -187,51 +187,51 @@ exports[`Lexical - Block > Lexical - Block (fail) > { async function f() {} func
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { async function f() {} let f } 1`] = `
-"SyntaxError [1:30-1:31]: Duplicate binding 'f'
+"SyntaxError [1:28-1:29]: Duplicate binding 'f'
 > 1 | { async function f() {} let f }
-    |                               ^ Duplicate binding 'f'"
+    |                             ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { async function f() {} let f } 2`] = `
-"SyntaxError [1:30-1:31]: Duplicate binding 'f'
+"SyntaxError [1:28-1:29]: Duplicate binding 'f'
 > 1 | { async function f() {} let f }
-    |                               ^ Duplicate binding 'f'"
+    |                             ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { async function f() {} let f } 3`] = `
-"SyntaxError [1:30-1:31]: Duplicate binding 'f'
+"SyntaxError [1:28-1:29]: Duplicate binding 'f'
 > 1 | { async function f() {} let f }
-    |                               ^ Duplicate binding 'f'"
+    |                             ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { async function f() {} var f } 1`] = `
-"SyntaxError [1:30-1:31]: Duplicate binding 'f'
+"SyntaxError [1:28-1:29]: Duplicate binding 'f'
 > 1 | { async function f() {} var f }
-    |                               ^ Duplicate binding 'f'"
+    |                             ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { async function f() {} var f } 2`] = `
-"SyntaxError [1:30-1:31]: Duplicate binding 'f'
+"SyntaxError [1:28-1:29]: Duplicate binding 'f'
 > 1 | { async function f() {} var f }
-    |                               ^ Duplicate binding 'f'"
+    |                             ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { async function f() {} var f; } 1`] = `
-"SyntaxError [1:29-1:30]: Duplicate binding 'f'
+"SyntaxError [1:28-1:29]: Duplicate binding 'f'
 > 1 | { async function f() {} var f; }
-    |                              ^ Duplicate binding 'f'"
+    |                             ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { async function f() {}; { var f; } } 1`] = `
-"SyntaxError [1:32-1:33]: Duplicate binding 'f'
+"SyntaxError [1:31-1:32]: Duplicate binding 'f'
 > 1 | { async function f() {}; { var f; } }
-    |                                 ^ Duplicate binding 'f'"
+    |                                ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { async function f() {}; var f; } 1`] = `
-"SyntaxError [1:30-1:31]: Duplicate binding 'f'
+"SyntaxError [1:29-1:30]: Duplicate binding 'f'
 > 1 | { async function f() {}; var f; }
-    |                               ^ Duplicate binding 'f'"
+    |                              ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { async function f(){} async function f(){} } 1`] = `
@@ -271,15 +271,15 @@ exports[`Lexical - Block > Lexical - Block (fail) > { async function* f() {} asy
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { async function* f() {} const f = 0 } 1`] = `
-"SyntaxError [1:33-1:34]: Duplicate binding 'f'
+"SyntaxError [1:31-1:32]: Duplicate binding 'f'
 > 1 | { async function* f() {} const f = 0 }
-    |                                  ^ Duplicate binding 'f'"
+    |                                ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { async function* f() {} const f = 0 } 2`] = `
-"SyntaxError [1:33-1:34]: Duplicate binding 'f'
+"SyntaxError [1:31-1:32]: Duplicate binding 'f'
 > 1 | { async function* f() {} const f = 0 }
-    |                                  ^ Duplicate binding 'f'"
+    |                                ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { async function* f() {} function f() {} } 1`] = `
@@ -301,51 +301,51 @@ exports[`Lexical - Block > Lexical - Block (fail) > { async function* f() {} fun
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { async function* f() {} let f } 1`] = `
-"SyntaxError [1:31-1:32]: Duplicate binding 'f'
+"SyntaxError [1:29-1:30]: Duplicate binding 'f'
 > 1 | { async function* f() {} let f }
-    |                                ^ Duplicate binding 'f'"
+    |                              ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { async function* f() {} let f } 2`] = `
-"SyntaxError [1:31-1:32]: Duplicate binding 'f'
+"SyntaxError [1:29-1:30]: Duplicate binding 'f'
 > 1 | { async function* f() {} let f }
-    |                                ^ Duplicate binding 'f'"
+    |                              ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { async function* f() {} var f } 1`] = `
-"SyntaxError [1:31-1:32]: Duplicate binding 'f'
+"SyntaxError [1:29-1:30]: Duplicate binding 'f'
 > 1 | { async function* f() {} var f }
-    |                                ^ Duplicate binding 'f'"
+    |                              ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { async function* f() {}; { var f; } } 1`] = `
-"SyntaxError [1:33-1:34]: Duplicate binding 'f'
+"SyntaxError [1:32-1:33]: Duplicate binding 'f'
 > 1 | { async function* f() {}; { var f; } }
-    |                                  ^ Duplicate binding 'f'"
+    |                                 ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { async function* f() {}; var f; } 1`] = `
-"SyntaxError [1:31-1:32]: Duplicate binding 'f'
+"SyntaxError [1:30-1:31]: Duplicate binding 'f'
 > 1 | { async function* f() {}; var f; }
-    |                                ^ Duplicate binding 'f'"
+    |                               ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { class async {}; { var async; } } 1`] = `
-"SyntaxError [1:29-1:30]: Duplicate binding 'async'
+"SyntaxError [1:24-1:29]: Duplicate binding 'async'
 > 1 | { class async {}; { var async; } }
-    |                              ^ Duplicate binding 'async'"
+    |                         ^^^^^ Duplicate binding 'async'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { class async {}; { var async; } } 2`] = `
-"SyntaxError [1:29-1:30]: Duplicate binding 'async'
+"SyntaxError [1:24-1:29]: Duplicate binding 'async'
 > 1 | { class async {}; { var async; } }
-    |                              ^ Duplicate binding 'async'"
+    |                         ^^^^^ Duplicate binding 'async'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { class async {}; { var async; } } 3`] = `
-"SyntaxError [1:29-1:30]: Duplicate binding 'async'
+"SyntaxError [1:24-1:29]: Duplicate binding 'async'
 > 1 | { class async {}; { var async; } }
-    |                              ^ Duplicate binding 'async'"
+    |                         ^^^^^ Duplicate binding 'async'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { class f {} async function f() {} } 1`] = `
@@ -367,15 +367,15 @@ exports[`Lexical - Block > Lexical - Block (fail) > { class f {} class f {}; } 1
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { class f {} const f = 0 } 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'f'
+"SyntaxError [1:19-1:20]: Duplicate binding 'f'
 > 1 | { class f {} const f = 0 }
-    |                      ^ Duplicate binding 'f'"
+    |                    ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { class f {} const f = 0; } 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'f'
+"SyntaxError [1:19-1:20]: Duplicate binding 'f'
 > 1 | { class f {} const f = 0; }
-    |                      ^ Duplicate binding 'f'"
+    |                    ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { class f {} function *f(){} } 1`] = `
@@ -397,39 +397,39 @@ exports[`Lexical - Block > Lexical - Block (fail) > { class f {} function* f() {
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { class f {} let f; } 1`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'f'
+"SyntaxError [1:17-1:18]: Duplicate binding 'f'
 > 1 | { class f {} let f; }
-    |                   ^ Duplicate binding 'f'"
+    |                  ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { class f {} var f } 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'f'
+"SyntaxError [1:17-1:18]: Duplicate binding 'f'
 > 1 | { class f {} var f }
-    |                    ^ Duplicate binding 'f'"
+    |                  ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { class f {} var f; } 1`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'f'
+"SyntaxError [1:17-1:18]: Duplicate binding 'f'
 > 1 | { class f {} var f; }
-    |                   ^ Duplicate binding 'f'"
+    |                  ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { class f {}; { var f; } } 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'f'
+"SyntaxError [1:20-1:21]: Duplicate binding 'f'
 > 1 | { class f {}; { var f; } }
-    |                      ^ Duplicate binding 'f'"
+    |                     ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { class f {}; var f; } 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'f'
+"SyntaxError [1:18-1:19]: Duplicate binding 'f'
 > 1 | { class f {}; var f; }
-    |                    ^ Duplicate binding 'f'"
+    |                   ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { class f {}; var f; } 2`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'f'
+"SyntaxError [1:18-1:19]: Duplicate binding 'f'
 > 1 | { class f {}; var f; }
-    |                    ^ Duplicate binding 'f'"
+    |                   ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { const a = 1; function a(){} } 1`] = `
@@ -445,15 +445,15 @@ exports[`Lexical - Block > Lexical - Block (fail) > { const a = 1; function a(){
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { const f = 0; { var f; } } 1`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'f'
+"SyntaxError [1:21-1:22]: Duplicate binding 'f'
 > 1 | { const f = 0; { var f; } }
-    |                       ^ Duplicate binding 'f'"
+    |                      ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { const f = 0; { var f; } } 2`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'f'
+"SyntaxError [1:21-1:22]: Duplicate binding 'f'
 > 1 | { const f = 0; { var f; } }
-    |                       ^ Duplicate binding 'f'"
+    |                      ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { const f = 0; async function f() {} } 1`] = `
@@ -481,15 +481,15 @@ exports[`Lexical - Block > Lexical - Block (fail) > { const f = 0; class f {} } 
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { const f = 0; const f = 0 } 1`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'f'
+"SyntaxError [1:21-1:22]: Duplicate binding 'f'
 > 1 | { const f = 0; const f = 0 }
-    |                        ^ Duplicate binding 'f'"
+    |                      ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { const f = 0; const f = 0 } 2`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'f'
+"SyntaxError [1:21-1:22]: Duplicate binding 'f'
 > 1 | { const f = 0; const f = 0 }
-    |                        ^ Duplicate binding 'f'"
+    |                      ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { const f = 0; function f() {} } 1`] = `
@@ -505,15 +505,15 @@ exports[`Lexical - Block > Lexical - Block (fail) > { const f = 0; function* f()
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { const f = 0; let f } 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'f'
+"SyntaxError [1:19-1:20]: Duplicate binding 'f'
 > 1 | { const f = 0; let f }
-    |                      ^ Duplicate binding 'f'"
+    |                    ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { const f = 0; var f } 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'f'
+"SyntaxError [1:19-1:20]: Duplicate binding 'f'
 > 1 | { const f = 0; var f }
-    |                      ^ Duplicate binding 'f'"
+    |                    ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { const f = x; async function *f(){} } 1`] = `
@@ -535,9 +535,9 @@ exports[`Lexical - Block > Lexical - Block (fail) > { const f = x; function *f()
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { for (var x;;); const x = 1 } 1`] = `
-"SyntaxError [1:25-1:26]: Duplicate binding 'x'
+"SyntaxError [1:23-1:24]: Duplicate binding 'x'
 > 1 | { for (var x;;); const x = 1 }
-    |                          ^ Duplicate binding 'x'"
+    |                        ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { function *f(){} class f {} } 1`] = `
@@ -595,15 +595,15 @@ exports[`Lexical - Block > Lexical - Block (fail) > { function f() {} function f
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { function f() {} let f } 1`] = `
-"SyntaxError [1:24-1:25]: Duplicate binding 'f'
+"SyntaxError [1:22-1:23]: Duplicate binding 'f'
 > 1 | { function f() {} let f }
-    |                         ^ Duplicate binding 'f'"
+    |                       ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { function f() {} var f; } 1`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'f'
+"SyntaxError [1:22-1:23]: Duplicate binding 'f'
 > 1 | { function f() {} var f; }
-    |                        ^ Duplicate binding 'f'"
+    |                       ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { function f(){} async function f(){} } 1`] = `
@@ -637,9 +637,9 @@ exports[`Lexical - Block > Lexical - Block (fail) > { function foo() {} function
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { function foo() {} var foo = 1; } 1`] = `
-"SyntaxError [1:28-1:29]: Duplicate binding 'foo'
+"SyntaxError [1:24-1:27]: Duplicate binding 'foo'
 > 1 | { function foo() {} var foo = 1; }
-    |                             ^ Duplicate binding 'foo'"
+    |                         ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { function* f() {} async function f() {} } 1`] = `
@@ -697,33 +697,33 @@ exports[`Lexical - Block > Lexical - Block (fail) > { function* f() {} function*
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { function* f() {} let f } 1`] = `
-"SyntaxError [1:25-1:26]: Duplicate binding 'f'
+"SyntaxError [1:23-1:24]: Duplicate binding 'f'
 > 1 | { function* f() {} let f }
-    |                          ^ Duplicate binding 'f'"
+    |                        ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { function* f() {} let f; } 1`] = `
-"SyntaxError [1:24-1:25]: Duplicate binding 'f'
+"SyntaxError [1:23-1:24]: Duplicate binding 'f'
 > 1 | { function* f() {} let f; }
-    |                         ^ Duplicate binding 'f'"
+    |                        ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { function* f() {} var f; } 1`] = `
-"SyntaxError [1:24-1:25]: Duplicate binding 'f'
+"SyntaxError [1:23-1:24]: Duplicate binding 'f'
 > 1 | { function* f() {} var f; }
-    |                         ^ Duplicate binding 'f'"
+    |                        ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { function* f() {}; var f; } 1`] = `
-"SyntaxError [1:25-1:26]: Duplicate binding 'f'
+"SyntaxError [1:24-1:25]: Duplicate binding 'f'
 > 1 | { function* f() {}; var f; }
-    |                          ^ Duplicate binding 'f'"
+    |                         ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { function* f() {}; var f; } 2`] = `
-"SyntaxError [1:25-1:26]: Duplicate binding 'f'
+"SyntaxError [1:24-1:25]: Duplicate binding 'f'
 > 1 | { function* f() {}; var f; }
-    |                          ^ Duplicate binding 'f'"
+    |                         ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { if (x) function f() {} ; function f() {} } 1`] = `
@@ -733,9 +733,9 @@ exports[`Lexical - Block > Lexical - Block (fail) > { if (x) function f() {} ; f
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { let a; { var a; } } 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'a'
+"SyntaxError [1:15-1:16]: Duplicate binding 'a'
 > 1 | { let a; { var a; } }
-    |                 ^ Duplicate binding 'a'"
+    |                ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { let a; class a {} } 1`] = `
@@ -763,15 +763,15 @@ exports[`Lexical - Block > Lexical - Block (fail) > { let f = 123; if (false) ; 
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { let f; { var f; } } 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'f'
+"SyntaxError [1:15-1:16]: Duplicate binding 'f'
 > 1 | { let f; { var f; } }
-    |                 ^ Duplicate binding 'f'"
+    |                ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { let f; { var f; } } 2`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'f'
+"SyntaxError [1:15-1:16]: Duplicate binding 'f'
 > 1 | { let f; { var f; } }
-    |                 ^ Duplicate binding 'f'"
+    |                ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { let f; async function *f(){} } 1`] = `
@@ -817,27 +817,27 @@ exports[`Lexical - Block > Lexical - Block (fail) > { let f; function* f() {} } 
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { let f; let f } 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'f'
+"SyntaxError [1:13-1:14]: Duplicate binding 'f'
 > 1 | { let f; let f }
-    |                ^ Duplicate binding 'f'"
+    |              ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { let f; var f } 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'f'
+"SyntaxError [1:13-1:14]: Duplicate binding 'f'
 > 1 | { let f; var f }
-    |                ^ Duplicate binding 'f'"
+    |              ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { let f; var f; } 1`] = `
-"SyntaxError [1:14-1:15]: Duplicate binding 'f'
+"SyntaxError [1:13-1:14]: Duplicate binding 'f'
 > 1 | { let f; var f; }
-    |               ^ Duplicate binding 'f'"
+    |              ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { let f; var f; } 2`] = `
-"SyntaxError [1:14-1:15]: Duplicate binding 'f'
+"SyntaxError [1:13-1:14]: Duplicate binding 'f'
 > 1 | { let f; var f; }
-    |               ^ Duplicate binding 'f'"
+    |              ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { var f = 123; if (true) function f(){} } 1`] = `
@@ -859,9 +859,9 @@ exports[`Lexical - Block > Lexical - Block (fail) > { var f; async function* f()
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { var f; const f = 0 } 1`] = `
-"SyntaxError [1:17-1:18]: Duplicate binding 'f'
+"SyntaxError [1:15-1:16]: Duplicate binding 'f'
 > 1 | { var f; const f = 0 }
-    |                  ^ Duplicate binding 'f'"
+    |                ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { var f; function *f(){} } 1`] = `
@@ -877,9 +877,9 @@ exports[`Lexical - Block > Lexical - Block (fail) > { var f; function* f() {} } 
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > { var x; } let x; 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'x'
+"SyntaxError [1:15-1:16]: Duplicate binding 'x'
 > 1 | { var x; } let x;
-    |                 ^ Duplicate binding 'x'"
+    |                ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > async function *f(){} async function *f(){} } 1`] = `
@@ -889,38 +889,38 @@ exports[`Lexical - Block > Lexical - Block (fail) > async function *f(){} async 
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > for (const x in {}) { var x; } 1`] = `
-"SyntaxError [1:27-1:28]: Duplicate binding 'x'
+"SyntaxError [1:26-1:27]: Duplicate binding 'x'
 > 1 | for (const x in {}) { var x; }
-    |                            ^ Duplicate binding 'x'"
+    |                           ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > for (const x in {}) { var x; } 2`] = `
-"SyntaxError [1:27-1:28]: Duplicate binding 'x'
+"SyntaxError [1:26-1:27]: Duplicate binding 'x'
 > 1 | for (const x in {}) { var x; }
-    |                            ^ Duplicate binding 'x'"
+    |                           ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > for (let x of []) { var x;  } 1`] = `
-"SyntaxError [1:25-1:26]: Duplicate binding 'x'
+"SyntaxError [1:24-1:25]: Duplicate binding 'x'
 > 1 | for (let x of []) { var x;  }
-    |                          ^ Duplicate binding 'x'"
+    |                         ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > for (let x; false; ) { var x; } 1`] = `
-"SyntaxError [1:28-1:29]: Duplicate binding 'x'
+"SyntaxError [1:27-1:28]: Duplicate binding 'x'
 > 1 | for (let x; false; ) { var x; }
-    |                             ^ Duplicate binding 'x'"
+    |                            ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > function f(){
   for (var x;;);
   const x = 1
 } 1`] = `
-"SyntaxError [3:10-3:11]: Duplicate binding 'x'
+"SyntaxError [3:8-3:9]: Duplicate binding 'x'
   1 | function f(){
   2 |   for (var x;;);
 > 3 |   const x = 1
-    |           ^ Duplicate binding 'x'
+    |         ^ Duplicate binding 'x'
   4 | }"
 `;
 
@@ -931,57 +931,57 @@ exports[`Lexical - Block > Lexical - Block (fail) > function f(){ var f = 123; i
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > function g() { { function f() {} { var f; } }} 1`] = `
-"SyntaxError [1:40-1:41]: Duplicate binding 'f'
+"SyntaxError [1:39-1:40]: Duplicate binding 'f'
 > 1 | function g() { { function f() {} { var f; } }}
-    |                                         ^ Duplicate binding 'f'"
+    |                                        ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > function x() { { async function f() {}; var f; } } 1`] = `
-"SyntaxError [1:45-1:46]: Duplicate binding 'f'
+"SyntaxError [1:44-1:45]: Duplicate binding 'f'
 > 1 | function x() { { async function f() {}; var f; } }
-    |                                              ^ Duplicate binding 'f'"
+    |                                             ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > function x() { { async function* f() {}; var f; } } 1`] = `
-"SyntaxError [1:46-1:47]: Duplicate binding 'f'
+"SyntaxError [1:45-1:46]: Duplicate binding 'f'
 > 1 | function x() { { async function* f() {}; var f; } }
-    |                                               ^ Duplicate binding 'f'"
+    |                                              ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > function x() { { async function* f() {}; var f; } } 2`] = `
-"SyntaxError [1:46-1:47]: Duplicate binding 'f'
+"SyntaxError [1:45-1:46]: Duplicate binding 'f'
 > 1 | function x() { { async function* f() {}; var f; } }
-    |                                               ^ Duplicate binding 'f'"
+    |                                              ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > function x() { { const f = 0; var f; } } 1`] = `
-"SyntaxError [1:35-1:36]: Duplicate binding 'f'
+"SyntaxError [1:34-1:35]: Duplicate binding 'f'
 > 1 | function x() { { const f = 0; var f; } }
-    |                                    ^ Duplicate binding 'f'"
+    |                                   ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > function x() { { function* f() {}; var f; } } 1`] = `
-"SyntaxError [1:40-1:41]: Duplicate binding 'f'
+"SyntaxError [1:39-1:40]: Duplicate binding 'f'
 > 1 | function x() { { function* f() {}; var f; } }
-    |                                         ^ Duplicate binding 'f'"
+    |                                        ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > let x; { var x; } 1`] = `
-"SyntaxError [1:14-1:15]: Duplicate binding 'x'
+"SyntaxError [1:13-1:14]: Duplicate binding 'x'
 > 1 | let x; { var x; }
-    |               ^ Duplicate binding 'x'"
+    |              ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > let x; var x; 1`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'x'
+"SyntaxError [1:11-1:12]: Duplicate binding 'x'
 > 1 | let x; var x;
-    |             ^ Duplicate binding 'x'"
+    |            ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > switch (0) { case 1: function* a() {} break; default: var a; } 1`] = `
-"SyntaxError [1:59-1:60]: Duplicate binding 'a'
+"SyntaxError [1:58-1:59]: Duplicate binding 'a'
 > 1 | switch (0) { case 1: function* a() {} break; default: var a; }
-    |                                                            ^ Duplicate binding 'a'"
+    |                                                           ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > try { # var f } catch (e) {} 1`] = `
@@ -1009,7 +1009,7 @@ exports[`Lexical - Block > Lexical - Block (fail) > var x = a; function x(){}; 1
 `;
 
 exports[`Lexical - Block > Lexical - Block (fail) > var x; let x; 1`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'x'
+"SyntaxError [1:11-1:12]: Duplicate binding 'x'
 > 1 | var x; let x;
-    |             ^ Duplicate binding 'x'"
+    |            ^ Duplicate binding 'x'"
 `;

--- a/test/parser/lexical/__snapshots__/class.ts.snap
+++ b/test/parser/lexical/__snapshots__/class.ts.snap
@@ -109,9 +109,9 @@ exports[`Lexical - Class > Lexical - Class (fail) > class o {f([b, a, a]) {}} 1`
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f([b, a, b, a]) {}} 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'a'
+"SyntaxError [1:18-1:19]: Duplicate binding 'b'
 > 1 | class o {f([b, a, b, a]) {}}
-    |                      ^ Duplicate binding 'a'"
+    |                   ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f([b, a], ...b) {}} 1`] = `
@@ -199,45 +199,45 @@ exports[`Lexical - Class > Lexical - Class (fail) > class o {f(b, a, a) {}} 2`] 
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(b, a, b, ...a) {}} 1`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'b'
 > 1 | class o {f(b, a, b, ...a) {}}
-    |                        ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(b, a, b, a = x) {}} 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'b'
 > 1 | class o {f(b, a, b, a = x) {}}
-    |                     ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(b, a, b, a = x) {}} 2`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'b'
 > 1 | class o {f(b, a, b, a = x) {}}
-    |                     ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(b, a, b, a) {}} 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'b'
 > 1 | class o {f(b, a, b, a) {}}
-    |                     ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(b, a, b, a) {}} 2`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'b'
 > 1 | class o {f(b, a, b, a) {}}
-    |                     ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(b, a, b, a, [fine]) {}} 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'b'
 > 1 | class o {f(b, a, b, a, [fine]) {}}
-    |                     ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(b, a, b, a, [fine]) {}} 2`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'b'
 > 1 | class o {f(b, a, b, a, [fine]) {}}
-    |                     ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(x) { const x = y }} 1`] = `

--- a/test/parser/lexical/__snapshots__/class.ts.snap
+++ b/test/parser/lexical/__snapshots__/class.ts.snap
@@ -1,21 +1,21 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Lexical - Class > Lexical - Class (fail) > class A { static f([a, a]){} } 1`] = `
-"SyntaxError [1:24-1:25]: Duplicate binding 'a'
+"SyntaxError [1:23-1:24]: Duplicate binding 'a'
 > 1 | class A { static f([a, a]){} }
-    |                         ^ Duplicate binding 'a'"
+    |                        ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class A { static f({a, a}){} } 1`] = `
-"SyntaxError [1:24-1:25]: Duplicate binding 'a'
+"SyntaxError [1:23-1:24]: Duplicate binding 'a'
 > 1 | class A { static f({a, a}){} }
-    |                         ^ Duplicate binding 'a'"
+    |                        ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class A { static f(a, a){} } 1`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'a'
+"SyntaxError [1:22-1:23]: Duplicate binding 'a'
 > 1 | class A { static f(a, a){} }
-    |                        ^ Duplicate binding 'a'"
+    |                       ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class C {} class C {} 1`] = `
@@ -31,9 +31,9 @@ exports[`Lexical - Class > Lexical - Class (fail) > class foo {}; class foo {}; 
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class foo {}; const foo = 1; 1`] = `
-"SyntaxError [1:24-1:25]: Duplicate binding 'foo'
+"SyntaxError [1:20-1:23]: Duplicate binding 'foo'
 > 1 | class foo {}; const foo = 1;
-    |                         ^ Duplicate binding 'foo'"
+    |                     ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class foo {}; function foo () {}; 1`] = `
@@ -43,27 +43,27 @@ exports[`Lexical - Class > Lexical - Class (fail) > class foo {}; function foo (
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class foo {}; let foo = 1; 1`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'foo'
+"SyntaxError [1:18-1:21]: Duplicate binding 'foo'
 > 1 | class foo {}; let foo = 1;
-    |                       ^ Duplicate binding 'foo'"
+    |                   ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class foo {}; var foo; 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'foo'
+"SyntaxError [1:18-1:21]: Duplicate binding 'foo'
 > 1 | class foo {}; var foo;
-    |                      ^ Duplicate binding 'foo'"
+    |                   ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(){ const x = y; var x; }} 1`] = `
-"SyntaxError [1:32-1:33]: Duplicate binding 'x'
+"SyntaxError [1:31-1:32]: Duplicate binding 'x'
 > 1 | class o {f(){ const x = y; var x; }}
-    |                                 ^ Duplicate binding 'x'"
+    |                                ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(){ function x(){} let x; }} 1`] = `
-"SyntaxError [1:34-1:35]: Duplicate binding 'x'
+"SyntaxError [1:33-1:34]: Duplicate binding 'x'
 > 1 | class o {f(){ function x(){} let x; }}
-    |                                   ^ Duplicate binding 'x'"
+    |                                  ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(){ let x; function x(){} }} 1`] = `
@@ -73,187 +73,187 @@ exports[`Lexical - Class > Lexical - Class (fail) > class o {f(){ let x; functio
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(){ let x; var x; }} 1`] = `
-"SyntaxError [1:26-1:27]: Duplicate binding 'x'
+"SyntaxError [1:25-1:26]: Duplicate binding 'x'
 > 1 | class o {f(){ let x; var x; }}
-    |                           ^ Duplicate binding 'x'"
+    |                          ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(){ var x; const x = y; }} 1`] = `
-"SyntaxError [1:29-1:30]: Duplicate binding 'x'
+"SyntaxError [1:27-1:28]: Duplicate binding 'x'
 > 1 | class o {f(){ var x; const x = y; }}
-    |                              ^ Duplicate binding 'x'"
+    |                            ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(){ var x; let x; }} 1`] = `
-"SyntaxError [1:26-1:27]: Duplicate binding 'x'
+"SyntaxError [1:25-1:26]: Duplicate binding 'x'
 > 1 | class o {f(){ var x; let x; }}
-    |                           ^ Duplicate binding 'x'"
+    |                          ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f([a, a]) {}} 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'a'
+"SyntaxError [1:15-1:16]: Duplicate binding 'a'
 > 1 | class o {f([a, a]) {}}
-    |                 ^ Duplicate binding 'a'"
+    |                ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f([a, b, a]) {}} 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'a'
+"SyntaxError [1:18-1:19]: Duplicate binding 'a'
 > 1 | class o {f([a, b, a]) {}}
-    |                    ^ Duplicate binding 'a'"
+    |                   ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f([b, a, a]) {}} 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'a'
+"SyntaxError [1:18-1:19]: Duplicate binding 'a'
 > 1 | class o {f([b, a, a]) {}}
-    |                    ^ Duplicate binding 'a'"
+    |                   ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f([b, a, b, a]) {}} 1`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'a'
+"SyntaxError [1:21-1:22]: Duplicate binding 'a'
 > 1 | class o {f([b, a, b, a]) {}}
-    |                       ^ Duplicate binding 'a'"
+    |                      ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f([b, a], ...b) {}} 1`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'b'
+"SyntaxError [1:22-1:23]: Duplicate binding 'b'
 > 1 | class o {f([b, a], ...b) {}}
-    |                        ^ Duplicate binding 'b'"
+    |                       ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f([b, a], {b}) {}} 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'b'
+"SyntaxError [1:20-1:21]: Duplicate binding 'b'
 > 1 | class o {f([b, a], {b}) {}}
-    |                      ^ Duplicate binding 'b'"
+    |                     ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f([b, a], {b}) {}} 2`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'b'
+"SyntaxError [1:20-1:21]: Duplicate binding 'b'
 > 1 | class o {f([b, a], {b}) {}}
-    |                      ^ Duplicate binding 'b'"
+    |                     ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f([b, a], b) {}} 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'b'
+"SyntaxError [1:19-1:20]: Duplicate binding 'b'
 > 1 | class o {f([b, a], b) {}}
-    |                     ^ Duplicate binding 'b'"
+    |                    ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f([b, a], b) {}} 2`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'b'
+"SyntaxError [1:19-1:20]: Duplicate binding 'b'
 > 1 | class o {f([b, a], b) {}}
-    |                     ^ Duplicate binding 'b'"
+    |                    ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f([b, a], b=x) {}} 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'b'
+"SyntaxError [1:19-1:20]: Duplicate binding 'b'
 > 1 | class o {f([b, a], b=x) {}}
-    |                     ^ Duplicate binding 'b'"
+    |                    ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f([b, a], b=x) {}} 2`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'b'
+"SyntaxError [1:19-1:20]: Duplicate binding 'b'
 > 1 | class o {f([b, a], b=x) {}}
-    |                     ^ Duplicate binding 'b'"
+    |                    ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(a, a) {}} 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'a'
+"SyntaxError [1:14-1:15]: Duplicate binding 'a'
 > 1 | class o {f(a, a) {}}
-    |                ^ Duplicate binding 'a'"
+    |               ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(a, a, b) {}} 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'a'
+"SyntaxError [1:14-1:15]: Duplicate binding 'a'
 > 1 | class o {f(a, a, b) {}}
-    |                ^ Duplicate binding 'a'"
+    |               ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(a, a, b) {}} 2`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'a'
+"SyntaxError [1:14-1:15]: Duplicate binding 'a'
 > 1 | class o {f(a, a, b) {}}
-    |                ^ Duplicate binding 'a'"
+    |               ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(a, b, a) {}} 1`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'a'
 > 1 | class o {f(a, b, a) {}}
-    |                   ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(a, b, a) {}} 2`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'a'
 > 1 | class o {f(a, b, a) {}}
-    |                   ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(b, a, a) {}} 1`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'a'
 > 1 | class o {f(b, a, a) {}}
-    |                   ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(b, a, a) {}} 2`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'a'
 > 1 | class o {f(b, a, a) {}}
-    |                   ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(b, a, b, ...a) {}} 1`] = `
-"SyntaxError [1:24-1:25]: Duplicate binding 'a'
+"SyntaxError [1:23-1:24]: Duplicate binding 'a'
 > 1 | class o {f(b, a, b, ...a) {}}
-    |                         ^ Duplicate binding 'a'"
+    |                        ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(b, a, b, a = x) {}} 1`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'a'
+"SyntaxError [1:20-1:21]: Duplicate binding 'a'
 > 1 | class o {f(b, a, b, a = x) {}}
-    |                       ^ Duplicate binding 'a'"
+    |                     ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(b, a, b, a = x) {}} 2`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'a'
+"SyntaxError [1:20-1:21]: Duplicate binding 'a'
 > 1 | class o {f(b, a, b, a = x) {}}
-    |                       ^ Duplicate binding 'a'"
+    |                     ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(b, a, b, a) {}} 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'a'
+"SyntaxError [1:20-1:21]: Duplicate binding 'a'
 > 1 | class o {f(b, a, b, a) {}}
-    |                      ^ Duplicate binding 'a'"
+    |                     ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(b, a, b, a) {}} 2`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'a'
+"SyntaxError [1:20-1:21]: Duplicate binding 'a'
 > 1 | class o {f(b, a, b, a) {}}
-    |                      ^ Duplicate binding 'a'"
+    |                     ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(b, a, b, a, [fine]) {}} 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'a'
+"SyntaxError [1:20-1:21]: Duplicate binding 'a'
 > 1 | class o {f(b, a, b, a, [fine]) {}}
-    |                      ^ Duplicate binding 'a'"
+    |                     ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(b, a, b, a, [fine]) {}} 2`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'a'
+"SyntaxError [1:20-1:21]: Duplicate binding 'a'
 > 1 | class o {f(b, a, b, a, [fine]) {}}
-    |                      ^ Duplicate binding 'a'"
+    |                     ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(x) { const x = y }} 1`] = `
-"SyntaxError [1:24-1:25]: Duplicate binding 'x'
+"SyntaxError [1:22-1:23]: Duplicate binding 'x'
 > 1 | class o {f(x) { const x = y }}
-    |                         ^ Duplicate binding 'x'"
+    |                       ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(x) { let x }} 1`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'x'
+"SyntaxError [1:20-1:21]: Duplicate binding 'x'
 > 1 | class o {f(x) { let x }}
-    |                       ^ Duplicate binding 'x'"
+    |                     ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Class > Lexical - Class (fail) > class o {f(x) { let x }} 2`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'x'
+"SyntaxError [1:20-1:21]: Duplicate binding 'x'
 > 1 | class o {f(x) { let x }}
-    |                       ^ Duplicate binding 'x'"
+    |                     ^ Duplicate binding 'x'"
 `;

--- a/test/parser/lexical/__snapshots__/for.ts.snap
+++ b/test/parser/lexical/__snapshots__/for.ts.snap
@@ -4,101 +4,101 @@ exports[`Lexical - For statement > Lexical - For statement (fail) > {
   for (var x;;);
   const x = 1
 } 1`] = `
-"SyntaxError [3:10-3:11]: Duplicate binding 'x'
+"SyntaxError [3:8-3:9]: Duplicate binding 'x'
   1 | {
   2 |   for (var x;;);
 > 3 |   const x = 1
-    |           ^ Duplicate binding 'x'
+    |         ^ Duplicate binding 'x'
   4 | }"
 `;
 
 exports[`Lexical - For statement > Lexical - For statement (fail) > for (const [x, x] in {}) {} 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'x'
+"SyntaxError [1:15-1:16]: Duplicate binding 'x'
 > 1 | for (const [x, x] in {}) {}
-    |                 ^ Duplicate binding 'x'"
+    |                ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - For statement > Lexical - For statement (fail) > for (const x = y;;) { var x; } 1`] = `
-"SyntaxError [1:27-1:28]: Duplicate binding 'x'
+"SyntaxError [1:26-1:27]: Duplicate binding 'x'
 > 1 | for (const x = y;;) { var x; }
-    |                            ^ Duplicate binding 'x'"
+    |                           ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - For statement > Lexical - For statement (fail) > for (const x = y;;) { var x; } 2`] = `
-"SyntaxError [1:27-1:28]: Duplicate binding 'x'
+"SyntaxError [1:26-1:27]: Duplicate binding 'x'
 > 1 | for (const x = y;;) { var x; }
-    |                            ^ Duplicate binding 'x'"
+    |                           ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - For statement > Lexical - For statement (fail) > for (const x in {}) { var x; } 1`] = `
-"SyntaxError [1:27-1:28]: Duplicate binding 'x'
+"SyntaxError [1:26-1:27]: Duplicate binding 'x'
 > 1 | for (const x in {}) { var x; }
-    |                            ^ Duplicate binding 'x'"
+    |                           ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - For statement > Lexical - For statement (fail) > for (const x in y) { var x; } 1`] = `
-"SyntaxError [1:26-1:27]: Duplicate binding 'x'
-> 1 | for (const x in y) { var x; }
-    |                           ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - For statement > Lexical - For statement (fail) > for (const x of y) { var x; } 1`] = `
-"SyntaxError [1:26-1:27]: Duplicate binding 'x'
-> 1 | for (const x of y) { var x; }
-    |                           ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - For statement > Lexical - For statement (fail) > for (let a, b, x, d;;) { var foo; var bar; { var doo, x, ee; } } 1`] = `
-"SyntaxError [1:55-1:56]: Duplicate binding 'x'
-> 1 | for (let a, b, x, d;;) { var foo; var bar; { var doo, x, ee; } }
-    |                                                        ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - For statement > Lexical - For statement (fail) > for (let x in y) { var x;  1`] = `
-"SyntaxError [1:24-1:25]: Duplicate binding 'x'
-> 1 | for (let x in y) { var x; 
-    |                         ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - For statement > Lexical - For statement (fail) > for (let x of []) { var x;  } 1`] = `
 "SyntaxError [1:25-1:26]: Duplicate binding 'x'
-> 1 | for (let x of []) { var x;  }
+> 1 | for (const x in y) { var x; }
     |                          ^ Duplicate binding 'x'"
 `;
 
-exports[`Lexical - For statement > Lexical - For statement (fail) > for (let x of y) { var x; } 1`] = `
+exports[`Lexical - For statement > Lexical - For statement (fail) > for (const x of y) { var x; } 1`] = `
+"SyntaxError [1:25-1:26]: Duplicate binding 'x'
+> 1 | for (const x of y) { var x; }
+    |                          ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - For statement > Lexical - For statement (fail) > for (let a, b, x, d;;) { var foo; var bar; { var doo, x, ee; } } 1`] = `
+"SyntaxError [1:54-1:55]: Duplicate binding 'x'
+> 1 | for (let a, b, x, d;;) { var foo; var bar; { var doo, x, ee; } }
+    |                                                       ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - For statement > Lexical - For statement (fail) > for (let x in y) { var x;  1`] = `
+"SyntaxError [1:23-1:24]: Duplicate binding 'x'
+> 1 | for (let x in y) { var x; 
+    |                        ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - For statement > Lexical - For statement (fail) > for (let x of []) { var x;  } 1`] = `
 "SyntaxError [1:24-1:25]: Duplicate binding 'x'
-> 1 | for (let x of y) { var x; }
+> 1 | for (let x of []) { var x;  }
     |                         ^ Duplicate binding 'x'"
 `;
 
+exports[`Lexical - For statement > Lexical - For statement (fail) > for (let x of y) { var x; } 1`] = `
+"SyntaxError [1:23-1:24]: Duplicate binding 'x'
+> 1 | for (let x of y) { var x; }
+    |                        ^ Duplicate binding 'x'"
+`;
+
 exports[`Lexical - For statement > Lexical - For statement (fail) > for (let x;;) { var x; } 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'x'
+"SyntaxError [1:20-1:21]: Duplicate binding 'x'
 > 1 | for (let x;;) { var x; }
-    |                      ^ Duplicate binding 'x'"
+    |                     ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - For statement > Lexical - For statement (fail) > for (let x;;) { var x; } 2`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'x'
+"SyntaxError [1:20-1:21]: Duplicate binding 'x'
 > 1 | for (let x;;) { var x; }
-    |                      ^ Duplicate binding 'x'"
+    |                     ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - For statement > Lexical - For statement (fail) > for (var a;;) { var b; let b; } 1`] = `
-"SyntaxError [1:28-1:29]: Duplicate binding 'b'
+"SyntaxError [1:27-1:28]: Duplicate binding 'b'
 > 1 | for (var a;;) { var b; let b; }
-    |                             ^ Duplicate binding 'b'"
+    |                            ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - For statement > Lexical - For statement (fail) > function f(){
   for (var x;;);
   const x = 1
 } 1`] = `
-"SyntaxError [3:10-3:11]: Duplicate binding 'x'
+"SyntaxError [3:8-3:9]: Duplicate binding 'x'
   1 | function f(){
   2 |   for (var x;;);
 > 3 |   const x = 1
-    |           ^ Duplicate binding 'x'
+    |         ^ Duplicate binding 'x'
   4 | }"
 `;
 
@@ -109,7 +109,7 @@ exports[`Lexical - For statement > Lexical - For statement (fail) > function f()
 `;
 
 exports[`Lexical - For statement > Lexical - For statement (fail) > let x; for (;;) { var x; } 1`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'x'
+"SyntaxError [1:22-1:23]: Duplicate binding 'x'
 > 1 | let x; for (;;) { var x; }
-    |                        ^ Duplicate binding 'x'"
+    |                       ^ Duplicate binding 'x'"
 `;

--- a/test/parser/lexical/__snapshots__/function.ts.snap
+++ b/test/parser/lexical/__snapshots__/function.ts.snap
@@ -1,39 +1,39 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Lexical - Function > Lexical - Function (fail) > "use strict"; function foo(bar, bar){} 1`] = `
-"SyntaxError [1:35-1:36]: Duplicate binding 'bar'
+"SyntaxError [1:32-1:35]: Duplicate binding 'bar'
 > 1 | "use strict"; function foo(bar, bar){}
-    |                                    ^ Duplicate binding 'bar'"
+    |                                 ^^^ Duplicate binding 'bar'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > (a, b = () => a) => { const b = 1; }; 1`] = `
-"SyntaxError [1:30-1:31]: Duplicate binding 'b'
+"SyntaxError [1:28-1:29]: Duplicate binding 'b'
 > 1 | (a, b = () => a) => { const b = 1; };
-    |                               ^ Duplicate binding 'b'"
+    |                             ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > (a, b = () => a) => { let b; }; 1`] = `
-"SyntaxError [1:27-1:28]: Duplicate binding 'b'
+"SyntaxError [1:26-1:27]: Duplicate binding 'b'
 > 1 | (a, b = () => a) => { let b; };
-    |                            ^ Duplicate binding 'b'"
+    |                           ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > (arguments, b = () => arguments) => { let arguments; }; 1`] = `
-"SyntaxError [1:51-1:52]: Duplicate binding 'arguments'
+"SyntaxError [1:42-1:51]: Duplicate binding 'arguments'
 > 1 | (arguments, b = () => arguments) => { let arguments; };
-    |                                                    ^ Duplicate binding 'arguments'"
+    |                                           ^^^^^^^^^ Duplicate binding 'arguments'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > (function (e) { var e; const e = undefined; }); 1`] = `
-"SyntaxError [1:31-1:32]: Duplicate binding 'e'
+"SyntaxError [1:29-1:30]: Duplicate binding 'e'
 > 1 | (function (e) { var e; const e = undefined; });
-    |                                ^ Duplicate binding 'e'"
+    |                              ^ Duplicate binding 'e'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > (function() { "use strict"; { const f = 1; var f; } }) 1`] = `
-"SyntaxError [1:48-1:49]: Duplicate binding 'f'
+"SyntaxError [1:47-1:48]: Duplicate binding 'f'
 > 1 | (function() { "use strict"; { const f = 1; var f; } })
-    |                                                 ^ Duplicate binding 'f'"
+    |                                                ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > (function() { { async function foo() {} async function foo() {} } })() 1`] = `
@@ -91,21 +91,21 @@ exports[`Lexical - Function > Lexical - Function (fail) > { function f(){} funct
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > { var x; } let x; 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'x'
+"SyntaxError [1:15-1:16]: Duplicate binding 'x'
 > 1 | { var x; } let x;
-    |                 ^ Duplicate binding 'x'"
+    |                ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > 0, function(x = 0, x) {}; 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'x'
+"SyntaxError [1:19-1:20]: Duplicate binding 'x'
 > 1 | 0, function(x = 0, x) {};
-    |                     ^ Duplicate binding 'x'"
+    |                    ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > 0, function(x = 0, x) {}; 2`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'x'
+"SyntaxError [1:19-1:20]: Duplicate binding 'x'
 > 1 | 0, function(x = 0, x) {};
-    |                     ^ Duplicate binding 'x'"
+    |                    ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > async function af(x) { class x { } } 1`] = `
@@ -115,15 +115,15 @@ exports[`Lexical - Function > Lexical - Function (fail) > async function af(x) {
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > async function af(x) { const x = 1; } 1`] = `
-"SyntaxError [1:31-1:32]: Duplicate binding 'x'
+"SyntaxError [1:29-1:30]: Duplicate binding 'x'
 > 1 | async function af(x) { const x = 1; }
-    |                                ^ Duplicate binding 'x'"
+    |                              ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > async function af(x) { let x; } 1`] = `
-"SyntaxError [1:28-1:29]: Duplicate binding 'x'
+"SyntaxError [1:27-1:28]: Duplicate binding 'x'
 > 1 | async function af(x) { let x; }
-    |                             ^ Duplicate binding 'x'"
+    |                            ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > const x = a; function x(){}; 1`] = `
@@ -133,57 +133,57 @@ exports[`Lexical - Function > Lexical - Function (fail) > const x = a; function 
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function a() { const x = 1; var x = 2; } 1`] = `
-"SyntaxError [1:34-1:35]: Duplicate binding 'x'
+"SyntaxError [1:32-1:33]: Duplicate binding 'x'
 > 1 | function a() { const x = 1; var x = 2; }
-    |                                   ^ Duplicate binding 'x'"
+    |                                 ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function a() { const x = 1; var x = 2; } 2`] = `
-"SyntaxError [1:34-1:35]: Duplicate binding 'x'
+"SyntaxError [1:32-1:33]: Duplicate binding 'x'
 > 1 | function a() { const x = 1; var x = 2; }
-    |                                   ^ Duplicate binding 'x'"
+    |                                 ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function a() { const x = 1; var x = 2; } 3`] = `
-"SyntaxError [1:34-1:35]: Duplicate binding 'x'
+"SyntaxError [1:32-1:33]: Duplicate binding 'x'
 > 1 | function a() { const x = 1; var x = 2; }
-    |                                   ^ Duplicate binding 'x'"
+    |                                 ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function a() { const x = 1; var x = 2; } 4`] = `
-"SyntaxError [1:34-1:35]: Duplicate binding 'x'
+"SyntaxError [1:32-1:33]: Duplicate binding 'x'
 > 1 | function a() { const x = 1; var x = 2; }
-    |                                   ^ Duplicate binding 'x'"
+    |                                 ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f() { { { var x; } let x; } } 1`] = `
-"SyntaxError [1:33-1:34]: Duplicate binding 'x'
+"SyntaxError [1:32-1:33]: Duplicate binding 'x'
 > 1 | function f() { { { var x; } let x; } }
-    |                                  ^ Duplicate binding 'x'"
+    |                                 ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f() { { { var x; } let x; } } 2`] = `
-"SyntaxError [1:33-1:34]: Duplicate binding 'x'
+"SyntaxError [1:32-1:33]: Duplicate binding 'x'
 > 1 | function f() { { { var x; } let x; } }
-    |                                  ^ Duplicate binding 'x'"
+    |                                 ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f() { { var x; let x; } } 1`] = `
-"SyntaxError [1:29-1:30]: Duplicate binding 'x'
+"SyntaxError [1:28-1:29]: Duplicate binding 'x'
 > 1 | function f() { { var x; let x; } }
-    |                              ^ Duplicate binding 'x'"
+    |                             ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f() { { var x; let x; } } 2`] = `
-"SyntaxError [1:29-1:30]: Duplicate binding 'x'
+"SyntaxError [1:28-1:29]: Duplicate binding 'x'
 > 1 | function f() { { var x; let x; } }
-    |                              ^ Duplicate binding 'x'"
+    |                             ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(){  for (var x;;); const x = 1  } 1`] = `
-"SyntaxError [1:38-1:39]: Duplicate binding 'x'
+"SyntaxError [1:36-1:37]: Duplicate binding 'x'
 > 1 | function f(){  for (var x;;); const x = 1  }
-    |                                       ^ Duplicate binding 'x'"
+    |                                     ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(){ const x = y; function x(){} } 1`] = `
@@ -193,21 +193,21 @@ exports[`Lexical - Function > Lexical - Function (fail) > function f(){ const x 
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(){ const x = y; var x; } 1`] = `
-"SyntaxError [1:32-1:33]: Duplicate binding 'x'
+"SyntaxError [1:31-1:32]: Duplicate binding 'x'
 > 1 | function f(){ const x = y; var x; }
-    |                                 ^ Duplicate binding 'x'"
+    |                                ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(){ function x(){} const x = y; } 1`] = `
-"SyntaxError [1:37-1:38]: Duplicate binding 'x'
+"SyntaxError [1:35-1:36]: Duplicate binding 'x'
 > 1 | function f(){ function x(){} const x = y; }
-    |                                      ^ Duplicate binding 'x'"
+    |                                    ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(){ function x(){} let x; } 1`] = `
-"SyntaxError [1:34-1:35]: Duplicate binding 'x'
+"SyntaxError [1:33-1:34]: Duplicate binding 'x'
 > 1 | function f(){ function x(){} let x; }
-    |                                   ^ Duplicate binding 'x'"
+    |                                  ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(){ let x; function x(){} } 1`] = `
@@ -217,21 +217,21 @@ exports[`Lexical - Function > Lexical - Function (fail) > function f(){ let x; f
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(){ let x; var x; } 1`] = `
-"SyntaxError [1:26-1:27]: Duplicate binding 'x'
+"SyntaxError [1:25-1:26]: Duplicate binding 'x'
 > 1 | function f(){ let x; var x; }
-    |                           ^ Duplicate binding 'x'"
+    |                          ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(){ var x; const x = y; } 1`] = `
-"SyntaxError [1:29-1:30]: Duplicate binding 'x'
+"SyntaxError [1:27-1:28]: Duplicate binding 'x'
 > 1 | function f(){ var x; const x = y; }
-    |                              ^ Duplicate binding 'x'"
+    |                            ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(){ var x; let x; } 1`] = `
-"SyntaxError [1:26-1:27]: Duplicate binding 'x'
+"SyntaxError [1:25-1:26]: Duplicate binding 'x'
 > 1 | function f(){ var x; let x; }
-    |                           ^ Duplicate binding 'x'"
+    |                          ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(){} function f(){} 1`] = `
@@ -301,123 +301,123 @@ exports[`Lexical - Function > Lexical - Function (fail) > function f(...rest, b)
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f([{foo}] = x, [{foo}]){} 1`] = `
-"SyntaxError [1:29-1:30]: Duplicate binding 'foo'
+"SyntaxError [1:26-1:29]: Duplicate binding 'foo'
 > 1 | function f([{foo}] = x, [{foo}]){}
-    |                              ^ Duplicate binding 'foo'"
+    |                           ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f([{foo}] = x, [{foo}]){} 2`] = `
-"SyntaxError [1:29-1:30]: Duplicate binding 'foo'
+"SyntaxError [1:26-1:29]: Duplicate binding 'foo'
 > 1 | function f([{foo}] = x, [{foo}]){}
-    |                              ^ Duplicate binding 'foo'"
+    |                           ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f([{foo}] = x, {foo}){} 1`] = `
-"SyntaxError [1:28-1:29]: Duplicate binding 'foo'
+"SyntaxError [1:25-1:28]: Duplicate binding 'foo'
 > 1 | function f([{foo}] = x, {foo}){}
-    |                             ^ Duplicate binding 'foo'"
+    |                          ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f([a, a, b]) {} 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'a'
+"SyntaxError [1:15-1:16]: Duplicate binding 'a'
 > 1 | function f([a, a, b]) {}
-    |                 ^ Duplicate binding 'a'"
+    |                ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f([a, a, b]) {} 2`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'a'
+"SyntaxError [1:15-1:16]: Duplicate binding 'a'
 > 1 | function f([a, a, b]) {}
-    |                 ^ Duplicate binding 'a'"
+    |                ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f([a, a]) {} 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'a'
+"SyntaxError [1:15-1:16]: Duplicate binding 'a'
 > 1 | function f([a, a]) {}
-    |                 ^ Duplicate binding 'a'"
+    |                ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f([a, b, a]) {} 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'a'
+"SyntaxError [1:18-1:19]: Duplicate binding 'a'
 > 1 | function f([a, b, a]) {}
-    |                    ^ Duplicate binding 'a'"
+    |                   ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f([b, a, a]) {} 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'a'
+"SyntaxError [1:18-1:19]: Duplicate binding 'a'
 > 1 | function f([b, a, a]) {}
-    |                    ^ Duplicate binding 'a'"
+    |                   ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f([b, a, b, a]) {} 1`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'a'
+"SyntaxError [1:21-1:22]: Duplicate binding 'a'
 > 1 | function f([b, a, b, a]) {}
-    |                       ^ Duplicate binding 'a'"
+    |                      ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f([b, a, b, a]) {} 2`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'a'
+"SyntaxError [1:21-1:22]: Duplicate binding 'a'
 > 1 | function f([b, a, b, a]) {}
-    |                       ^ Duplicate binding 'a'"
+    |                      ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f([b, a], ...b) {} 1`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'b'
+"SyntaxError [1:22-1:23]: Duplicate binding 'b'
 > 1 | function f([b, a], ...b) {}
-    |                        ^ Duplicate binding 'b'"
+    |                       ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f([b, a], ...b) {} 2`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'b'
+"SyntaxError [1:22-1:23]: Duplicate binding 'b'
 > 1 | function f([b, a], ...b) {}
-    |                        ^ Duplicate binding 'b'"
+    |                       ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f([b, a], {b}) {} 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'b'
+"SyntaxError [1:20-1:21]: Duplicate binding 'b'
 > 1 | function f([b, a], {b}) {}
-    |                      ^ Duplicate binding 'b'"
+    |                     ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f([b, a], {b}) {} 2`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'b'
+"SyntaxError [1:20-1:21]: Duplicate binding 'b'
 > 1 | function f([b, a], {b}) {}
-    |                      ^ Duplicate binding 'b'"
+    |                     ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f([b, a], b) {} 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'b'
+"SyntaxError [1:19-1:20]: Duplicate binding 'b'
 > 1 | function f([b, a], b) {}
-    |                     ^ Duplicate binding 'b'"
+    |                    ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f([b, a], b) {} 2`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'b'
+"SyntaxError [1:19-1:20]: Duplicate binding 'b'
 > 1 | function f([b, a], b) {}
-    |                     ^ Duplicate binding 'b'"
+    |                    ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f([b, a], b=x) {} 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'b'
+"SyntaxError [1:19-1:20]: Duplicate binding 'b'
 > 1 | function f([b, a], b=x) {}
-    |                     ^ Duplicate binding 'b'"
+    |                    ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f([b, a], b=x) {} 2`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'b'
+"SyntaxError [1:19-1:20]: Duplicate binding 'b'
 > 1 | function f([b, a], b=x) {}
-    |                     ^ Duplicate binding 'b'"
+    |                    ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f([foo] = x, [foo] = y){} 1`] = `
-"SyntaxError [1:26-1:27]: Duplicate binding 'foo'
+"SyntaxError [1:23-1:26]: Duplicate binding 'foo'
 > 1 | function f([foo] = x, [foo] = y){}
-    |                           ^ Duplicate binding 'foo'"
+    |                        ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f([foo], [foo]){} 1`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'foo'
+"SyntaxError [1:19-1:22]: Duplicate binding 'foo'
 > 1 | function f([foo], [foo]){}
-    |                       ^ Duplicate binding 'foo'"
+    |                    ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f({a: x, ...{x}}) {} 1`] = `
@@ -427,177 +427,177 @@ exports[`Lexical - Function > Lexical - Function (fail) > function f({a: x, ...{
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f({a: x, ...x}) {} 1`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'x'
+"SyntaxError [1:21-1:22]: Duplicate binding 'x'
 > 1 | function f({a: x, ...x}) {}
-    |                       ^ Duplicate binding 'x'"
+    |                      ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f({a: x, b: x}) {} 1`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'x'
+"SyntaxError [1:21-1:22]: Duplicate binding 'x'
 > 1 | function f({a: x, b: x}) {}
-    |                       ^ Duplicate binding 'x'"
+    |                      ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f({foo} = x, {foo}){} 1`] = `
-"SyntaxError [1:26-1:27]: Duplicate binding 'foo'
+"SyntaxError [1:23-1:26]: Duplicate binding 'foo'
 > 1 | function f({foo} = x, {foo}){}
-    |                           ^ Duplicate binding 'foo'"
+    |                        ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f({x, x}) {} 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'x'
+"SyntaxError [1:15-1:16]: Duplicate binding 'x'
 > 1 | function f({x, x}) {}
-    |                 ^ Duplicate binding 'x'"
+    |                ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(a, a) {"use strict"} 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'a'
+"SyntaxError [1:14-1:15]: Duplicate binding 'a'
 > 1 | function f(a, a) {"use strict"}
-    |                ^ Duplicate binding 'a'"
+    |               ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(a, a) {} 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'a'
+"SyntaxError [1:14-1:15]: Duplicate binding 'a'
 > 1 | function f(a, a) {}
-    |                ^ Duplicate binding 'a'"
+    |               ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(a, a, b) {} 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'a'
+"SyntaxError [1:14-1:15]: Duplicate binding 'a'
 > 1 | function f(a, a, b) {}
-    |                ^ Duplicate binding 'a'"
+    |               ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(a, b = 10, a) { } 1`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'a'
+"SyntaxError [1:22-1:23]: Duplicate binding 'a'
 > 1 | function f(a, b = 10, a) { }
-    |                        ^ Duplicate binding 'a'"
+    |                       ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(a, b, a) {"use strict"} 1`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'a'
 > 1 | function f(a, b, a) {"use strict"}
-    |                   ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(a, b, a) {} 1`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'a'
 > 1 | function f(a, b, a) {}
-    |                   ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(a, b, a, c = 10) { } 1`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'a'
 > 1 | function f(a, b, a, c = 10) { }
-    |                   ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(b, a, a) {"use strict"} 1`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'a'
 > 1 | function f(b, a, a) {"use strict"}
-    |                   ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(b, a, a) {} 1`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'a'
 > 1 | function f(b, a, a) {}
-    |                   ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(b, a, b, ...a) {"use strict"} 1`] = `
-"SyntaxError [1:24-1:25]: Duplicate binding 'a'
+"SyntaxError [1:23-1:24]: Duplicate binding 'a'
 > 1 | function f(b, a, b, ...a) {"use strict"}
-    |                         ^ Duplicate binding 'a'"
+    |                        ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(b, a, b, ...a) {} 1`] = `
-"SyntaxError [1:24-1:25]: Duplicate binding 'a'
+"SyntaxError [1:23-1:24]: Duplicate binding 'a'
 > 1 | function f(b, a, b, ...a) {}
-    |                         ^ Duplicate binding 'a'"
+    |                        ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(b, a, b, a = x) {"use strict"} 1`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'a'
+"SyntaxError [1:20-1:21]: Duplicate binding 'a'
 > 1 | function f(b, a, b, a = x) {"use strict"}
-    |                       ^ Duplicate binding 'a'"
+    |                     ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(b, a, b, a = x) {} 1`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'a'
+"SyntaxError [1:20-1:21]: Duplicate binding 'a'
 > 1 | function f(b, a, b, a = x) {}
-    |                       ^ Duplicate binding 'a'"
+    |                     ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(b, a, b, a = x) {} 2`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'a'
+"SyntaxError [1:20-1:21]: Duplicate binding 'a'
 > 1 | function f(b, a, b, a = x) {}
-    |                       ^ Duplicate binding 'a'"
+    |                     ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(b, a, b, a) {"use strict"} 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'a'
+"SyntaxError [1:20-1:21]: Duplicate binding 'a'
 > 1 | function f(b, a, b, a) {"use strict"}
-    |                      ^ Duplicate binding 'a'"
+    |                     ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(b, a, b, a) {} 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'a'
+"SyntaxError [1:20-1:21]: Duplicate binding 'a'
 > 1 | function f(b, a, b, a) {}
-    |                      ^ Duplicate binding 'a'"
+    |                     ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(b, a, b, a, [fine]) {"use strict"} 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'a'
+"SyntaxError [1:20-1:21]: Duplicate binding 'a'
 > 1 | function f(b, a, b, a, [fine]) {"use strict"}
-    |                      ^ Duplicate binding 'a'"
+    |                     ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(b, a, b, a, [fine]) {} 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'a'
+"SyntaxError [1:20-1:21]: Duplicate binding 'a'
 > 1 | function f(b, a, b, a, [fine]) {}
-    |                      ^ Duplicate binding 'a'"
+    |                     ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(x = 0, x) {} 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'x'
+"SyntaxError [1:18-1:19]: Duplicate binding 'x'
 > 1 | function f(x = 0, x) {}
-    |                    ^ Duplicate binding 'x'"
+    |                   ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(x = 0, x) {} 2`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'x'
+"SyntaxError [1:18-1:19]: Duplicate binding 'x'
 > 1 | function f(x = 0, x) {}
-    |                    ^ Duplicate binding 'x'"
+    |                   ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(x) { const x = y } 1`] = `
-"SyntaxError [1:24-1:25]: Duplicate binding 'x'
+"SyntaxError [1:22-1:23]: Duplicate binding 'x'
 > 1 | function f(x) { const x = y }
-    |                         ^ Duplicate binding 'x'"
+    |                       ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(x) { let x } 1`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'x'
+"SyntaxError [1:20-1:21]: Duplicate binding 'x'
 > 1 | function f(x) { let x }
-    |                       ^ Duplicate binding 'x'"
+    |                     ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(x) { let x } 2`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'x'
+"SyntaxError [1:20-1:21]: Duplicate binding 'x'
 > 1 | function f(x) { let x }
-    |                       ^ Duplicate binding 'x'"
+    |                     ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(x) { let x } 3`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'x'
+"SyntaxError [1:20-1:21]: Duplicate binding 'x'
 > 1 | function f(x) { let x }
-    |                       ^ Duplicate binding 'x'"
+    |                     ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(x) {let x} 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'x'
+"SyntaxError [1:19-1:20]: Duplicate binding 'x'
 > 1 | function f(x) {let x}
-    |                     ^ Duplicate binding 'x'"
+    |                    ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(x, {"foo": x}) {} 1`] = `
@@ -613,21 +613,21 @@ exports[`Lexical - Function > Lexical - Function (fail) > function f(x, {15: x})
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(x, {a: {b: x}}) {} 1`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'x'
+"SyntaxError [1:22-1:23]: Duplicate binding 'x'
 > 1 | function f(x, {a: {b: x}}) {}
-    |                        ^ Duplicate binding 'x'"
+    |                       ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(x, {a: {x}}) {} 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'x'
+"SyntaxError [1:19-1:20]: Duplicate binding 'x'
 > 1 | function f(x, {a: {x}}) {}
-    |                     ^ Duplicate binding 'x'"
+    |                    ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(x, {a: x}) {} 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'x'
+"SyntaxError [1:18-1:19]: Duplicate binding 'x'
 > 1 | function f(x, {a: x}) {}
-    |                    ^ Duplicate binding 'x'"
+    |                   ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function foo() { return {}; }; let {x:foo()} = {}; 1`] = `
@@ -637,9 +637,9 @@ exports[`Lexical - Function > Lexical - Function (fail) > function foo() { retur
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function foo() {try {} catch([x, x]) {} } 1`] = `
-"SyntaxError [1:34-1:35]: Duplicate binding 'x'
+"SyntaxError [1:33-1:34]: Duplicate binding 'x'
 > 1 | function foo() {try {} catch([x, x]) {} }
-    |                                   ^ Duplicate binding 'x'"
+    |                                  ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function foo() {try {} catch([x]) { function x() {} } } 1`] = `
@@ -649,243 +649,243 @@ exports[`Lexical - Function > Lexical - Function (fail) > function foo() {try {}
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function foo() {try {} catch([x]) { let x = 10;} } 1`] = `
-"SyntaxError [1:42-1:43]: 'x' shadowed a catch clause binding
+"SyntaxError [1:40-1:41]: 'x' shadowed a catch clause binding
 > 1 | function foo() {try {} catch([x]) { let x = 10;} }
-    |                                           ^ 'x' shadowed a catch clause binding"
+    |                                         ^ 'x' shadowed a catch clause binding"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function foo() {try {} catch([x]) { var x = 10;} } 1`] = `
-"SyntaxError [1:42-1:43]: Duplicate binding 'x'
+"SyntaxError [1:40-1:41]: Duplicate binding 'x'
 > 1 | function foo() {try {} catch([x]) { var x = 10;} }
-    |                                           ^ Duplicate binding 'x'"
+    |                                         ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function foo() {try {} catch({x:x, x:x}) {} } 1`] = `
-"SyntaxError [1:38-1:39]: Duplicate binding 'x'
-> 1 | function foo() {try {} catch({x:x, x:x}) {} }
-    |                                       ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function foo() {try {} catch({z1, x:{z:[z1]}}) {} } 1`] = `
-"SyntaxError [1:42-1:43]: Duplicate binding 'z1'
-> 1 | function foo() {try {} catch({z1, x:{z:[z1]}}) {} }
-    |                                           ^ Duplicate binding 'z1'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function foo([a], b = () => a) { const b = 1; }; 1`] = `
-"SyntaxError [1:41-1:42]: Duplicate binding 'b'
-> 1 | function foo([a], b = () => a) { const b = 1; };
-    |                                          ^ Duplicate binding 'b'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function foo([arguments, b = () => arguments]) { let arguments; }; 1`] = `
-"SyntaxError [1:62-1:63]: Duplicate binding 'arguments'
-> 1 | function foo([arguments, b = () => arguments]) { let arguments; };
-    |                                                               ^ Duplicate binding 'arguments'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function foo([x, x]) {} 1`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'x'
-> 1 | function foo([x, x]) {}
-    |                   ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function foo([x, x]) {} 2`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'x'
-> 1 | function foo([x, x]) {}
-    |                   ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function foo([x, x]) {} 3`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'x'
-> 1 | function foo([x, x]) {}
-    |                   ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function foo([x]) { let x = 10;} 1`] = `
-"SyntaxError [1:26-1:27]: Duplicate binding 'x'
-> 1 | function foo([x]) { let x = 10;}
-    |                           ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function foo([x]) { let x = 10;} 2`] = `
-"SyntaxError [1:26-1:27]: Duplicate binding 'x'
-> 1 | function foo([x]) { let x = 10;}
-    |                           ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function foo([x], [x]) {} 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'x'
-> 1 | function foo([x], [x]) {}
-    |                     ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function foo([x], [x]) {} 2`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'x'
-> 1 | function foo([x], [x]) {}
-    |                     ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function foo([x], [x]) {} 3`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'x'
-> 1 | function foo([x], [x]) {}
-    |                     ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function foo([x], {x:x}) {} 1`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'x'
-> 1 | function foo([x], {x:x}) {}
-    |                       ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function foo([x], {x:x}) {} 2`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'x'
-> 1 | function foo([x], {x:x}) {}
-    |                       ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function foo([x], x) {} 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'x'
-> 1 | function foo([x], x) {}
-    |                    ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function foo({a, b = () => a}) { let b; }; 1`] = `
-"SyntaxError [1:38-1:39]: Duplicate binding 'b'
-> 1 | function foo({a, b = () => a}) { let b; };
-    |                                       ^ Duplicate binding 'b'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function foo({x:{z:[z1]}}, z1) {} 1`] = `
-"SyntaxError [1:29-1:30]: Duplicate binding 'z1'
-> 1 | function foo({x:{z:[z1]}}, z1) {}
-    |                              ^ Duplicate binding 'z1'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function foo({x:x, x:x}) {} 1`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'x'
-> 1 | function foo({x:x, x:x}) {}
-    |                       ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function foo({x:x}, {x:x}) {} 1`] = `
-"SyntaxError [1:24-1:25]: Duplicate binding 'x'
-> 1 | function foo({x:x}, {x:x}) {}
-    |                         ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function foo(a) { let a; } 1`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'a'
-> 1 | function foo(a) { let a; }
-    |                        ^ Duplicate binding 'a'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function foo(a, a = b) {} 1`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'a'
-> 1 | function foo(a, a = b) {}
-    |                   ^ Duplicate binding 'a'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function foo(a, a = b) {} 2`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'a'
-> 1 | function foo(a, a = b) {}
-    |                   ^ Duplicate binding 'a'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function foo(a, b = () => a) { const b = 1; }; 1`] = `
-"SyntaxError [1:39-1:40]: Duplicate binding 'b'
-> 1 | function foo(a, b = () => a) { const b = 1; };
-    |                                        ^ Duplicate binding 'b'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function foo(a, b = () => a) { let b; }; 1`] = `
-"SyntaxError [1:36-1:37]: Duplicate binding 'b'
-> 1 | function foo(a, b = () => a) { let b; };
-    |                                     ^ Duplicate binding 'b'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function foo(arguments, b = () => arguments) { const arguments = 1; }; 1`] = `
-"SyntaxError [1:63-1:64]: Duplicate binding 'arguments'
-> 1 | function foo(arguments, b = () => arguments) { const arguments = 1; };
-    |                                                                ^ Duplicate binding 'arguments'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function foo(arguments, b = () => arguments) { let arguments; }; 1`] = `
-"SyntaxError [1:60-1:61]: Duplicate binding 'arguments'
-> 1 | function foo(arguments, b = () => arguments) { let arguments; };
-    |                                                             ^ Duplicate binding 'arguments'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function foo(bar, bar){} 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'bar'
-> 1 | function foo(bar, bar){}
-    |                      ^ Duplicate binding 'bar'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function foo(x, [x]) {} 1`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'x'
-> 1 | function foo(x, [x]) {}
-    |                   ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function fooa(a = b, a) {} 1`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'a'
-> 1 | function fooa(a = b, a) {}
-    |                       ^ Duplicate binding 'a'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function g() { { var x; let x; } } 1`] = `
-"SyntaxError [1:29-1:30]: Duplicate binding 'x'
-> 1 | function g() { { var x; let x; } }
-    |                              ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function x() {}const x = function() {}; 1`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'x'
-> 1 | function x() {}const x = function() {};
-    |                        ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function x() {}const y = 4, x = 5; 1`] = `
-"SyntaxError [1:30-1:31]: Duplicate binding 'x'
-> 1 | function x() {}const y = 4, x = 5;
-    |                               ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function x() {}const y = 4, x = 5; 2`] = `
-"SyntaxError [1:30-1:31]: Duplicate binding 'x'
-> 1 | function x() {}const y = 4, x = 5;
-    |                               ^ Duplicate binding 'x'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function x([public], public){} 1`] = `
-"SyntaxError [1:27-1:28]: Duplicate binding 'public'
-> 1 | function x([public], public){}
-    |                            ^ Duplicate binding 'public'"
-`;
-
-exports[`Lexical - Function > Lexical - Function (fail) > function x(x = class x {}) { const x = y; } 1`] = `
 "SyntaxError [1:37-1:38]: Duplicate binding 'x'
-> 1 | function x(x = class x {}) { const x = y; }
+> 1 | function foo() {try {} catch({x:x, x:x}) {} }
     |                                      ^ Duplicate binding 'x'"
 `;
 
+exports[`Lexical - Function > Lexical - Function (fail) > function foo() {try {} catch({z1, x:{z:[z1]}}) {} } 1`] = `
+"SyntaxError [1:40-1:42]: Duplicate binding 'z1'
+> 1 | function foo() {try {} catch({z1, x:{z:[z1]}}) {} }
+    |                                         ^^ Duplicate binding 'z1'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function foo([a], b = () => a) { const b = 1; }; 1`] = `
+"SyntaxError [1:39-1:40]: Duplicate binding 'b'
+> 1 | function foo([a], b = () => a) { const b = 1; };
+    |                                        ^ Duplicate binding 'b'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function foo([arguments, b = () => arguments]) { let arguments; }; 1`] = `
+"SyntaxError [1:53-1:62]: Duplicate binding 'arguments'
+> 1 | function foo([arguments, b = () => arguments]) { let arguments; };
+    |                                                      ^^^^^^^^^ Duplicate binding 'arguments'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function foo([x, x]) {} 1`] = `
+"SyntaxError [1:17-1:18]: Duplicate binding 'x'
+> 1 | function foo([x, x]) {}
+    |                  ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function foo([x, x]) {} 2`] = `
+"SyntaxError [1:17-1:18]: Duplicate binding 'x'
+> 1 | function foo([x, x]) {}
+    |                  ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function foo([x, x]) {} 3`] = `
+"SyntaxError [1:17-1:18]: Duplicate binding 'x'
+> 1 | function foo([x, x]) {}
+    |                  ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function foo([x]) { let x = 10;} 1`] = `
+"SyntaxError [1:24-1:25]: Duplicate binding 'x'
+> 1 | function foo([x]) { let x = 10;}
+    |                         ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function foo([x]) { let x = 10;} 2`] = `
+"SyntaxError [1:24-1:25]: Duplicate binding 'x'
+> 1 | function foo([x]) { let x = 10;}
+    |                         ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function foo([x], [x]) {} 1`] = `
+"SyntaxError [1:19-1:20]: Duplicate binding 'x'
+> 1 | function foo([x], [x]) {}
+    |                    ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function foo([x], [x]) {} 2`] = `
+"SyntaxError [1:19-1:20]: Duplicate binding 'x'
+> 1 | function foo([x], [x]) {}
+    |                    ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function foo([x], [x]) {} 3`] = `
+"SyntaxError [1:19-1:20]: Duplicate binding 'x'
+> 1 | function foo([x], [x]) {}
+    |                    ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function foo([x], {x:x}) {} 1`] = `
+"SyntaxError [1:21-1:22]: Duplicate binding 'x'
+> 1 | function foo([x], {x:x}) {}
+    |                      ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function foo([x], {x:x}) {} 2`] = `
+"SyntaxError [1:21-1:22]: Duplicate binding 'x'
+> 1 | function foo([x], {x:x}) {}
+    |                      ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function foo([x], x) {} 1`] = `
+"SyntaxError [1:18-1:19]: Duplicate binding 'x'
+> 1 | function foo([x], x) {}
+    |                   ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function foo({a, b = () => a}) { let b; }; 1`] = `
+"SyntaxError [1:37-1:38]: Duplicate binding 'b'
+> 1 | function foo({a, b = () => a}) { let b; };
+    |                                      ^ Duplicate binding 'b'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function foo({x:{z:[z1]}}, z1) {} 1`] = `
+"SyntaxError [1:27-1:29]: Duplicate binding 'z1'
+> 1 | function foo({x:{z:[z1]}}, z1) {}
+    |                            ^^ Duplicate binding 'z1'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function foo({x:x, x:x}) {} 1`] = `
+"SyntaxError [1:21-1:22]: Duplicate binding 'x'
+> 1 | function foo({x:x, x:x}) {}
+    |                      ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function foo({x:x}, {x:x}) {} 1`] = `
+"SyntaxError [1:23-1:24]: Duplicate binding 'x'
+> 1 | function foo({x:x}, {x:x}) {}
+    |                        ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function foo(a) { let a; } 1`] = `
+"SyntaxError [1:22-1:23]: Duplicate binding 'a'
+> 1 | function foo(a) { let a; }
+    |                       ^ Duplicate binding 'a'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function foo(a, a = b) {} 1`] = `
+"SyntaxError [1:16-1:17]: Duplicate binding 'a'
+> 1 | function foo(a, a = b) {}
+    |                 ^ Duplicate binding 'a'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function foo(a, a = b) {} 2`] = `
+"SyntaxError [1:16-1:17]: Duplicate binding 'a'
+> 1 | function foo(a, a = b) {}
+    |                 ^ Duplicate binding 'a'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function foo(a, b = () => a) { const b = 1; }; 1`] = `
+"SyntaxError [1:37-1:38]: Duplicate binding 'b'
+> 1 | function foo(a, b = () => a) { const b = 1; };
+    |                                      ^ Duplicate binding 'b'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function foo(a, b = () => a) { let b; }; 1`] = `
+"SyntaxError [1:35-1:36]: Duplicate binding 'b'
+> 1 | function foo(a, b = () => a) { let b; };
+    |                                    ^ Duplicate binding 'b'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function foo(arguments, b = () => arguments) { const arguments = 1; }; 1`] = `
+"SyntaxError [1:53-1:62]: Duplicate binding 'arguments'
+> 1 | function foo(arguments, b = () => arguments) { const arguments = 1; };
+    |                                                      ^^^^^^^^^ Duplicate binding 'arguments'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function foo(arguments, b = () => arguments) { let arguments; }; 1`] = `
+"SyntaxError [1:51-1:60]: Duplicate binding 'arguments'
+> 1 | function foo(arguments, b = () => arguments) { let arguments; };
+    |                                                    ^^^^^^^^^ Duplicate binding 'arguments'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function foo(bar, bar){} 1`] = `
+"SyntaxError [1:18-1:21]: Duplicate binding 'bar'
+> 1 | function foo(bar, bar){}
+    |                   ^^^ Duplicate binding 'bar'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function foo(x, [x]) {} 1`] = `
+"SyntaxError [1:17-1:18]: Duplicate binding 'x'
+> 1 | function foo(x, [x]) {}
+    |                  ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function fooa(a = b, a) {} 1`] = `
+"SyntaxError [1:21-1:22]: Duplicate binding 'a'
+> 1 | function fooa(a = b, a) {}
+    |                      ^ Duplicate binding 'a'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function g() { { var x; let x; } } 1`] = `
+"SyntaxError [1:28-1:29]: Duplicate binding 'x'
+> 1 | function g() { { var x; let x; } }
+    |                             ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function x() {}const x = function() {}; 1`] = `
+"SyntaxError [1:21-1:22]: Duplicate binding 'x'
+> 1 | function x() {}const x = function() {};
+    |                      ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function x() {}const y = 4, x = 5; 1`] = `
+"SyntaxError [1:28-1:29]: Duplicate binding 'x'
+> 1 | function x() {}const y = 4, x = 5;
+    |                             ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function x() {}const y = 4, x = 5; 2`] = `
+"SyntaxError [1:28-1:29]: Duplicate binding 'x'
+> 1 | function x() {}const y = 4, x = 5;
+    |                             ^ Duplicate binding 'x'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function x([public], public){} 1`] = `
+"SyntaxError [1:21-1:27]: Duplicate binding 'public'
+> 1 | function x([public], public){}
+    |                      ^^^^^^ Duplicate binding 'public'"
+`;
+
+exports[`Lexical - Function > Lexical - Function (fail) > function x(x = class x {}) { const x = y; } 1`] = `
+"SyntaxError [1:35-1:36]: Duplicate binding 'x'
+> 1 | function x(x = class x {}) { const x = y; }
+    |                                    ^ Duplicate binding 'x'"
+`;
+
 exports[`Lexical - Function > Lexical - Function (fail) > function* f([a]){ let a; } 1`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'a'
+"SyntaxError [1:22-1:23]: Duplicate binding 'a'
 > 1 | function* f([a]){ let a; }
-    |                        ^ Duplicate binding 'a'"
+    |                       ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function* f({a}){ let a; } 1`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'a'
+"SyntaxError [1:22-1:23]: Duplicate binding 'a'
 > 1 | function* f({a}){ let a; }
-    |                        ^ Duplicate binding 'a'"
+    |                       ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function* f(a) { let a; } 1`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'a'
+"SyntaxError [1:21-1:22]: Duplicate binding 'a'
 > 1 | function* f(a) { let a; }
-    |                       ^ Duplicate binding 'a'"
+    |                      ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > let x = a; function x(){}; 1`] = `
@@ -895,7 +895,7 @@ exports[`Lexical - Function > Lexical - Function (fail) > let x = a; function x(
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > let x; { var x; } 1`] = `
-"SyntaxError [1:14-1:15]: Duplicate binding 'x'
+"SyntaxError [1:13-1:14]: Duplicate binding 'x'
 > 1 | let x; { var x; }
-    |               ^ Duplicate binding 'x'"
+    |              ^ Duplicate binding 'x'"
 `;

--- a/test/parser/lexical/__snapshots__/function.ts.snap
+++ b/test/parser/lexical/__snapshots__/function.ts.snap
@@ -349,15 +349,15 @@ exports[`Lexical - Function > Lexical - Function (fail) > function f([b, a, a]) 
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f([b, a, b, a]) {} 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'a'
+"SyntaxError [1:18-1:19]: Duplicate binding 'b'
 > 1 | function f([b, a, b, a]) {}
-    |                      ^ Duplicate binding 'a'"
+    |                   ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f([b, a, b, a]) {} 2`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'a'
+"SyntaxError [1:18-1:19]: Duplicate binding 'b'
 > 1 | function f([b, a, b, a]) {}
-    |                      ^ Duplicate binding 'a'"
+    |                   ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f([b, a], ...b) {} 1`] = `
@@ -505,57 +505,57 @@ exports[`Lexical - Function > Lexical - Function (fail) > function f(b, a, a) {}
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(b, a, b, ...a) {"use strict"} 1`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'b'
 > 1 | function f(b, a, b, ...a) {"use strict"}
-    |                        ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(b, a, b, ...a) {} 1`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'b'
 > 1 | function f(b, a, b, ...a) {}
-    |                        ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(b, a, b, a = x) {"use strict"} 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'b'
 > 1 | function f(b, a, b, a = x) {"use strict"}
-    |                     ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(b, a, b, a = x) {} 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'b'
 > 1 | function f(b, a, b, a = x) {}
-    |                     ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(b, a, b, a = x) {} 2`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'b'
 > 1 | function f(b, a, b, a = x) {}
-    |                     ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(b, a, b, a) {"use strict"} 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'b'
 > 1 | function f(b, a, b, a) {"use strict"}
-    |                     ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(b, a, b, a) {} 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'b'
 > 1 | function f(b, a, b, a) {}
-    |                     ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(b, a, b, a, [fine]) {"use strict"} 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'b'
 > 1 | function f(b, a, b, a, [fine]) {"use strict"}
-    |                     ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(b, a, b, a, [fine]) {} 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'b'
 > 1 | function f(b, a, b, a, [fine]) {}
-    |                     ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Function > Lexical - Function (fail) > function f(x = 0, x) {} 1`] = `

--- a/test/parser/lexical/__snapshots__/if.ts.snap
+++ b/test/parser/lexical/__snapshots__/if.ts.snap
@@ -19,51 +19,51 @@ exports[`Lexical - If > Lexical - If (fail) > do async function f(){} while (x);
 `;
 
 exports[`Lexical - If > Lexical - If (fail) > if (x) { if (y) var foo = 1; } let foo = 1; 1`] = `
-"SyntaxError [1:39-1:40]: Duplicate binding 'foo'
+"SyntaxError [1:35-1:38]: Duplicate binding 'foo'
 > 1 | if (x) { if (y) var foo = 1; } let foo = 1;
-    |                                        ^ Duplicate binding 'foo'"
+    |                                    ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - If > Lexical - If (fail) > if (x) { if (y) var foo = 1; } let foo = 1; 2`] = `
-"SyntaxError [1:39-1:40]: Duplicate binding 'foo'
+"SyntaxError [1:35-1:38]: Duplicate binding 'foo'
 > 1 | if (x) { if (y) var foo = 1; } let foo = 1;
-    |                                        ^ Duplicate binding 'foo'"
+    |                                    ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - If > Lexical - If (fail) > if (x) { if (y) var foo = 1; } let foo = 1; 3`] = `
-"SyntaxError [1:39-1:40]: Duplicate binding 'foo'
+"SyntaxError [1:35-1:38]: Duplicate binding 'foo'
 > 1 | if (x) { if (y) var foo = 1; } let foo = 1;
-    |                                        ^ Duplicate binding 'foo'"
+    |                                    ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - If > Lexical - If (fail) > if (x) { if (y) var foo = 1; } let foo = 1; 4`] = `
-"SyntaxError [1:39-1:40]: Duplicate binding 'foo'
+"SyntaxError [1:35-1:38]: Duplicate binding 'foo'
 > 1 | if (x) { if (y) var foo = 1; } let foo = 1;
-    |                                        ^ Duplicate binding 'foo'"
+    |                                    ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - If > Lexical - If (fail) > if (x) {} else if (y) {} else var foo = 1; let foo = 1; 1`] = `
-"SyntaxError [1:51-1:52]: Duplicate binding 'foo'
+"SyntaxError [1:47-1:50]: Duplicate binding 'foo'
 > 1 | if (x) {} else if (y) {} else var foo = 1; let foo = 1;
-    |                                                    ^ Duplicate binding 'foo'"
+    |                                                ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - If > Lexical - If (fail) > if (x) {} else if (y) {} else var foo = 1; let foo = 1; 2`] = `
-"SyntaxError [1:51-1:52]: Duplicate binding 'foo'
+"SyntaxError [1:47-1:50]: Duplicate binding 'foo'
 > 1 | if (x) {} else if (y) {} else var foo = 1; let foo = 1;
-    |                                                    ^ Duplicate binding 'foo'"
+    |                                                ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - If > Lexical - If (fail) > if (x) {} else var foo = 1; let foo = 1; 1`] = `
-"SyntaxError [1:36-1:37]: Duplicate binding 'foo'
+"SyntaxError [1:32-1:35]: Duplicate binding 'foo'
 > 1 | if (x) {} else var foo = 1; let foo = 1;
-    |                                     ^ Duplicate binding 'foo'"
+    |                                 ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - If > Lexical - If (fail) > if (x) {} else var foo = 1; let foo = 1; 2`] = `
-"SyntaxError [1:36-1:37]: Duplicate binding 'foo'
+"SyntaxError [1:32-1:35]: Duplicate binding 'foo'
 > 1 | if (x) {} else var foo = 1; let foo = 1;
-    |                                     ^ Duplicate binding 'foo'"
+    |                                 ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - If > Lexical - If (fail) > if (x) async function f(){} 1`] = `
@@ -73,45 +73,45 @@ exports[`Lexical - If > Lexical - If (fail) > if (x) async function f(){} 1`] = 
 `;
 
 exports[`Lexical - If > Lexical - If (fail) > if (x) var foo = 1; else {} let foo = 1; 1`] = `
-"SyntaxError [1:36-1:37]: Duplicate binding 'foo'
+"SyntaxError [1:32-1:35]: Duplicate binding 'foo'
 > 1 | if (x) var foo = 1; else {} let foo = 1;
-    |                                     ^ Duplicate binding 'foo'"
+    |                                 ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - If > Lexical - If (fail) > if (x) var foo = 1; else {} let foo = 1; 2`] = `
-"SyntaxError [1:36-1:37]: Duplicate binding 'foo'
+"SyntaxError [1:32-1:35]: Duplicate binding 'foo'
 > 1 | if (x) var foo = 1; else {} let foo = 1;
-    |                                     ^ Duplicate binding 'foo'"
+    |                                 ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - If > Lexical - If (fail) > if (x) var foo = 1; let foo = 1; 1`] = `
-"SyntaxError [1:28-1:29]: Duplicate binding 'foo'
+"SyntaxError [1:24-1:27]: Duplicate binding 'foo'
 > 1 | if (x) var foo = 1; let foo = 1;
-    |                             ^ Duplicate binding 'foo'"
+    |                         ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - If > Lexical - If (fail) > if (x) var foo = 1; let foo = 1; 2`] = `
-"SyntaxError [1:28-1:29]: Duplicate binding 'foo'
+"SyntaxError [1:24-1:27]: Duplicate binding 'foo'
 > 1 | if (x) var foo = 1; let foo = 1;
-    |                             ^ Duplicate binding 'foo'"
+    |                         ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - If > Lexical - If (fail) > if (x) var foo = 1; let foo = 1; 3`] = `
-"SyntaxError [1:28-1:29]: Duplicate binding 'foo'
+"SyntaxError [1:24-1:27]: Duplicate binding 'foo'
 > 1 | if (x) var foo = 1; let foo = 1;
-    |                             ^ Duplicate binding 'foo'"
+    |                         ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - If > Lexical - If (fail) > if (x) var foo = 1; let foo = 1; 4`] = `
-"SyntaxError [1:28-1:29]: Duplicate binding 'foo'
+"SyntaxError [1:24-1:27]: Duplicate binding 'foo'
 > 1 | if (x) var foo = 1; let foo = 1;
-    |                             ^ Duplicate binding 'foo'"
+    |                         ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - If > Lexical - If (fail) > if (x) var foo = 1; let foo = 1; 5`] = `
-"SyntaxError [1:28-1:29]: Duplicate binding 'foo'
+"SyntaxError [1:24-1:27]: Duplicate binding 'foo'
 > 1 | if (x) var foo = 1; let foo = 1;
-    |                             ^ Duplicate binding 'foo'"
+    |                         ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - If > Lexical - If (fail) > if (x) x;

--- a/test/parser/lexical/__snapshots__/lexical.ts.snap
+++ b/test/parser/lexical/__snapshots__/lexical.ts.snap
@@ -1,21 +1,21 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > (function() { let a; var a; })(); 1`] = `
-"SyntaxError [1:26-1:27]: Duplicate binding 'a'
+"SyntaxError [1:25-1:26]: Duplicate binding 'a'
 > 1 | (function() { let a; var a; })();
-    |                           ^ Duplicate binding 'a'"
+    |                          ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > { let a; { var a; } } 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'a'
+"SyntaxError [1:15-1:16]: Duplicate binding 'a'
 > 1 | { let a; { var a; } }
-    |                 ^ Duplicate binding 'a'"
+    |                ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > { let a; let a; } 1`] = `
-"SyntaxError [1:14-1:15]: Duplicate binding 'a'
+"SyntaxError [1:13-1:14]: Duplicate binding 'a'
 > 1 | { let a; let a; }
-    |               ^ Duplicate binding 'a'"
+    |              ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > { var f; function f() {} } 1`] = `
@@ -25,15 +25,15 @@ exports[`Lexical - Lexical > Lexical - Lexical (fail) > { var f; function f() {}
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > { var f; let f; } 1`] = `
-"SyntaxError [1:14-1:15]: Duplicate binding 'f'
+"SyntaxError [1:13-1:14]: Duplicate binding 'f'
 > 1 | { var f; let f; }
-    |               ^ Duplicate binding 'f'"
+    |              ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > { var x } let x; 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'x'
+"SyntaxError [1:14-1:15]: Duplicate binding 'x'
 > 1 | { var x } let x;
-    |                ^ Duplicate binding 'x'"
+    |               ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > { var x; } let x 1`] = `
@@ -49,135 +49,135 @@ exports[`Lexical - Lexical > Lexical - Lexical (fail) > const [a, let, b] = [1, 
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > const [x, {x}] = y 1`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'x'
+"SyntaxError [1:11-1:12]: Duplicate binding 'x'
 > 1 | const [x, {x}] = y
-    |             ^ Duplicate binding 'x'"
+    |            ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > const [x, {x}] = y 2`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'x'
+"SyntaxError [1:11-1:12]: Duplicate binding 'x'
 > 1 | const [x, {x}] = y
-    |             ^ Duplicate binding 'x'"
+    |            ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > const [x, x] = c 1`] = `
-"SyntaxError [1:11-1:12]: Duplicate binding 'x'
+"SyntaxError [1:10-1:11]: Duplicate binding 'x'
 > 1 | const [x, x] = c
-    |            ^ Duplicate binding 'x'"
+    |           ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > const [x, x] = c 2`] = `
-"SyntaxError [1:11-1:12]: Duplicate binding 'x'
+"SyntaxError [1:10-1:11]: Duplicate binding 'x'
 > 1 | const [x, x] = c
-    |            ^ Duplicate binding 'x'"
+    |           ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > const {a:a, a:a} = {}; 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'a'
+"SyntaxError [1:14-1:15]: Duplicate binding 'a'
 > 1 | const {a:a, a:a} = {};
-    |                ^ Duplicate binding 'a'"
+    |               ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > const {x:c, y:c} = {}; 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'c'
+"SyntaxError [1:14-1:15]: Duplicate binding 'c'
 > 1 | const {x:c, y:c} = {};
-    |                ^ Duplicate binding 'c'"
+    |               ^ Duplicate binding 'c'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > const {x:x, x:x} = c 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'x'
+"SyntaxError [1:14-1:15]: Duplicate binding 'x'
 > 1 | const {x:x, x:x} = c
-    |                ^ Duplicate binding 'x'"
+    |               ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > const {x:x, x:x} = c 2`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'x'
+"SyntaxError [1:14-1:15]: Duplicate binding 'x'
 > 1 | const {x:x, x:x} = c
-    |                ^ Duplicate binding 'x'"
+    |               ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > const a = 0, a = 1; 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'a'
+"SyntaxError [1:13-1:14]: Duplicate binding 'a'
 > 1 | const a = 0, a = 1;
-    |                ^ Duplicate binding 'a'"
+    |              ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > const a = 1, a = 2 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'a'
+"SyntaxError [1:13-1:14]: Duplicate binding 'a'
 > 1 | const a = 1, a = 2
-    |                ^ Duplicate binding 'a'"
+    |              ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > const a = 1; const a = 2 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'a'
+"SyntaxError [1:19-1:20]: Duplicate binding 'a'
 > 1 | const a = 1; const a = 2
-    |                      ^ Duplicate binding 'a'"
+    |                    ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > const a = 1; let a = 2 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'a'
 > 1 | const a = 1; let a = 2
-    |                    ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > const a = 1; let a = 2 2`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'a'
 > 1 | const a = 1; let a = 2
-    |                    ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > const a = 1; let a = 2 3`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'a'
 > 1 | const a = 1; let a = 2
-    |                    ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > const a = b, a = c 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'a'
+"SyntaxError [1:13-1:14]: Duplicate binding 'a'
 > 1 | const a = b, a = c
-    |                ^ Duplicate binding 'a'"
+    |              ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > const a = b; const a = c 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'a'
+"SyntaxError [1:19-1:20]: Duplicate binding 'a'
 > 1 | const a = b; const a = c
-    |                      ^ Duplicate binding 'a'"
+    |                    ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > const a = b; const a = c 2`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'a'
+"SyntaxError [1:19-1:20]: Duplicate binding 'a'
 > 1 | const a = b; const a = c
-    |                      ^ Duplicate binding 'a'"
+    |                    ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > const a = b; let a = c 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'a'
 > 1 | const a = b; let a = c
-    |                    ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > const a = b; let a = c 2`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'a'
 > 1 | const a = b; let a = c
-    |                    ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > const x = a; const x = b; 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'x'
+"SyntaxError [1:19-1:20]: Duplicate binding 'x'
 > 1 | const x = a; const x = b;
-    |                      ^ Duplicate binding 'x'"
+    |                    ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > const x = a; const x = b; 2`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'x'
+"SyntaxError [1:19-1:20]: Duplicate binding 'x'
 > 1 | const x = a; const x = b;
-    |                      ^ Duplicate binding 'x'"
+    |                    ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > const x = a; const x = b; 3`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'x'
+"SyntaxError [1:19-1:20]: Duplicate binding 'x'
 > 1 | const x = a; const x = b;
-    |                      ^ Duplicate binding 'x'"
+    |                    ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > const x = a; function x(){}; 1`] = `
@@ -187,15 +187,15 @@ exports[`Lexical - Lexical > Lexical - Lexical (fail) > const x = a; function x(
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > const x = x, x = y; 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'x'
+"SyntaxError [1:13-1:14]: Duplicate binding 'x'
 > 1 | const x = x, x = y;
-    |                ^ Duplicate binding 'x'"
+    |              ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > const x = x, x = y; 2`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'x'
+"SyntaxError [1:13-1:14]: Duplicate binding 'x'
 > 1 | const x = x, x = y;
-    |                ^ Duplicate binding 'x'"
+    |              ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > const x; { let x; var y; } 1`] = `
@@ -211,15 +211,15 @@ exports[`Lexical - Lexical > Lexical - Lexical (fail) > const x; { let x; var y;
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > for (;;) { var x; } let x; 1`] = `
-"SyntaxError [1:25-1:26]: Duplicate binding 'x'
+"SyntaxError [1:24-1:25]: Duplicate binding 'x'
 > 1 | for (;;) { var x; } let x;
-    |                          ^ Duplicate binding 'x'"
+    |                         ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > for (let x;;) { var x; } 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'x'
+"SyntaxError [1:20-1:21]: Duplicate binding 'x'
 > 1 | for (let x;;) { var x; }
-    |                      ^ Duplicate binding 'x'"
+    |                     ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > for(let let in { }) { }; 1`] = `
@@ -235,15 +235,15 @@ exports[`Lexical - Lexical > Lexical - Lexical (fail) > function f(){let i; clas
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let [a, ...a]; 1`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'a'
+"SyntaxError [1:11-1:12]: Duplicate binding 'a'
 > 1 | let [a, ...a];
-    |             ^ Duplicate binding 'a'"
+    |            ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let [a, a] = []; 1`] = `
-"SyntaxError [1:9-1:10]: Duplicate binding 'a'
+"SyntaxError [1:8-1:9]: Duplicate binding 'a'
 > 1 | let [a, a] = [];
-    |          ^ Duplicate binding 'a'"
+    |         ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let {...(a,b)} = foo 1`] = `
@@ -361,105 +361,105 @@ exports[`Lexical - Lexical > Lexical - Lexical (fail) > let {...{a,b}} = foo 5`]
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let {[a]: x, [b]: x} = obj 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'x'
+"SyntaxError [1:18-1:19]: Duplicate binding 'x'
 > 1 | let {[a]: x, [b]: x} = obj
-    |                    ^ Duplicate binding 'x'"
+    |                   ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let {[a]: x, b: x} = obj 1`] = `
-"SyntaxError [1:17-1:18]: Duplicate binding 'x'
+"SyntaxError [1:16-1:17]: Duplicate binding 'x'
 > 1 | let {[a]: x, b: x} = obj
-    |                  ^ Duplicate binding 'x'"
+    |                 ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let {a: x, ...{x}} = obj 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'x'
+"SyntaxError [1:15-1:16]: Duplicate binding 'x'
 > 1 | let {a: x, ...{x}} = obj
-    |                 ^ Duplicate binding 'x'"
+    |                ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let {a: x, ...{x}} = obj 2`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'x'
+"SyntaxError [1:15-1:16]: Duplicate binding 'x'
 > 1 | let {a: x, ...{x}} = obj
-    |                 ^ Duplicate binding 'x'"
+    |                ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let {a: x, ...x} = obj 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'x'
+"SyntaxError [1:14-1:15]: Duplicate binding 'x'
 > 1 | let {a: x, ...x} = obj
-    |                ^ Duplicate binding 'x'"
+    |               ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let {a: x, ...x} = obj 2`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'x'
+"SyntaxError [1:14-1:15]: Duplicate binding 'x'
 > 1 | let {a: x, ...x} = obj
-    |                ^ Duplicate binding 'x'"
+    |               ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let {a: x, b: x} = obj 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'x'
+"SyntaxError [1:14-1:15]: Duplicate binding 'x'
 > 1 | let {a: x, b: x} = obj
-    |                ^ Duplicate binding 'x'"
+    |               ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let {a: x, b: x} = obj 2`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'x'
+"SyntaxError [1:14-1:15]: Duplicate binding 'x'
 > 1 | let {a: x, b: x} = obj
-    |                ^ Duplicate binding 'x'"
+    |               ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let {a: x, c: {b: x}} = obj 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'x'
+"SyntaxError [1:18-1:19]: Duplicate binding 'x'
 > 1 | let {a: x, c: {b: x}} = obj
-    |                    ^ Duplicate binding 'x'"
+    |                   ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let {a:a, a:a} = {}; 1`] = `
-"SyntaxError [1:13-1:14]: Duplicate binding 'a'
+"SyntaxError [1:12-1:13]: Duplicate binding 'a'
 > 1 | let {a:a, a:a} = {};
-    |              ^ Duplicate binding 'a'"
+    |             ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let {b, b} = {}; 1`] = `
-"SyntaxError [1:9-1:10]: Duplicate binding 'b'
+"SyntaxError [1:8-1:9]: Duplicate binding 'b'
 > 1 | let {b, b} = {};
-    |          ^ Duplicate binding 'b'"
+    |         ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let {x, x} = obj 1`] = `
-"SyntaxError [1:9-1:10]: Duplicate binding 'x'
+"SyntaxError [1:8-1:9]: Duplicate binding 'x'
 > 1 | let {x, x} = obj
-    |          ^ Duplicate binding 'x'"
+    |         ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let {x:c, y:c} = {}; 1`] = `
-"SyntaxError [1:13-1:14]: Duplicate binding 'c'
+"SyntaxError [1:12-1:13]: Duplicate binding 'c'
 > 1 | let {x:c, y:c} = {};
-    |              ^ Duplicate binding 'c'"
+    |             ^ Duplicate binding 'c'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let a = 1; const a = 2 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'a'
 > 1 | let a = 1; const a = 2
-    |                    ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let a = b; const a = c 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'a'
 > 1 | let a = b; const a = c
-    |                    ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let a = b; const a = c 2`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'a'
 > 1 | let a = b; const a = c
-    |                    ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let a, [a]; 1`] = `
-"SyntaxError [1:9-1:10]: Duplicate binding 'a'
+"SyntaxError [1:8-1:9]: Duplicate binding 'a'
 > 1 | let a, [a];
-    |          ^ Duplicate binding 'a'"
+    |         ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let a, a 1`] = `
@@ -476,40 +476,40 @@ exports[`Lexical - Lexical > Lexical - Lexical (fail) > let a; export function a
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let a; let a;
 let a; let a; 1`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'a'
+"SyntaxError [1:11-1:12]: Duplicate binding 'a'
 > 1 | let a; let a;
-    |             ^ Duplicate binding 'a'
+    |            ^ Duplicate binding 'a'
   2 | let a; let a;"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let a; let a; 1`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'a'
+"SyntaxError [1:11-1:12]: Duplicate binding 'a'
 > 1 | let a; let a;
-    |             ^ Duplicate binding 'a'"
+    |            ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let foo = 1; { var foo = 1; }  1`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'foo'
+"SyntaxError [1:19-1:22]: Duplicate binding 'foo'
 > 1 | let foo = 1; { var foo = 1; } 
-    |                        ^ Duplicate binding 'foo'"
+    |                    ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let foo = 1; function x(foo) {} { var foo = 1; } 1`] = `
-"SyntaxError [1:42-1:43]: Duplicate binding 'foo'
+"SyntaxError [1:38-1:41]: Duplicate binding 'foo'
 > 1 | let foo = 1; function x(foo) {} { var foo = 1; }
-    |                                           ^ Duplicate binding 'foo'"
+    |                                       ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let foo = 1; function x(foo) {} { var foo = 1; } 2`] = `
-"SyntaxError [1:42-1:43]: Duplicate binding 'foo'
+"SyntaxError [1:38-1:41]: Duplicate binding 'foo'
 > 1 | let foo = 1; function x(foo) {} { var foo = 1; }
-    |                                           ^ Duplicate binding 'foo'"
+    |                                       ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let foo = 1; var foo = 1; 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'foo'
+"SyntaxError [1:17-1:20]: Duplicate binding 'foo'
 > 1 | let foo = 1; var foo = 1;
-    |                      ^ Duplicate binding 'foo'"
+    |                  ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let test = 2, let = 1; 1`] = `
@@ -519,27 +519,27 @@ exports[`Lexical - Lexical > Lexical - Lexical (fail) > let test = 2, let = 1; 1
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let x = a; const x = b; 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'x'
+"SyntaxError [1:17-1:18]: Duplicate binding 'x'
 > 1 | let x = a; const x = b;
-    |                    ^ Duplicate binding 'x'"
+    |                  ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let x = a; const x = b; 2`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'x'
+"SyntaxError [1:17-1:18]: Duplicate binding 'x'
 > 1 | let x = a; const x = b;
-    |                    ^ Duplicate binding 'x'"
+    |                  ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let x = a; const x = b; 3`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'x'
+"SyntaxError [1:17-1:18]: Duplicate binding 'x'
 > 1 | let x = a; const x = b;
-    |                    ^ Duplicate binding 'x'"
+    |                  ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let x = a; const x = b; 4`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'x'
+"SyntaxError [1:17-1:18]: Duplicate binding 'x'
 > 1 | let x = a; const x = b;
-    |                    ^ Duplicate binding 'x'"
+    |                  ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let x = a; function x(){}; 1`] = `
@@ -549,179 +549,179 @@ exports[`Lexical - Lexical > Lexical - Lexical (fail) > let x = a; function x(){
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let x = a; let x = b; 1`] = `
-"SyntaxError [1:17-1:18]: Duplicate binding 'x'
+"SyntaxError [1:15-1:16]: Duplicate binding 'x'
 > 1 | let x = a; let x = b;
-    |                  ^ Duplicate binding 'x'"
+    |                ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let x = a; let x = b; 2`] = `
-"SyntaxError [1:17-1:18]: Duplicate binding 'x'
+"SyntaxError [1:15-1:16]: Duplicate binding 'x'
 > 1 | let x = a; let x = b;
-    |                  ^ Duplicate binding 'x'"
+    |                ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let x, {a: {b: x}} = obj 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'x'
+"SyntaxError [1:15-1:16]: Duplicate binding 'x'
 > 1 | let x, {a: {b: x}} = obj
-    |                 ^ Duplicate binding 'x'"
+    |                ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let x, {a: {x}} = obj 1`] = `
-"SyntaxError [1:13-1:14]: Duplicate binding 'x'
+"SyntaxError [1:12-1:13]: Duplicate binding 'x'
 > 1 | let x, {a: {x}} = obj
-    |              ^ Duplicate binding 'x'"
+    |             ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let x, {a: x} = obj 1`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'x'
+"SyntaxError [1:11-1:12]: Duplicate binding 'x'
 > 1 | let x, {a: x} = obj
-    |             ^ Duplicate binding 'x'"
+    |            ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let x, {a: x} = obj 2`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'x'
+"SyntaxError [1:11-1:12]: Duplicate binding 'x'
 > 1 | let x, {a: x} = obj
-    |             ^ Duplicate binding 'x'"
+    |            ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let x, {x} = obj 1`] = `
-"SyntaxError [1:9-1:10]: Duplicate binding 'x'
+"SyntaxError [1:8-1:9]: Duplicate binding 'x'
 > 1 | let x, {x} = obj
-    |          ^ Duplicate binding 'x'"
+    |         ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let x, {x} = obj 2`] = `
-"SyntaxError [1:9-1:10]: Duplicate binding 'x'
+"SyntaxError [1:8-1:9]: Duplicate binding 'x'
 > 1 | let x, {x} = obj
-    |          ^ Duplicate binding 'x'"
+    |         ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let x; { var x }
 let x; { var x } 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'x'
+"SyntaxError [1:13-1:14]: Duplicate binding 'x'
 > 1 | let x; { var x }
-    |                ^ Duplicate binding 'x'
+    |              ^ Duplicate binding 'x'
   2 | let x; { var x }"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let x; { var x } 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'x'
+"SyntaxError [1:13-1:14]: Duplicate binding 'x'
 > 1 | let x; { var x }
-    |                ^ Duplicate binding 'x'"
+    |              ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let x; { var x } 2`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'x'
+"SyntaxError [1:13-1:14]: Duplicate binding 'x'
 > 1 | let x; { var x }
-    |                ^ Duplicate binding 'x'"
+    |              ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let x; { var x } 3`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'x'
+"SyntaxError [1:13-1:14]: Duplicate binding 'x'
 > 1 | let x; { var x }
-    |                ^ Duplicate binding 'x'"
+    |              ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let x; { var x; } 1`] = `
-"SyntaxError [1:14-1:15]: Duplicate binding 'x'
+"SyntaxError [1:13-1:14]: Duplicate binding 'x'
 > 1 | let x; { var x; }
-    |               ^ Duplicate binding 'x'"
+    |              ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let x; {var x} 1`] = `
-"SyntaxError [1:13-1:14]: Duplicate binding 'x'
+"SyntaxError [1:12-1:13]: Duplicate binding 'x'
 > 1 | let x; {var x}
-    |              ^ Duplicate binding 'x'"
+    |             ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let x; {var x} 2`] = `
-"SyntaxError [1:13-1:14]: Duplicate binding 'x'
+"SyntaxError [1:12-1:13]: Duplicate binding 'x'
 > 1 | let x; {var x}
-    |              ^ Duplicate binding 'x'"
+    |             ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let x; for (;;) { var x; } 1`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'x'
+"SyntaxError [1:22-1:23]: Duplicate binding 'x'
 > 1 | let x; for (;;) { var x; }
-    |                        ^ Duplicate binding 'x'"
+    |                       ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let x; var x; 1`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'x'
+"SyntaxError [1:11-1:12]: Duplicate binding 'x'
 > 1 | let x; var x;
-    |             ^ Duplicate binding 'x'"
+    |            ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > let x; var x; 2`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'x'
+"SyntaxError [1:11-1:12]: Duplicate binding 'x'
 > 1 | let x; var x;
-    |             ^ Duplicate binding 'x'"
+    |            ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > var [{ bar: [foo] }] = x; let {foo} = 1; 1`] = `
-"SyntaxError [1:34-1:35]: Duplicate binding 'foo'
+"SyntaxError [1:31-1:34]: Duplicate binding 'foo'
 > 1 | var [{ bar: [foo] }] = x; let {foo} = 1;
-    |                                   ^ Duplicate binding 'foo'"
+    |                                ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > var [foo] = [1]; let foo = 1; 1`] = `
-"SyntaxError [1:25-1:26]: Duplicate binding 'foo'
+"SyntaxError [1:21-1:24]: Duplicate binding 'foo'
 > 1 | var [foo] = [1]; let foo = 1;
-    |                          ^ Duplicate binding 'foo'"
+    |                      ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > var foo = 1; function x() {} let foo = 1; 1`] = `
-"SyntaxError [1:37-1:38]: Duplicate binding 'foo'
+"SyntaxError [1:33-1:36]: Duplicate binding 'foo'
 > 1 | var foo = 1; function x() {} let foo = 1;
-    |                                      ^ Duplicate binding 'foo'"
+    |                                  ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > var foo = 1; function x() {} let foo = 1; 2`] = `
-"SyntaxError [1:37-1:38]: Duplicate binding 'foo'
+"SyntaxError [1:33-1:36]: Duplicate binding 'foo'
 > 1 | var foo = 1; function x() {} let foo = 1;
-    |                                      ^ Duplicate binding 'foo'"
+    |                                  ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > var foo = 1; function x(a) { let a; }  1`] = `
-"SyntaxError [1:34-1:35]: Duplicate binding 'a'
+"SyntaxError [1:33-1:34]: Duplicate binding 'a'
 > 1 | var foo = 1; function x(a) { let a; } 
-    |                                   ^ Duplicate binding 'a'"
+    |                                  ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > var foo = 1; let foo = 1; 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'foo'
+"SyntaxError [1:17-1:20]: Duplicate binding 'foo'
 > 1 | var foo = 1; let foo = 1;
-    |                      ^ Duplicate binding 'foo'"
+    |                  ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > var x = a; const x = b; 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'x'
+"SyntaxError [1:17-1:18]: Duplicate binding 'x'
 > 1 | var x = a; const x = b;
-    |                    ^ Duplicate binding 'x'"
+    |                  ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > var x = a; const x = b; 2`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'x'
+"SyntaxError [1:17-1:18]: Duplicate binding 'x'
 > 1 | var x = a; const x = b;
-    |                    ^ Duplicate binding 'x'"
+    |                  ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > var x = a; const x = b; 3`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'x'
+"SyntaxError [1:17-1:18]: Duplicate binding 'x'
 > 1 | var x = a; const x = b;
-    |                    ^ Duplicate binding 'x'"
+    |                  ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > var x = a; const x = b; 4`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'x'
+"SyntaxError [1:17-1:18]: Duplicate binding 'x'
 > 1 | var x = a; const x = b;
-    |                    ^ Duplicate binding 'x'"
+    |                  ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > var x = a; const x = b; 5`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'x'
+"SyntaxError [1:17-1:18]: Duplicate binding 'x'
 > 1 | var x = a; const x = b;
-    |                    ^ Duplicate binding 'x'"
+    |                  ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > var x = a; function x(){}; 1`] = `
@@ -731,51 +731,51 @@ exports[`Lexical - Lexical > Lexical - Lexical (fail) > var x = a; function x(){
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > var x = a; let x = b; 1`] = `
-"SyntaxError [1:17-1:18]: Duplicate binding 'x'
+"SyntaxError [1:15-1:16]: Duplicate binding 'x'
 > 1 | var x = a; let x = b;
-    |                  ^ Duplicate binding 'x'"
+    |                ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > var x = a; let x = b; 2`] = `
-"SyntaxError [1:17-1:18]: Duplicate binding 'x'
+"SyntaxError [1:15-1:16]: Duplicate binding 'x'
 > 1 | var x = a; let x = b;
-    |                  ^ Duplicate binding 'x'"
+    |                ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > var x = a; let x = b; 3`] = `
-"SyntaxError [1:17-1:18]: Duplicate binding 'x'
+"SyntaxError [1:15-1:16]: Duplicate binding 'x'
 > 1 | var x = a; let x = b;
-    |                  ^ Duplicate binding 'x'"
+    |                ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > var x; let x;
 var x; let x; 1`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'x'
+"SyntaxError [1:11-1:12]: Duplicate binding 'x'
 > 1 | var x; let x;
-    |             ^ Duplicate binding 'x'
+    |            ^ Duplicate binding 'x'
   2 | var x; let x;"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > var x; let x; 1`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'x'
+"SyntaxError [1:11-1:12]: Duplicate binding 'x'
 > 1 | var x; let x;
-    |             ^ Duplicate binding 'x'"
+    |            ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > var x; let x; 2`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'x'
+"SyntaxError [1:11-1:12]: Duplicate binding 'x'
 > 1 | var x; let x;
-    |             ^ Duplicate binding 'x'"
+    |            ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > var x; let x; 3`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'x'
+"SyntaxError [1:11-1:12]: Duplicate binding 'x'
 > 1 | var x; let x;
-    |             ^ Duplicate binding 'x'"
+    |            ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Lexical > Lexical - Lexical (fail) > var x; let x; 4`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'x'
+"SyntaxError [1:11-1:12]: Duplicate binding 'x'
 > 1 | var x; let x;
-    |             ^ Duplicate binding 'x'"
+    |            ^ Duplicate binding 'x'"
 `;

--- a/test/parser/lexical/__snapshots__/object.ts.snap
+++ b/test/parser/lexical/__snapshots__/object.ts.snap
@@ -289,9 +289,9 @@ exports[`Lexical - Object > Lexical - Object (fail) > !{f([b, a, a]) {}} 1`] = `
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f([b, a, b, a]) {}} 1`] = `
-"SyntaxError [1:14-1:15]: Duplicate binding 'a'
+"SyntaxError [1:11-1:12]: Duplicate binding 'b'
 > 1 | !{f([b, a, b, a]) {}}
-    |               ^ Duplicate binding 'a'"
+    |            ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f([b, a], ...b) {}} 1`] = `
@@ -415,27 +415,27 @@ exports[`Lexical - Object > Lexical - Object (fail) > !{f(b, a, a) {}} 1`] = `
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f(b, a, b, ...a) {}} 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'a'
+"SyntaxError [1:10-1:11]: Duplicate binding 'b'
 > 1 | !{f(b, a, b, ...a) {}}
-    |                 ^ Duplicate binding 'a'"
+    |           ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f(b, a, b, a = x) {}} 1`] = `
-"SyntaxError [1:13-1:14]: Duplicate binding 'a'
+"SyntaxError [1:10-1:11]: Duplicate binding 'b'
 > 1 | !{f(b, a, b, a = x) {}}
-    |              ^ Duplicate binding 'a'"
+    |           ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f(b, a, b, a) {}} 1`] = `
-"SyntaxError [1:13-1:14]: Duplicate binding 'a'
+"SyntaxError [1:10-1:11]: Duplicate binding 'b'
 > 1 | !{f(b, a, b, a) {}}
-    |              ^ Duplicate binding 'a'"
+    |           ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f(b, a, b, a, [fine]) {}} 1`] = `
-"SyntaxError [1:13-1:14]: Duplicate binding 'a'
+"SyntaxError [1:10-1:11]: Duplicate binding 'b'
 > 1 | !{f(b, a, b, a, [fine]) {}}
-    |              ^ Duplicate binding 'a'"
+    |           ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f(x) { const x = y }} 1`] = `

--- a/test/parser/lexical/__snapshots__/object.ts.snap
+++ b/test/parser/lexical/__snapshots__/object.ts.snap
@@ -1,195 +1,195 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{ *foo(x) { const x = 3; } } 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'x'
+"SyntaxError [1:19-1:20]: Duplicate binding 'x'
 > 1 | !{ *foo(x) { const x = 3; } }
-    |                      ^ Duplicate binding 'x'"
+    |                    ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{ *foo(x) { const x = 3; } } 2`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'x'
+"SyntaxError [1:19-1:20]: Duplicate binding 'x'
 > 1 | !{ *foo(x) { const x = 3; } }
-    |                      ^ Duplicate binding 'x'"
+    |                    ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{ *foo(x) { let x = 3; } } 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'x'
+"SyntaxError [1:17-1:18]: Duplicate binding 'x'
 > 1 | !{ *foo(x) { let x = 3; } }
-    |                    ^ Duplicate binding 'x'"
+    |                  ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{ *foo(x) { let x = 3; } } 2`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'x'
+"SyntaxError [1:17-1:18]: Duplicate binding 'x'
 > 1 | !{ *foo(x) { let x = 3; } }
-    |                    ^ Duplicate binding 'x'"
+    |                  ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{ *g(){ let a; var a; } }; 1`] = `
-"SyntaxError [1:21-1:22]: Duplicate binding 'a'
+"SyntaxError [1:20-1:21]: Duplicate binding 'a'
 > 1 | !{ *g(){ let a; var a; } };
-    |                      ^ Duplicate binding 'a'"
+    |                     ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{ *g([a, a]){} }; 1`] = `
-"SyntaxError [1:11-1:12]: Duplicate binding 'a'
+"SyntaxError [1:10-1:11]: Duplicate binding 'a'
 > 1 | !{ *g([a, a]){} };
-    |            ^ Duplicate binding 'a'"
+    |           ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{ *g([a, a]){} }; 2`] = `
-"SyntaxError [1:11-1:12]: Duplicate binding 'a'
+"SyntaxError [1:10-1:11]: Duplicate binding 'a'
 > 1 | !{ *g([a, a]){} };
-    |            ^ Duplicate binding 'a'"
+    |           ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{ *g({a, a}){} }; 1`] = `
-"SyntaxError [1:11-1:12]: Duplicate binding 'a'
+"SyntaxError [1:10-1:11]: Duplicate binding 'a'
 > 1 | !{ *g({a, a}){} };
-    |            ^ Duplicate binding 'a'"
+    |           ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{ *g({a, a}){} }; 2`] = `
-"SyntaxError [1:11-1:12]: Duplicate binding 'a'
+"SyntaxError [1:10-1:11]: Duplicate binding 'a'
 > 1 | !{ *g({a, a}){} };
-    |            ^ Duplicate binding 'a'"
+    |           ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{ *g(a, a){} }; 1`] = `
-"SyntaxError [1:10-1:11]: Duplicate binding 'a'
-> 1 | !{ *g(a, a){} };
-    |           ^ Duplicate binding 'a'"
-`;
-
-exports[`Lexical - Object > Lexical - Object (fail) > !{ *g(a, a){} }; 2`] = `
-"SyntaxError [1:10-1:11]: Duplicate binding 'a'
-> 1 | !{ *g(a, a){} };
-    |           ^ Duplicate binding 'a'"
-`;
-
-exports[`Lexical - Object > Lexical - Object (fail) > !{ f(){ let a; var a; } }; 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'a'
-> 1 | !{ f(){ let a; var a; } };
-    |                     ^ Duplicate binding 'a'"
-`;
-
-exports[`Lexical - Object > Lexical - Object (fail) > !{ f([a, a]){} }; 1`] = `
-"SyntaxError [1:10-1:11]: Duplicate binding 'a'
-> 1 | !{ f([a, a]){} };
-    |           ^ Duplicate binding 'a'"
-`;
-
-exports[`Lexical - Object > Lexical - Object (fail) > !{ f([a]){ let a; } }; 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'a'
-> 1 | !{ f([a]){ let a; } };
-    |                 ^ Duplicate binding 'a'"
-`;
-
-exports[`Lexical - Object > Lexical - Object (fail) > !{ f([a]){ let a; } }; 2`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'a'
-> 1 | !{ f([a]){ let a; } };
-    |                 ^ Duplicate binding 'a'"
-`;
-
-exports[`Lexical - Object > Lexical - Object (fail) > !{ f({a, a}){} }; 1`] = `
-"SyntaxError [1:10-1:11]: Duplicate binding 'a'
-> 1 | !{ f({a, a}){} };
-    |           ^ Duplicate binding 'a'"
-`;
-
-exports[`Lexical - Object > Lexical - Object (fail) > !{ f({a, a}){} }; 2`] = `
-"SyntaxError [1:10-1:11]: Duplicate binding 'a'
-> 1 | !{ f({a, a}){} };
-    |           ^ Duplicate binding 'a'"
-`;
-
-exports[`Lexical - Object > Lexical - Object (fail) > !{ f({a}){ let a; } }; 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'a'
-> 1 | !{ f({a}){ let a; } };
-    |                 ^ Duplicate binding 'a'"
-`;
-
-exports[`Lexical - Object > Lexical - Object (fail) > !{ f({a}){ let a; } }; 2`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'a'
-> 1 | !{ f({a}){ let a; } };
-    |                 ^ Duplicate binding 'a'"
-`;
-
-exports[`Lexical - Object > Lexical - Object (fail) > !{ f(a) { let a; } }; 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'a'
-> 1 | !{ f(a) { let a; } };
-    |                ^ Duplicate binding 'a'"
-`;
-
-exports[`Lexical - Object > Lexical - Object (fail) > !{ f(a) { let a; } }; 2`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'a'
-> 1 | !{ f(a) { let a; } };
-    |                ^ Duplicate binding 'a'"
-`;
-
-exports[`Lexical - Object > Lexical - Object (fail) > !{ f(a, a){} }; 1`] = `
 "SyntaxError [1:9-1:10]: Duplicate binding 'a'
-> 1 | !{ f(a, a){} };
+> 1 | !{ *g(a, a){} };
     |          ^ Duplicate binding 'a'"
 `;
 
+exports[`Lexical - Object > Lexical - Object (fail) > !{ *g(a, a){} }; 2`] = `
+"SyntaxError [1:9-1:10]: Duplicate binding 'a'
+> 1 | !{ *g(a, a){} };
+    |          ^ Duplicate binding 'a'"
+`;
+
+exports[`Lexical - Object > Lexical - Object (fail) > !{ f(){ let a; var a; } }; 1`] = `
+"SyntaxError [1:19-1:20]: Duplicate binding 'a'
+> 1 | !{ f(){ let a; var a; } };
+    |                    ^ Duplicate binding 'a'"
+`;
+
+exports[`Lexical - Object > Lexical - Object (fail) > !{ f([a, a]){} }; 1`] = `
+"SyntaxError [1:9-1:10]: Duplicate binding 'a'
+> 1 | !{ f([a, a]){} };
+    |          ^ Duplicate binding 'a'"
+`;
+
+exports[`Lexical - Object > Lexical - Object (fail) > !{ f([a]){ let a; } }; 1`] = `
+"SyntaxError [1:15-1:16]: Duplicate binding 'a'
+> 1 | !{ f([a]){ let a; } };
+    |                ^ Duplicate binding 'a'"
+`;
+
+exports[`Lexical - Object > Lexical - Object (fail) > !{ f([a]){ let a; } }; 2`] = `
+"SyntaxError [1:15-1:16]: Duplicate binding 'a'
+> 1 | !{ f([a]){ let a; } };
+    |                ^ Duplicate binding 'a'"
+`;
+
+exports[`Lexical - Object > Lexical - Object (fail) > !{ f({a, a}){} }; 1`] = `
+"SyntaxError [1:9-1:10]: Duplicate binding 'a'
+> 1 | !{ f({a, a}){} };
+    |          ^ Duplicate binding 'a'"
+`;
+
+exports[`Lexical - Object > Lexical - Object (fail) > !{ f({a, a}){} }; 2`] = `
+"SyntaxError [1:9-1:10]: Duplicate binding 'a'
+> 1 | !{ f({a, a}){} };
+    |          ^ Duplicate binding 'a'"
+`;
+
+exports[`Lexical - Object > Lexical - Object (fail) > !{ f({a}){ let a; } }; 1`] = `
+"SyntaxError [1:15-1:16]: Duplicate binding 'a'
+> 1 | !{ f({a}){ let a; } };
+    |                ^ Duplicate binding 'a'"
+`;
+
+exports[`Lexical - Object > Lexical - Object (fail) > !{ f({a}){ let a; } }; 2`] = `
+"SyntaxError [1:15-1:16]: Duplicate binding 'a'
+> 1 | !{ f({a}){ let a; } };
+    |                ^ Duplicate binding 'a'"
+`;
+
+exports[`Lexical - Object > Lexical - Object (fail) > !{ f(a) { let a; } }; 1`] = `
+"SyntaxError [1:14-1:15]: Duplicate binding 'a'
+> 1 | !{ f(a) { let a; } };
+    |               ^ Duplicate binding 'a'"
+`;
+
+exports[`Lexical - Object > Lexical - Object (fail) > !{ f(a) { let a; } }; 2`] = `
+"SyntaxError [1:14-1:15]: Duplicate binding 'a'
+> 1 | !{ f(a) { let a; } };
+    |               ^ Duplicate binding 'a'"
+`;
+
+exports[`Lexical - Object > Lexical - Object (fail) > !{ f(a, a){} }; 1`] = `
+"SyntaxError [1:8-1:9]: Duplicate binding 'a'
+> 1 | !{ f(a, a){} };
+    |         ^ Duplicate binding 'a'"
+`;
+
 exports[`Lexical - Object > Lexical - Object (fail) > !{ get f(){ let a; var a; } }; 1`] = `
-"SyntaxError [1:24-1:25]: Duplicate binding 'a'
+"SyntaxError [1:23-1:24]: Duplicate binding 'a'
 > 1 | !{ get f(){ let a; var a; } };
-    |                         ^ Duplicate binding 'a'"
+    |                        ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{ set f([a, a]){} }; 1`] = `
-"SyntaxError [1:14-1:15]: Duplicate binding 'a'
+"SyntaxError [1:13-1:14]: Duplicate binding 'a'
 > 1 | !{ set f([a, a]){} };
-    |               ^ Duplicate binding 'a'"
+    |              ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{ set f([a, a]){} }; 2`] = `
-"SyntaxError [1:14-1:15]: Duplicate binding 'a'
+"SyntaxError [1:13-1:14]: Duplicate binding 'a'
 > 1 | !{ set f([a, a]){} };
-    |               ^ Duplicate binding 'a'"
+    |              ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{ set f([a]){ let a; } }; 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'a'
+"SyntaxError [1:19-1:20]: Duplicate binding 'a'
 > 1 | !{ set f([a]){ let a; } };
-    |                     ^ Duplicate binding 'a'"
+    |                    ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{ set f({a, a}){} }; 1`] = `
-"SyntaxError [1:14-1:15]: Duplicate binding 'a'
+"SyntaxError [1:13-1:14]: Duplicate binding 'a'
 > 1 | !{ set f({a, a}){} };
-    |               ^ Duplicate binding 'a'"
+    |              ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{ set f({a, a}){} }; 2`] = `
-"SyntaxError [1:14-1:15]: Duplicate binding 'a'
+"SyntaxError [1:13-1:14]: Duplicate binding 'a'
 > 1 | !{ set f({a, a}){} };
-    |               ^ Duplicate binding 'a'"
+    |              ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{ set f({a}){ let a; } }; 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'a'
+"SyntaxError [1:19-1:20]: Duplicate binding 'a'
 > 1 | !{ set f({a}){ let a; } };
-    |                     ^ Duplicate binding 'a'"
+    |                    ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{ set f(a) { let a; } }; 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'a'
+"SyntaxError [1:18-1:19]: Duplicate binding 'a'
 > 1 | !{ set f(a) { let a; } };
-    |                    ^ Duplicate binding 'a'"
+    |                   ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{ set f(a) { let a; } }; 2`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'a'
+"SyntaxError [1:18-1:19]: Duplicate binding 'a'
 > 1 | !{ set f(a) { let a; } };
-    |                    ^ Duplicate binding 'a'"
+    |                   ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{ set f(b){ let a; var a; } }; 1`] = `
-"SyntaxError [1:25-1:26]: Duplicate binding 'a'
+"SyntaxError [1:24-1:25]: Duplicate binding 'a'
 > 1 | !{ set f(b){ let a; var a; } };
-    |                          ^ Duplicate binding 'a'"
+    |                         ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f(){ const x = y; function x(){} }} 1`] = `
@@ -205,27 +205,27 @@ exports[`Lexical - Object > Lexical - Object (fail) > !{f(){ const x = y; functi
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f(){ const x = y; var x; }} 1`] = `
-"SyntaxError [1:25-1:26]: Duplicate binding 'x'
+"SyntaxError [1:24-1:25]: Duplicate binding 'x'
 > 1 | !{f(){ const x = y; var x; }}
-    |                          ^ Duplicate binding 'x'"
+    |                         ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f(){ function x(){} const x = y; }} 1`] = `
-"SyntaxError [1:30-1:31]: Duplicate binding 'x'
+"SyntaxError [1:28-1:29]: Duplicate binding 'x'
 > 1 | !{f(){ function x(){} const x = y; }}
-    |                               ^ Duplicate binding 'x'"
+    |                             ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f(){ function x(){} const x = y; }} 2`] = `
-"SyntaxError [1:30-1:31]: Duplicate binding 'x'
+"SyntaxError [1:28-1:29]: Duplicate binding 'x'
 > 1 | !{f(){ function x(){} const x = y; }}
-    |                               ^ Duplicate binding 'x'"
+    |                             ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f(){ function x(){} let x; }} 1`] = `
-"SyntaxError [1:27-1:28]: Duplicate binding 'x'
+"SyntaxError [1:26-1:27]: Duplicate binding 'x'
 > 1 | !{f(){ function x(){} let x; }}
-    |                            ^ Duplicate binding 'x'"
+    |                           ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f(){ let x; function x(){} }} 1`] = `
@@ -235,217 +235,217 @@ exports[`Lexical - Object > Lexical - Object (fail) > !{f(){ let x; function x()
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f(){ let x; var x; }} 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'x'
+"SyntaxError [1:18-1:19]: Duplicate binding 'x'
 > 1 | !{f(){ let x; var x; }}
-    |                    ^ Duplicate binding 'x'"
+    |                   ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f(){ let x; var x; }} 2`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'x'
+"SyntaxError [1:18-1:19]: Duplicate binding 'x'
 > 1 | !{f(){ let x; var x; }}
-    |                    ^ Duplicate binding 'x'"
+    |                   ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f(){ var x; const x = y; }} 1`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'x'
+"SyntaxError [1:20-1:21]: Duplicate binding 'x'
 > 1 | !{f(){ var x; const x = y; }}
-    |                       ^ Duplicate binding 'x'"
+    |                     ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f(){ var x; let x; }} 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'x'
+"SyntaxError [1:18-1:19]: Duplicate binding 'x'
 > 1 | !{f(){ var x; let x; }}
-    |                    ^ Duplicate binding 'x'"
+    |                   ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f(){ var x; let x; }} 2`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'x'
+"SyntaxError [1:18-1:19]: Duplicate binding 'x'
 > 1 | !{f(){ var x; let x; }}
-    |                    ^ Duplicate binding 'x'"
+    |                   ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f([a, a, b]) {}} 1`] = `
-"SyntaxError [1:9-1:10]: Duplicate binding 'a'
+"SyntaxError [1:8-1:9]: Duplicate binding 'a'
 > 1 | !{f([a, a, b]) {}}
-    |          ^ Duplicate binding 'a'"
+    |         ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f([a, a]) {}} 1`] = `
-"SyntaxError [1:9-1:10]: Duplicate binding 'a'
+"SyntaxError [1:8-1:9]: Duplicate binding 'a'
 > 1 | !{f([a, a]) {}}
-    |          ^ Duplicate binding 'a'"
+    |         ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f([a, b, a]) {}} 1`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'a'
+"SyntaxError [1:11-1:12]: Duplicate binding 'a'
 > 1 | !{f([a, b, a]) {}}
-    |             ^ Duplicate binding 'a'"
+    |            ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f([b, a, a]) {}} 1`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'a'
+"SyntaxError [1:11-1:12]: Duplicate binding 'a'
 > 1 | !{f([b, a, a]) {}}
-    |             ^ Duplicate binding 'a'"
+    |            ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f([b, a, b, a]) {}} 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'a'
+"SyntaxError [1:14-1:15]: Duplicate binding 'a'
 > 1 | !{f([b, a, b, a]) {}}
-    |                ^ Duplicate binding 'a'"
+    |               ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f([b, a], ...b) {}} 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'b'
+"SyntaxError [1:15-1:16]: Duplicate binding 'b'
 > 1 | !{f([b, a], ...b) {}}
-    |                 ^ Duplicate binding 'b'"
+    |                ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f([b, a], ...b) {}} 2`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'b'
+"SyntaxError [1:15-1:16]: Duplicate binding 'b'
 > 1 | !{f([b, a], ...b) {}}
-    |                 ^ Duplicate binding 'b'"
+    |                ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f([b, a], {b}) {}} 1`] = `
-"SyntaxError [1:14-1:15]: Duplicate binding 'b'
+"SyntaxError [1:13-1:14]: Duplicate binding 'b'
 > 1 | !{f([b, a], {b}) {}}
-    |               ^ Duplicate binding 'b'"
+    |              ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f([b, a], {b}) {}} 2`] = `
-"SyntaxError [1:14-1:15]: Duplicate binding 'b'
+"SyntaxError [1:13-1:14]: Duplicate binding 'b'
 > 1 | !{f([b, a], {b}) {}}
-    |               ^ Duplicate binding 'b'"
+    |              ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f([b, a], b) {}} 1`] = `
-"SyntaxError [1:13-1:14]: Duplicate binding 'b'
+"SyntaxError [1:12-1:13]: Duplicate binding 'b'
 > 1 | !{f([b, a], b) {}}
-    |              ^ Duplicate binding 'b'"
+    |             ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f([b, a], b=x) {}} 1`] = `
-"SyntaxError [1:13-1:14]: Duplicate binding 'b'
+"SyntaxError [1:12-1:13]: Duplicate binding 'b'
 > 1 | !{f([b, a], b=x) {}}
-    |              ^ Duplicate binding 'b'"
+    |             ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f([b, a], b=x) {}} 2`] = `
-"SyntaxError [1:13-1:14]: Duplicate binding 'b'
+"SyntaxError [1:12-1:13]: Duplicate binding 'b'
 > 1 | !{f([b, a], b=x) {}}
-    |              ^ Duplicate binding 'b'"
+    |             ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f({"a": b}, ...b) {}} 1`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'b'
+"SyntaxError [1:17-1:18]: Duplicate binding 'b'
 > 1 | !{f({"a": b}, ...b) {}}
-    |                   ^ Duplicate binding 'b'"
+    |                  ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f({[a]: b}, ...b) {}} 1`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'b'
+"SyntaxError [1:17-1:18]: Duplicate binding 'b'
 > 1 | !{f({[a]: b}, ...b) {}}
-    |                   ^ Duplicate binding 'b'"
+    |                  ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f({[a]: b}, ...b) {}} 2`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'b'
+"SyntaxError [1:17-1:18]: Duplicate binding 'b'
 > 1 | !{f({[a]: b}, ...b) {}}
-    |                   ^ Duplicate binding 'b'"
+    |                  ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f({[a]: b}, ...b) {}} 3`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'b'
+"SyntaxError [1:17-1:18]: Duplicate binding 'b'
 > 1 | !{f({[a]: b}, ...b) {}}
-    |                   ^ Duplicate binding 'b'"
+    |                  ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f({[x]: b}, b = ((b) => {}) ) {}} 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'b'
+"SyntaxError [1:14-1:15]: Duplicate binding 'b'
 > 1 | !{f({[x]: b}, b = ((b) => {}) ) {}}
-    |                 ^ Duplicate binding 'b'"
+    |               ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f({2: b}, ...b) {}} 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'b'
+"SyntaxError [1:15-1:16]: Duplicate binding 'b'
 > 1 | !{f({2: b}, ...b) {}}
-    |                 ^ Duplicate binding 'b'"
+    |                ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f({a = b}, ...a) {}} 1`] = `
-"SyntaxError [1:17-1:18]: Duplicate binding 'a'
+"SyntaxError [1:16-1:17]: Duplicate binding 'a'
 > 1 | !{f({a = b}, ...a) {}}
-    |                  ^ Duplicate binding 'a'"
+    |                 ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f({a: b}, ...b) {}} 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'b'
+"SyntaxError [1:15-1:16]: Duplicate binding 'b'
 > 1 | !{f({a: b}, ...b) {}}
-    |                 ^ Duplicate binding 'b'"
+    |                ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f({b}, ...b) {}} 1`] = `
-"SyntaxError [1:13-1:14]: Duplicate binding 'b'
+"SyntaxError [1:12-1:13]: Duplicate binding 'b'
 > 1 | !{f({b}, ...b) {}}
-    |              ^ Duplicate binding 'b'"
+    |             ^ Duplicate binding 'b'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f(a, a) {}} 1`] = `
-"SyntaxError [1:8-1:9]: Duplicate binding 'a'
+"SyntaxError [1:7-1:8]: Duplicate binding 'a'
 > 1 | !{f(a, a) {}}
-    |         ^ Duplicate binding 'a'"
+    |        ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f(a, a, b) {}} 1`] = `
-"SyntaxError [1:8-1:9]: Duplicate binding 'a'
+"SyntaxError [1:7-1:8]: Duplicate binding 'a'
 > 1 | !{f(a, a, b) {}}
-    |         ^ Duplicate binding 'a'"
+    |        ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f(a, b, a) {}} 1`] = `
-"SyntaxError [1:11-1:12]: Duplicate binding 'a'
+"SyntaxError [1:10-1:11]: Duplicate binding 'a'
 > 1 | !{f(a, b, a) {}}
-    |            ^ Duplicate binding 'a'"
+    |           ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f(b, a, a) {}} 1`] = `
-"SyntaxError [1:11-1:12]: Duplicate binding 'a'
+"SyntaxError [1:10-1:11]: Duplicate binding 'a'
 > 1 | !{f(b, a, a) {}}
-    |            ^ Duplicate binding 'a'"
+    |           ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f(b, a, b, ...a) {}} 1`] = `
-"SyntaxError [1:17-1:18]: Duplicate binding 'a'
+"SyntaxError [1:16-1:17]: Duplicate binding 'a'
 > 1 | !{f(b, a, b, ...a) {}}
-    |                  ^ Duplicate binding 'a'"
+    |                 ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f(b, a, b, a = x) {}} 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'a'
+"SyntaxError [1:13-1:14]: Duplicate binding 'a'
 > 1 | !{f(b, a, b, a = x) {}}
-    |                ^ Duplicate binding 'a'"
+    |              ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f(b, a, b, a) {}} 1`] = `
-"SyntaxError [1:14-1:15]: Duplicate binding 'a'
+"SyntaxError [1:13-1:14]: Duplicate binding 'a'
 > 1 | !{f(b, a, b, a) {}}
-    |               ^ Duplicate binding 'a'"
+    |              ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f(b, a, b, a, [fine]) {}} 1`] = `
-"SyntaxError [1:14-1:15]: Duplicate binding 'a'
+"SyntaxError [1:13-1:14]: Duplicate binding 'a'
 > 1 | !{f(b, a, b, a, [fine]) {}}
-    |               ^ Duplicate binding 'a'"
+    |              ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f(x) { const x = y }} 1`] = `
-"SyntaxError [1:17-1:18]: Duplicate binding 'x'
+"SyntaxError [1:15-1:16]: Duplicate binding 'x'
 > 1 | !{f(x) { const x = y }}
-    |                  ^ Duplicate binding 'x'"
+    |                ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Object > Lexical - Object (fail) > !{f(x) { let x }} 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'x'
+"SyntaxError [1:13-1:14]: Duplicate binding 'x'
 > 1 | !{f(x) { let x }}
-    |                ^ Duplicate binding 'x'"
+    |              ^ Duplicate binding 'x'"
 `;

--- a/test/parser/lexical/__snapshots__/switch.ts.snap
+++ b/test/parser/lexical/__snapshots__/switch.ts.snap
@@ -19,9 +19,9 @@ exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: async
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: async function f() {} default: const f = 0 } 1`] = `
-"SyntaxError [1:60-1:61]: Duplicate binding 'f'
+"SyntaxError [1:58-1:59]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: async function f() {} default: const f = 0 }
-    |                                                             ^ Duplicate binding 'f'"
+    |                                                           ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: async function f() {} default: function f() {} } 1`] = `
@@ -37,15 +37,15 @@ exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: async
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: async function f() {} default: let f } 1`] = `
-"SyntaxError [1:58-1:59]: Duplicate binding 'f'
+"SyntaxError [1:56-1:57]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: async function f() {} default: let f }
-    |                                                           ^ Duplicate binding 'f'"
+    |                                                         ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: async function f() {} default: var f } 1`] = `
-"SyntaxError [1:58-1:59]: Duplicate binding 'f'
+"SyntaxError [1:56-1:57]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: async function f() {} default: var f }
-    |                                                           ^ Duplicate binding 'f'"
+    |                                                         ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: async function* f() {} default: async function f() {} } 1`] = `
@@ -73,15 +73,15 @@ exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: async
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: async function* f() {} default: const f = 0 } 1`] = `
-"SyntaxError [1:61-1:62]: Duplicate binding 'f'
+"SyntaxError [1:59-1:60]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: async function* f() {} default: const f = 0 }
-    |                                                              ^ Duplicate binding 'f'"
+    |                                                            ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: async function* f() {} default: const f = 0; } 1`] = `
-"SyntaxError [1:61-1:62]: Duplicate binding 'f'
+"SyntaxError [1:59-1:60]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: async function* f() {} default: const f = 0; }
-    |                                                              ^ Duplicate binding 'f'"
+    |                                                            ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: async function* f() {} default: function f() {} } 1`] = `
@@ -97,45 +97,45 @@ exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: async
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: async function* f() {} default: let f } 1`] = `
-"SyntaxError [1:59-1:60]: Duplicate binding 'f'
+"SyntaxError [1:57-1:58]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: async function* f() {} default: let f }
-    |                                                            ^ Duplicate binding 'f'"
+    |                                                          ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: async function* f() {} default: let f } 2`] = `
-"SyntaxError [1:59-1:60]: Duplicate binding 'f'
+"SyntaxError [1:57-1:58]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: async function* f() {} default: let f }
-    |                                                            ^ Duplicate binding 'f'"
+    |                                                          ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: async function* f() {} default: let f; } 1`] = `
-"SyntaxError [1:58-1:59]: Duplicate binding 'f'
+"SyntaxError [1:57-1:58]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: async function* f() {} default: let f; }
-    |                                                           ^ Duplicate binding 'f'"
+    |                                                          ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: async function* f() {} default: let f; } 2`] = `
-"SyntaxError [1:58-1:59]: Duplicate binding 'f'
+"SyntaxError [1:57-1:58]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: async function* f() {} default: let f; }
-    |                                                           ^ Duplicate binding 'f'"
+    |                                                          ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: async function* f() {} default: let f; } 3`] = `
-"SyntaxError [1:58-1:59]: Duplicate binding 'f'
+"SyntaxError [1:57-1:58]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: async function* f() {} default: let f; }
-    |                                                           ^ Duplicate binding 'f'"
+    |                                                          ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: async function* f() {} default: var f } 1`] = `
-"SyntaxError [1:59-1:60]: Duplicate binding 'f'
+"SyntaxError [1:57-1:58]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: async function* f() {} default: var f }
-    |                                                            ^ Duplicate binding 'f'"
+    |                                                          ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: async function* f() {} default: var f; } 1`] = `
-"SyntaxError [1:58-1:59]: Duplicate binding 'f'
+"SyntaxError [1:57-1:58]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: async function* f() {} default: var f; }
-    |                                                           ^ Duplicate binding 'f'"
+    |                                                          ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: class f {} default: async function f() {} } 1`] = `
@@ -163,21 +163,21 @@ exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: class
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: class f {} default: const f = 0 } 1`] = `
-"SyntaxError [1:49-1:50]: Duplicate binding 'f'
+"SyntaxError [1:47-1:48]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: class f {} default: const f = 0 }
-    |                                                  ^ Duplicate binding 'f'"
+    |                                                ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: class f {} default: const f = 0; } 1`] = `
-"SyntaxError [1:49-1:50]: Duplicate binding 'f'
+"SyntaxError [1:47-1:48]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: class f {} default: const f = 0; }
-    |                                                  ^ Duplicate binding 'f'"
+    |                                                ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: class f {} default: const f = 0; } 2`] = `
-"SyntaxError [1:49-1:50]: Duplicate binding 'f'
+"SyntaxError [1:47-1:48]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: class f {} default: const f = 0; }
-    |                                                  ^ Duplicate binding 'f'"
+    |                                                ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: class f {} default: function f() {} } 1`] = `
@@ -199,39 +199,39 @@ exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: class
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: class f {} default: let f; } 1`] = `
-"SyntaxError [1:46-1:47]: Duplicate binding 'f'
+"SyntaxError [1:45-1:46]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: class f {} default: let f; }
-    |                                               ^ Duplicate binding 'f'"
+    |                                              ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: class f {} default: let f; } 2`] = `
-"SyntaxError [1:46-1:47]: Duplicate binding 'f'
+"SyntaxError [1:45-1:46]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: class f {} default: let f; }
-    |                                               ^ Duplicate binding 'f'"
+    |                                              ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: class f {} default: let f; } 3`] = `
-"SyntaxError [1:46-1:47]: Duplicate binding 'f'
+"SyntaxError [1:45-1:46]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: class f {} default: let f; }
-    |                                               ^ Duplicate binding 'f'"
+    |                                              ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: class f {} default: var f; } 1`] = `
-"SyntaxError [1:46-1:47]: Duplicate binding 'f'
+"SyntaxError [1:45-1:46]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: class f {} default: var f; }
-    |                                               ^ Duplicate binding 'f'"
+    |                                              ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: class f {} default: var f; } 2`] = `
-"SyntaxError [1:46-1:47]: Duplicate binding 'f'
+"SyntaxError [1:45-1:46]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: class f {} default: var f; }
-    |                                               ^ Duplicate binding 'f'"
+    |                                              ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: class f {} default: var f; } 3`] = `
-"SyntaxError [1:46-1:47]: Duplicate binding 'f'
+"SyntaxError [1:45-1:46]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: class f {} default: var f; }
-    |                                               ^ Duplicate binding 'f'"
+    |                                              ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: const f = 0; default: async function f() {} } 1`] = `
@@ -277,15 +277,15 @@ exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: const
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: const f = 0; default: const f = 0; } 1`] = `
-"SyntaxError [1:51-1:52]: Duplicate binding 'f'
+"SyntaxError [1:49-1:50]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: const f = 0; default: const f = 0; }
-    |                                                    ^ Duplicate binding 'f'"
+    |                                                  ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: const f = 0; default: const f = 0; } 2`] = `
-"SyntaxError [1:51-1:52]: Duplicate binding 'f'
+"SyntaxError [1:49-1:50]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: const f = 0; default: const f = 0; }
-    |                                                    ^ Duplicate binding 'f'"
+    |                                                  ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: const f = 0; default: function f() {} } 1`] = `
@@ -307,33 +307,33 @@ exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: const
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: const f = 0; default: let f } 1`] = `
-"SyntaxError [1:49-1:50]: Duplicate binding 'f'
+"SyntaxError [1:47-1:48]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: const f = 0; default: let f }
-    |                                                  ^ Duplicate binding 'f'"
+    |                                                ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: const f = 0; default: let f; } 1`] = `
-"SyntaxError [1:48-1:49]: Duplicate binding 'f'
+"SyntaxError [1:47-1:48]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: const f = 0; default: let f; }
-    |                                                 ^ Duplicate binding 'f'"
+    |                                                ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: const f = 0; default: var f } 1`] = `
-"SyntaxError [1:49-1:50]: Duplicate binding 'f'
+"SyntaxError [1:47-1:48]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: const f = 0; default: var f }
-    |                                                  ^ Duplicate binding 'f'"
+    |                                                ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: const f = 0; default: var f; } 1`] = `
-"SyntaxError [1:48-1:49]: Duplicate binding 'f'
+"SyntaxError [1:47-1:48]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: const f = 0; default: var f; }
-    |                                                 ^ Duplicate binding 'f'"
+    |                                                ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: const f = 0; x; default: let {f} = x; } var {f} = f 1`] = `
-"SyntaxError [1:52-1:53]: Duplicate binding 'f'
+"SyntaxError [1:51-1:52]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: const f = 0; x; default: let {f} = x; } var {f} = f
-    |                                                     ^ Duplicate binding 'f'"
+    |                                                    ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: function f() {} default: async function f() {} } 1`] = `
@@ -355,27 +355,27 @@ exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: funct
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: function f() {} default: const f = 0 } 1`] = `
-"SyntaxError [1:54-1:55]: Duplicate binding 'f'
+"SyntaxError [1:52-1:53]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: function f() {} default: const f = 0 }
-    |                                                       ^ Duplicate binding 'f'"
+    |                                                     ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: function f() {} default: const f = 0; } 1`] = `
-"SyntaxError [1:54-1:55]: Duplicate binding 'f'
+"SyntaxError [1:52-1:53]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: function f() {} default: const f = 0; }
-    |                                                       ^ Duplicate binding 'f'"
+    |                                                     ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: function f() {} default: const f = 0; } 2`] = `
-"SyntaxError [1:54-1:55]: Duplicate binding 'f'
+"SyntaxError [1:52-1:53]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: function f() {} default: const f = 0; }
-    |                                                       ^ Duplicate binding 'f'"
+    |                                                     ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: function f() {} default: const f = 0; } 3`] = `
-"SyntaxError [1:54-1:55]: Duplicate binding 'f'
+"SyntaxError [1:52-1:53]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: function f() {} default: const f = 0; }
-    |                                                       ^ Duplicate binding 'f'"
+    |                                                     ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: function f() {} default: function f() {} } 1`] = `
@@ -391,39 +391,39 @@ exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: funct
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: function f() {} default: let f; } 1`] = `
-"SyntaxError [1:51-1:52]: Duplicate binding 'f'
+"SyntaxError [1:50-1:51]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: function f() {} default: let f; }
-    |                                                    ^ Duplicate binding 'f'"
+    |                                                   ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: function f() {} default: let f; } 2`] = `
-"SyntaxError [1:51-1:52]: Duplicate binding 'f'
+"SyntaxError [1:50-1:51]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: function f() {} default: let f; }
-    |                                                    ^ Duplicate binding 'f'"
+    |                                                   ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: function f() {} default: let f; } 3`] = `
-"SyntaxError [1:51-1:52]: Duplicate binding 'f'
+"SyntaxError [1:50-1:51]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: function f() {} default: let f; }
-    |                                                    ^ Duplicate binding 'f'"
+    |                                                   ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: function f() {} default: var f } 1`] = `
-"SyntaxError [1:52-1:53]: Duplicate binding 'f'
+"SyntaxError [1:50-1:51]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: function f() {} default: var f }
-    |                                                     ^ Duplicate binding 'f'"
+    |                                                   ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: function f() {} default: var f } 2`] = `
-"SyntaxError [1:52-1:53]: Duplicate binding 'f'
+"SyntaxError [1:50-1:51]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: function f() {} default: var f }
-    |                                                     ^ Duplicate binding 'f'"
+    |                                                   ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: function f() {} default: var f; } 1`] = `
-"SyntaxError [1:51-1:52]: Duplicate binding 'f'
+"SyntaxError [1:50-1:51]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: function f() {} default: var f; }
-    |                                                    ^ Duplicate binding 'f'"
+    |                                                   ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: function* f() {} default: async function f() {} } 1`] = `
@@ -463,27 +463,27 @@ exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: funct
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: function* f() {} default: var f; } 1`] = `
-"SyntaxError [1:52-1:53]: Duplicate binding 'f'
+"SyntaxError [1:51-1:52]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: function* f() {} default: var f; }
-    |                                                     ^ Duplicate binding 'f'"
+    |                                                    ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: let f = 0; default: var f; } 1`] = `
-"SyntaxError [1:46-1:47]: Duplicate binding 'f'
+"SyntaxError [1:45-1:46]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: let f = 0; default: var f; }
-    |                                               ^ Duplicate binding 'f'"
+    |                                              ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: let f = 0; var {f} = x; default: let x; } 1`] = `
-"SyntaxError [1:38-1:39]: Duplicate binding 'f'
+"SyntaxError [1:37-1:38]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: let f = 0; var {f} = x; default: let x; }
-    |                                       ^ Duplicate binding 'f'"
+    |                                      ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: let f = 0; var {f} = x; default: let x; } 2`] = `
-"SyntaxError [1:38-1:39]: Duplicate binding 'f'
+"SyntaxError [1:37-1:38]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: let f = 0; var {f} = x; default: let x; }
-    |                                       ^ Duplicate binding 'f'"
+    |                                      ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: let f; default: async function* f() {} } 1`] = `
@@ -505,9 +505,9 @@ exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: let f
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: let f; default: const f = 0 } 1`] = `
-"SyntaxError [1:45-1:46]: Duplicate binding 'f'
+"SyntaxError [1:43-1:44]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: let f; default: const f = 0 }
-    |                                              ^ Duplicate binding 'f'"
+    |                                            ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: let f; default: function* f() {} } 1`] = `
@@ -517,21 +517,21 @@ exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: let f
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: let f; default: let f } 1`] = `
-"SyntaxError [1:43-1:44]: Duplicate binding 'f'
+"SyntaxError [1:41-1:42]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: let f; default: let f }
-    |                                            ^ Duplicate binding 'f'"
+    |                                          ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: let f; default: let f; } 1`] = `
-"SyntaxError [1:42-1:43]: Duplicate binding 'f'
+"SyntaxError [1:41-1:42]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: let f; default: let f; }
-    |                                           ^ Duplicate binding 'f'"
+    |                                          ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: let f; default: var f; } 1`] = `
-"SyntaxError [1:42-1:43]: Duplicate binding 'f'
+"SyntaxError [1:41-1:42]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: let f; default: var f; }
-    |                                           ^ Duplicate binding 'f'"
+    |                                          ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: var f = 0; ({f}) default: let x; } 1`] = `
@@ -541,9 +541,9 @@ exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: var f
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: var f = 0; const {f} = x; default: let x; } 1`] = `
-"SyntaxError [1:40-1:41]: Duplicate binding 'f'
+"SyntaxError [1:39-1:40]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: var f = 0; const {f} = x; default: let x; }
-    |                                         ^ Duplicate binding 'f'"
+    |                                        ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: var f = 0; default: async function* f() {} } 1`] = `
@@ -553,9 +553,9 @@ exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: var f
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: var f = 0; default: let f; } 1`] = `
-"SyntaxError [1:46-1:47]: Duplicate binding 'f'
+"SyntaxError [1:45-1:46]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: var f = 0; default: let f; }
-    |                                               ^ Duplicate binding 'f'"
+    |                                              ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: var f; default: async function f() {} } 1`] = `
@@ -583,15 +583,15 @@ exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: var f
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: var f; default: const f = 0 } 1`] = `
-"SyntaxError [1:45-1:46]: Duplicate binding 'f'
+"SyntaxError [1:43-1:44]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: var f; default: const f = 0 }
-    |                                              ^ Duplicate binding 'f'"
+    |                                            ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: var f; default: const f = 0; } 1`] = `
-"SyntaxError [1:45-1:46]: Duplicate binding 'f'
+"SyntaxError [1:43-1:44]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: var f; default: const f = 0; }
-    |                                              ^ Duplicate binding 'f'"
+    |                                            ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: var f; default: function f() {} } 1`] = `
@@ -607,21 +607,21 @@ exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: var f
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: var f; default: let f } 1`] = `
-"SyntaxError [1:43-1:44]: Duplicate binding 'f'
+"SyntaxError [1:41-1:42]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: var f; default: let f }
-    |                                            ^ Duplicate binding 'f'"
+    |                                          ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: var f; default: let f } 2`] = `
-"SyntaxError [1:43-1:44]: Duplicate binding 'f'
+"SyntaxError [1:41-1:42]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: var f; default: let f }
-    |                                            ^ Duplicate binding 'f'"
+    |                                          ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { case 1: var f; default: let f; } 1`] = `
-"SyntaxError [1:42-1:43]: Duplicate binding 'f'
+"SyntaxError [1:41-1:42]: Duplicate binding 'f'
 > 1 | switch (0) { case 1: var f; default: let f; }
-    |                                           ^ Duplicate binding 'f'"
+    |                                          ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { default: let f; if (false) ; else function f() {  } } 1`] = `
@@ -637,63 +637,63 @@ exports[`Lexical - Switch > Lexical - Switch (fail) > switch (0) { default: let 
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (x) { case 0: var foo = 1 } let foo = 1; 1`] = `
-"SyntaxError [1:43-1:44]: Duplicate binding 'foo'
+"SyntaxError [1:39-1:42]: Duplicate binding 'foo'
 > 1 | switch (x) { case 0: var foo = 1 } let foo = 1;
-    |                                            ^ Duplicate binding 'foo'"
+    |                                        ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (x) { case a: const foo = x; break; case b: const foo = x; break; } 1`] = `
-"SyntaxError [1:61-1:62]: Duplicate binding 'foo'
+"SyntaxError [1:57-1:60]: Duplicate binding 'foo'
 > 1 | switch (x) { case a: const foo = x; break; case b: const foo = x; break; }
-    |                                                              ^ Duplicate binding 'foo'"
+    |                                                          ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (x) { case a: const foo = x; break; case b: let foo; break; } 1`] = `
-"SyntaxError [1:58-1:59]: Duplicate binding 'foo'
+"SyntaxError [1:55-1:58]: Duplicate binding 'foo'
 > 1 | switch (x) { case a: const foo = x; break; case b: let foo; break; }
-    |                                                           ^ Duplicate binding 'foo'"
+    |                                                        ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (x) { case a: const foo = x; break; case b: var foo = x; break; } 1`] = `
-"SyntaxError [1:59-1:60]: Duplicate binding 'foo'
+"SyntaxError [1:55-1:58]: Duplicate binding 'foo'
 > 1 | switch (x) { case a: const foo = x; break; case b: var foo = x; break; }
-    |                                                            ^ Duplicate binding 'foo'"
+    |                                                        ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (x) { case a: let foo; break; case b: const foo = x; break; } 1`] = `
-"SyntaxError [1:55-1:56]: Duplicate binding 'foo'
+"SyntaxError [1:51-1:54]: Duplicate binding 'foo'
 > 1 | switch (x) { case a: let foo; break; case b: const foo = x; break; }
-    |                                                        ^ Duplicate binding 'foo'"
+    |                                                    ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (x) { case a: let foo; break; case b: let foo; break; } 1`] = `
-"SyntaxError [1:52-1:53]: Duplicate binding 'foo'
+"SyntaxError [1:49-1:52]: Duplicate binding 'foo'
 > 1 | switch (x) { case a: let foo; break; case b: let foo; break; }
-    |                                                     ^ Duplicate binding 'foo'"
+    |                                                  ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (x) { case a: let foo; break; case b: var foo; break; } 1`] = `
-"SyntaxError [1:52-1:53]: Duplicate binding 'foo'
+"SyntaxError [1:49-1:52]: Duplicate binding 'foo'
 > 1 | switch (x) { case a: let foo; break; case b: var foo; break; }
-    |                                                     ^ Duplicate binding 'foo'"
+    |                                                  ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (x) { case a: let foo; break; default: let foo; break; } 1`] = `
-"SyntaxError [1:53-1:54]: Duplicate binding 'foo'
+"SyntaxError [1:50-1:53]: Duplicate binding 'foo'
 > 1 | switch (x) { case a: let foo; break; default: let foo; break; }
-    |                                                      ^ Duplicate binding 'foo'"
+    |                                                   ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (x) { case a: var foo = x; break; case b: const foo = x; break; } 1`] = `
-"SyntaxError [1:59-1:60]: Duplicate binding 'foo'
+"SyntaxError [1:55-1:58]: Duplicate binding 'foo'
 > 1 | switch (x) { case a: var foo = x; break; case b: const foo = x; break; }
-    |                                                            ^ Duplicate binding 'foo'"
+    |                                                        ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (x) { case a: var foo; break; case b: let foo; break; } 1`] = `
-"SyntaxError [1:52-1:53]: Duplicate binding 'foo'
+"SyntaxError [1:49-1:52]: Duplicate binding 'foo'
 > 1 | switch (x) { case a: var foo; break; case b: let foo; break; }
-    |                                                     ^ Duplicate binding 'foo'"
+    |                                                  ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (x) { case c: async function f(){} async function f(){} } 1`] = `
@@ -769,9 +769,9 @@ exports[`Lexical - Switch > Lexical - Switch (fail) > switch (x) {case a: async 
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (x) {case a: async function f(){}; break; case b: let f; break; } 1`] = `
-"SyntaxError [1:62-1:63]: Duplicate binding 'f'
+"SyntaxError [1:61-1:62]: Duplicate binding 'f'
 > 1 | switch (x) {case a: async function f(){}; break; case b: let f; break; }
-    |                                                               ^ Duplicate binding 'f'"
+    |                                                              ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (x) {case a: const f = x; break; case b: function f(){}; break; } 1`] = `
@@ -799,163 +799,163 @@ exports[`Lexical - Switch > Lexical - Switch (fail) > switch (x) {case a: functi
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch (x) {case a: function f(){}; break; case b: let f; break; } 1`] = `
-"SyntaxError [1:56-1:57]: Duplicate binding 'f'
+"SyntaxError [1:55-1:56]: Duplicate binding 'f'
 > 1 | switch (x) {case a: function f(){}; break; case b: let f; break; }
-    |                                                         ^ Duplicate binding 'f'"
+    |                                                        ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch(0) { case 0: const a = 0; default: var a; } 1`] = `
-"SyntaxError [1:47-1:48]: Duplicate binding 'a'
+"SyntaxError [1:46-1:47]: Duplicate binding 'a'
 > 1 | switch(0) { case 0: const a = 0; default: var a; }
-    |                                                ^ Duplicate binding 'a'"
+    |                                               ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch(0) { case 0: const a = 0; default: var a; } 2`] = `
-"SyntaxError [1:47-1:48]: Duplicate binding 'a'
+"SyntaxError [1:46-1:47]: Duplicate binding 'a'
 > 1 | switch(0) { case 0: const a = 0; default: var a; }
-    |                                                ^ Duplicate binding 'a'"
+    |                                               ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch(0) { case 0: let a; case 1: let a; } 1`] = `
-"SyntaxError [1:40-1:41]: Duplicate binding 'a'
+"SyntaxError [1:39-1:40]: Duplicate binding 'a'
 > 1 | switch(0) { case 0: let a; case 1: let a; }
-    |                                         ^ Duplicate binding 'a'"
+    |                                        ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch(0) { case 0: let a; case 1: var a; } 1`] = `
-"SyntaxError [1:40-1:41]: Duplicate binding 'a'
+"SyntaxError [1:39-1:40]: Duplicate binding 'a'
 > 1 | switch(0) { case 0: let a; case 1: var a; }
-    |                                         ^ Duplicate binding 'a'"
+    |                                        ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch(0) { case 0: let a; case 1: var a; } 2`] = `
-"SyntaxError [1:40-1:41]: Duplicate binding 'a'
+"SyntaxError [1:39-1:40]: Duplicate binding 'a'
 > 1 | switch(0) { case 0: let a; case 1: var a; }
-    |                                         ^ Duplicate binding 'a'"
+    |                                        ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch(0) { case 0: let a; case 1: var a; } 3`] = `
-"SyntaxError [1:40-1:41]: Duplicate binding 'a'
+"SyntaxError [1:39-1:40]: Duplicate binding 'a'
 > 1 | switch(0) { case 0: let a; case 1: var a; }
-    |                                         ^ Duplicate binding 'a'"
+    |                                        ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch(0) { case 0: let a; default: let a; } 1`] = `
-"SyntaxError [1:41-1:42]: Duplicate binding 'a'
+"SyntaxError [1:40-1:41]: Duplicate binding 'a'
 > 1 | switch(0) { case 0: let a; default: let a; }
-    |                                          ^ Duplicate binding 'a'"
+    |                                         ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch(0) { case 0: let a; default: let a; } 2`] = `
-"SyntaxError [1:41-1:42]: Duplicate binding 'a'
+"SyntaxError [1:40-1:41]: Duplicate binding 'a'
 > 1 | switch(0) { case 0: let a; default: let a; }
-    |                                          ^ Duplicate binding 'a'"
+    |                                         ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch(0) { case 0: let a; default: let a; } 3`] = `
-"SyntaxError [1:41-1:42]: Duplicate binding 'a'
+"SyntaxError [1:40-1:41]: Duplicate binding 'a'
 > 1 | switch(0) { case 0: let a; default: let a; }
-    |                                          ^ Duplicate binding 'a'"
+    |                                         ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch(0) { case 0: var a; case 1: const a = 0; } 1`] = `
-"SyntaxError [1:43-1:44]: Duplicate binding 'a'
+"SyntaxError [1:41-1:42]: Duplicate binding 'a'
 > 1 | switch(0) { case 0: var a; case 1: const a = 0; }
-    |                                            ^ Duplicate binding 'a'"
+    |                                          ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch(0) { case 0: var a; case 1: const a = 0; } 2`] = `
-"SyntaxError [1:43-1:44]: Duplicate binding 'a'
+"SyntaxError [1:41-1:42]: Duplicate binding 'a'
 > 1 | switch(0) { case 0: var a; case 1: const a = 0; }
-    |                                            ^ Duplicate binding 'a'"
+    |                                          ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch(0) { case 0: var a; case 1: let a; } 1`] = `
-"SyntaxError [1:40-1:41]: Duplicate binding 'a'
+"SyntaxError [1:39-1:40]: Duplicate binding 'a'
 > 1 | switch(0) { case 0: var a; case 1: let a; }
-    |                                         ^ Duplicate binding 'a'"
+    |                                        ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch(0) { case 0: var a; case 1: let a; } 2`] = `
-"SyntaxError [1:40-1:41]: Duplicate binding 'a'
+"SyntaxError [1:39-1:40]: Duplicate binding 'a'
 > 1 | switch(0) { case 0: var a; case 1: let a; }
-    |                                         ^ Duplicate binding 'a'"
+    |                                        ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch(0) { case 0: var a; default: const a = 0; } 1`] = `
-"SyntaxError [1:44-1:45]: Duplicate binding 'a'
+"SyntaxError [1:42-1:43]: Duplicate binding 'a'
 > 1 | switch(0) { case 0: var a; default: const a = 0; }
-    |                                             ^ Duplicate binding 'a'"
+    |                                           ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch(0) { case 0: var a; default: const a = 0; } 2`] = `
-"SyntaxError [1:44-1:45]: Duplicate binding 'a'
+"SyntaxError [1:42-1:43]: Duplicate binding 'a'
 > 1 | switch(0) { case 0: var a; default: const a = 0; }
-    |                                             ^ Duplicate binding 'a'"
+    |                                           ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch(0) { case 0: var a; default: let a; } 1`] = `
-"SyntaxError [1:41-1:42]: Duplicate binding 'a'
+"SyntaxError [1:40-1:41]: Duplicate binding 'a'
 > 1 | switch(0) { case 0: var a; default: let a; }
-    |                                          ^ Duplicate binding 'a'"
+    |                                         ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch(0) { case 0: var a; default: let a; } 2`] = `
-"SyntaxError [1:41-1:42]: Duplicate binding 'a'
+"SyntaxError [1:40-1:41]: Duplicate binding 'a'
 > 1 | switch(0) { case 0: var a; default: let a; }
-    |                                          ^ Duplicate binding 'a'"
+    |                                         ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch(0) { default: const a = 0; case 0: var a; } 1`] = `
-"SyntaxError [1:47-1:48]: Duplicate binding 'a'
+"SyntaxError [1:46-1:47]: Duplicate binding 'a'
 > 1 | switch(0) { default: const a = 0; case 0: var a; }
-    |                                                ^ Duplicate binding 'a'"
+    |                                               ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch(0) { default: const a = 0; case 0: var a; } 2`] = `
-"SyntaxError [1:47-1:48]: Duplicate binding 'a'
+"SyntaxError [1:46-1:47]: Duplicate binding 'a'
 > 1 | switch(0) { default: const a = 0; case 0: var a; }
-    |                                                ^ Duplicate binding 'a'"
+    |                                               ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch(0) { default: let a; case 0: let a; } 1`] = `
-"SyntaxError [1:41-1:42]: Duplicate binding 'a'
+"SyntaxError [1:40-1:41]: Duplicate binding 'a'
 > 1 | switch(0) { default: let a; case 0: let a; }
-    |                                          ^ Duplicate binding 'a'"
+    |                                         ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch(0) { default: let a; case 0: let a; } 2`] = `
-"SyntaxError [1:41-1:42]: Duplicate binding 'a'
+"SyntaxError [1:40-1:41]: Duplicate binding 'a'
 > 1 | switch(0) { default: let a; case 0: let a; }
-    |                                          ^ Duplicate binding 'a'"
+    |                                         ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch(0) { default: let a; case 0: let a; } 3`] = `
-"SyntaxError [1:41-1:42]: Duplicate binding 'a'
+"SyntaxError [1:40-1:41]: Duplicate binding 'a'
 > 1 | switch(0) { default: let a; case 0: let a; }
-    |                                          ^ Duplicate binding 'a'"
+    |                                         ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch(0) { default: let a; case 0: var a; } 1`] = `
-"SyntaxError [1:41-1:42]: Duplicate binding 'a'
+"SyntaxError [1:40-1:41]: Duplicate binding 'a'
 > 1 | switch(0) { default: let a; case 0: var a; }
-    |                                          ^ Duplicate binding 'a'"
+    |                                         ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch(0) { default: let a; case 0: var a; } 2`] = `
-"SyntaxError [1:41-1:42]: Duplicate binding 'a'
+"SyntaxError [1:40-1:41]: Duplicate binding 'a'
 > 1 | switch(0) { default: let a; case 0: var a; }
-    |                                          ^ Duplicate binding 'a'"
+    |                                         ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch(0) { default: var a; case 0: const a = 0; } 1`] = `
-"SyntaxError [1:44-1:45]: Duplicate binding 'a'
+"SyntaxError [1:42-1:43]: Duplicate binding 'a'
 > 1 | switch(0) { default: var a; case 0: const a = 0; }
-    |                                             ^ Duplicate binding 'a'"
+    |                                           ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Switch > Lexical - Switch (fail) > switch(0) { default: var a; case 0: const a = 0; } 2`] = `
-"SyntaxError [1:44-1:45]: Duplicate binding 'a'
+"SyntaxError [1:42-1:43]: Duplicate binding 'a'
 > 1 | switch(0) { default: var a; case 0: const a = 0; }
-    |                                             ^ Duplicate binding 'a'"
+    |                                           ^ Duplicate binding 'a'"
 `;

--- a/test/parser/lexical/__snapshots__/try.ts.snap
+++ b/test/parser/lexical/__snapshots__/try.ts.snap
@@ -1,9 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Lexical - Try > Lexical - Try (fail) > const a = 1, a = 2 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'a'
+"SyntaxError [1:13-1:14]: Duplicate binding 'a'
 > 1 | const a = 1, a = 2
-    |                ^ Duplicate binding 'a'"
+    |              ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > function f() { try {} catch (e) { function e(){} } } 1`] = `
@@ -19,27 +19,27 @@ exports[`Lexical - Try > Lexical - Try (fail) > function f() { try {} catch (e) 
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > let e; try {} catch (e) { let e; } 1`] = `
-"SyntaxError [1:31-1:32]: 'e' shadowed a catch clause binding
+"SyntaxError [1:30-1:31]: 'e' shadowed a catch clause binding
 > 1 | let e; try {} catch (e) { let e; }
-    |                                ^ 'e' shadowed a catch clause binding"
+    |                               ^ 'e' shadowed a catch clause binding"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > let foo; try {} catch (foo) {} let foo; 1`] = `
-"SyntaxError [1:38-1:39]: Duplicate binding 'foo'
+"SyntaxError [1:35-1:38]: Duplicate binding 'foo'
 > 1 | let foo; try {} catch (foo) {} let foo;
-    |                                       ^ Duplicate binding 'foo'"
+    |                                    ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try { } catch ([x, x]) {} 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'x'
+"SyntaxError [1:19-1:20]: Duplicate binding 'x'
 > 1 | try { } catch ([x, x]) {}
-    |                     ^ Duplicate binding 'x'"
+    |                    ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try { } catch ([x, x]) {} 2`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'x'
+"SyntaxError [1:19-1:20]: Duplicate binding 'x'
 > 1 | try { } catch ([x, x]) {}
-    |                     ^ Duplicate binding 'x'"
+    |                    ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try { } catch (e) { async function f(){} async function f(){} } 1`] = `
@@ -79,39 +79,39 @@ exports[`Lexical - Try > Lexical - Try (fail) > try { } catch (e) { function(){}
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try { } catch (x) { for (var x of []) {} } 1`] = `
-"SyntaxError [1:31-1:33]: Duplicate binding 'x'
+"SyntaxError [1:29-1:30]: Duplicate binding 'x'
 > 1 | try { } catch (x) { for (var x of []) {} }
-    |                                ^^ Duplicate binding 'x'"
+    |                              ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try { } catch (x) { for (var x of []) {} } 2`] = `
-"SyntaxError [1:31-1:33]: Duplicate binding 'x'
+"SyntaxError [1:29-1:30]: Duplicate binding 'x'
 > 1 | try { } catch (x) { for (var x of []) {} }
-    |                                ^^ Duplicate binding 'x'"
+    |                              ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try { } catch (x) { for (var x of []) {} } 3`] = `
-"SyntaxError [1:31-1:33]: Duplicate binding 'x'
+"SyntaxError [1:29-1:30]: Duplicate binding 'x'
 > 1 | try { } catch (x) { for (var x of []) {} }
-    |                                ^^ Duplicate binding 'x'"
+    |                              ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try { } catch (x) { let x; } 1`] = `
-"SyntaxError [1:25-1:26]: 'x' shadowed a catch clause binding
+"SyntaxError [1:24-1:25]: 'x' shadowed a catch clause binding
 > 1 | try { } catch (x) { let x; }
-    |                          ^ 'x' shadowed a catch clause binding"
+    |                         ^ 'x' shadowed a catch clause binding"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try { } catch (x) { let x; } 2`] = `
-"SyntaxError [1:25-1:26]: 'x' shadowed a catch clause binding
+"SyntaxError [1:24-1:25]: 'x' shadowed a catch clause binding
 > 1 | try { } catch (x) { let x; }
-    |                          ^ 'x' shadowed a catch clause binding"
+    |                         ^ 'x' shadowed a catch clause binding"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try { } catch (x) { let x; } 3`] = `
-"SyntaxError [1:25-1:26]: 'x' shadowed a catch clause binding
+"SyntaxError [1:24-1:25]: 'x' shadowed a catch clause binding
 > 1 | try { } catch (x) { let x; }
-    |                          ^ 'x' shadowed a catch clause binding"
+    |                         ^ 'x' shadowed a catch clause binding"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try { } finally { async function *f(){} async function *f(){} } 1`] = `
@@ -145,27 +145,27 @@ exports[`Lexical - Try > Lexical - Try (fail) > try { } finally { function(){} f
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try { async function *f(){} var f } catch (e) {} 1`] = `
-"SyntaxError [1:34-1:35]: Duplicate binding 'f'
+"SyntaxError [1:32-1:33]: Duplicate binding 'f'
 > 1 | try { async function *f(){} var f } catch (e) {}
-    |                                   ^ Duplicate binding 'f'"
+    |                                 ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try { async function f(){} var f } catch (e) {} 1`] = `
-"SyntaxError [1:33-1:34]: Duplicate binding 'f'
+"SyntaxError [1:31-1:32]: Duplicate binding 'f'
 > 1 | try { async function f(){} var f } catch (e) {}
-    |                                  ^ Duplicate binding 'f'"
+    |                                ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try { function *f(){} var f } catch (e) {} 1`] = `
-"SyntaxError [1:28-1:29]: Duplicate binding 'f'
+"SyntaxError [1:26-1:27]: Duplicate binding 'f'
 > 1 | try { function *f(){} var f } catch (e) {}
-    |                             ^ Duplicate binding 'f'"
+    |                           ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try { function f(){} var f } catch (e) {} 1`] = `
-"SyntaxError [1:27-1:28]: Duplicate binding 'f'
+"SyntaxError [1:25-1:26]: Duplicate binding 'f'
 > 1 | try { function f(){} var f } catch (e) {}
-    |                            ^ Duplicate binding 'f'"
+    |                          ^ Duplicate binding 'f'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try { function(){} var f } catch (e) {} 1`] = `
@@ -175,9 +175,9 @@ exports[`Lexical - Try > Lexical - Try (fail) > try { function(){} var f } catch
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try { throw "try"; } catch (x) { for (var x = y; x !== y; x++) {}} 1`] = `
-"SyntaxError [1:44-1:45]: Duplicate binding 'x'
+"SyntaxError [1:42-1:43]: Duplicate binding 'x'
 > 1 | try { throw "try"; } catch (x) { for (var x = y; x !== y; x++) {}}
-    |                                             ^ Duplicate binding 'x'"
+    |                                           ^ Duplicate binding 'x'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try { throw {}; } catch ({ f }) { if (true) function f() {  } } 1`] = `
@@ -187,9 +187,9 @@ exports[`Lexical - Try > Lexical - Try (fail) > try { throw {}; } catch ({ f }) 
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch ([a,a]) { } 1`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'a'
+"SyntaxError [1:17-1:18]: Duplicate binding 'a'
 > 1 | try {} catch ([a,a]) { }
-    |                   ^ Duplicate binding 'a'"
+    |                  ^ Duplicate binding 'a'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch ([a] = b) { } 1`] = `
@@ -199,81 +199,81 @@ exports[`Lexical - Try > Lexical - Try (fail) > try {} catch ([a] = b) { } 1`] =
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch ([foo, foo]) {} 1`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'foo'
+"SyntaxError [1:20-1:23]: Duplicate binding 'foo'
 > 1 | try {} catch ([foo, foo]) {}
-    |                        ^ Duplicate binding 'foo'"
+    |                     ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch ([foo, foo]) {} 2`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'foo'
+"SyntaxError [1:20-1:23]: Duplicate binding 'foo'
 > 1 | try {} catch ([foo, foo]) {}
-    |                        ^ Duplicate binding 'foo'"
+    |                     ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch ([foo]) { var foo; } 1`] = `
-"SyntaxError [1:30-1:31]: Duplicate binding 'foo'
+"SyntaxError [1:27-1:30]: Duplicate binding 'foo'
 > 1 | try {} catch ([foo]) { var foo; }
-    |                               ^ Duplicate binding 'foo'"
+    |                            ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch ([foo]) { var foo; } 2`] = `
-"SyntaxError [1:30-1:31]: Duplicate binding 'foo'
+"SyntaxError [1:27-1:30]: Duplicate binding 'foo'
 > 1 | try {} catch ([foo]) { var foo; }
-    |                               ^ Duplicate binding 'foo'"
+    |                            ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch ({ a: foo, b: { c: [foo] } }) {} 1`] = `
-"SyntaxError [1:36-1:37]: Duplicate binding 'foo'
+"SyntaxError [1:33-1:36]: Duplicate binding 'foo'
 > 1 | try {} catch ({ a: foo, b: { c: [foo] } }) {}
-    |                                     ^ Duplicate binding 'foo'"
+    |                                  ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch ({ a: foo, b: { c: [foo] } }) {} 2`] = `
-"SyntaxError [1:36-1:37]: Duplicate binding 'foo'
+"SyntaxError [1:33-1:36]: Duplicate binding 'foo'
 > 1 | try {} catch ({ a: foo, b: { c: [foo] } }) {}
-    |                                     ^ Duplicate binding 'foo'"
+    |                                  ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch ({ foo }) { var foo; } 1`] = `
-"SyntaxError [1:32-1:33]: Duplicate binding 'foo'
+"SyntaxError [1:29-1:32]: Duplicate binding 'foo'
 > 1 | try {} catch ({ foo }) { var foo; }
-    |                                 ^ Duplicate binding 'foo'"
+    |                              ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch ({ foo }) { var foo; } 2`] = `
-"SyntaxError [1:32-1:33]: Duplicate binding 'foo'
+"SyntaxError [1:29-1:32]: Duplicate binding 'foo'
 > 1 | try {} catch ({ foo }) { var foo; }
-    |                                 ^ Duplicate binding 'foo'"
+    |                              ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch ({a: e, b: e}) {} 1`] = `
-"SyntaxError [1:25-1:26]: Duplicate binding 'e'
+"SyntaxError [1:24-1:25]: Duplicate binding 'e'
 > 1 | try {} catch ({a: e, b: e}) {}
-    |                          ^ Duplicate binding 'e'"
+    |                         ^ Duplicate binding 'e'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch ({a: e, b: e}) {} 2`] = `
-"SyntaxError [1:25-1:26]: Duplicate binding 'e'
+"SyntaxError [1:24-1:25]: Duplicate binding 'e'
 > 1 | try {} catch ({a: e, b: e}) {}
-    |                          ^ Duplicate binding 'e'"
+    |                         ^ Duplicate binding 'e'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch ({e = 0, a: e}) {} 1`] = `
-"SyntaxError [1:26-1:27]: Duplicate binding 'e'
+"SyntaxError [1:25-1:26]: Duplicate binding 'e'
 > 1 | try {} catch ({e = 0, a: e}) {}
-    |                           ^ Duplicate binding 'e'"
+    |                          ^ Duplicate binding 'e'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch ({e, e}) {} 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'e'
+"SyntaxError [1:18-1:19]: Duplicate binding 'e'
 > 1 | try {} catch ({e, e}) {}
-    |                    ^ Duplicate binding 'e'"
+    |                   ^ Duplicate binding 'e'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (a) { const a = 1; }  1`] = `
-"SyntaxError [1:27-1:28]: 'a' shadowed a catch clause binding
+"SyntaxError [1:25-1:26]: 'a' shadowed a catch clause binding
 > 1 | try {} catch (a) { const a = 1; } 
-    |                            ^ 'a' shadowed a catch clause binding"
+    |                          ^ 'a' shadowed a catch clause binding"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (a, a) { } 1`] = `
@@ -295,105 +295,105 @@ exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (arguments) { } 2`]
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (e) { { var e = x; } } 1`] = `
-"SyntaxError [1:27-1:28]: Duplicate binding 'e'
+"SyntaxError [1:25-1:26]: Duplicate binding 'e'
 > 1 | try {} catch (e) { { var e = x; } }
-    |                            ^ Duplicate binding 'e'"
+    |                          ^ Duplicate binding 'e'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (e) { const e = x; } 1`] = `
-"SyntaxError [1:27-1:28]: 'e' shadowed a catch clause binding
+"SyntaxError [1:25-1:26]: 'e' shadowed a catch clause binding
 > 1 | try {} catch (e) { const e = x; }
-    |                            ^ 'e' shadowed a catch clause binding"
+    |                          ^ 'e' shadowed a catch clause binding"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (e) { const e = x; } 2`] = `
-"SyntaxError [1:27-1:28]: 'e' shadowed a catch clause binding
+"SyntaxError [1:25-1:26]: 'e' shadowed a catch clause binding
 > 1 | try {} catch (e) { const e = x; }
-    |                            ^ 'e' shadowed a catch clause binding"
+    |                          ^ 'e' shadowed a catch clause binding"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (e) { for (var e in y) {} } 1`] = `
-"SyntaxError [1:30-1:32]: Duplicate binding 'e'
+"SyntaxError [1:28-1:29]: Duplicate binding 'e'
 > 1 | try {} catch (e) { for (var e in y) {} }
-    |                               ^^ Duplicate binding 'e'"
+    |                             ^ Duplicate binding 'e'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (e) { for (var e in y) {} } 2`] = `
-"SyntaxError [1:30-1:32]: Duplicate binding 'e'
+"SyntaxError [1:28-1:29]: Duplicate binding 'e'
 > 1 | try {} catch (e) { for (var e in y) {} }
-    |                               ^^ Duplicate binding 'e'"
+    |                             ^ Duplicate binding 'e'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (e) { for (var e in y) {} } 3`] = `
-"SyntaxError [1:30-1:32]: Duplicate binding 'e'
+"SyntaxError [1:28-1:29]: Duplicate binding 'e'
 > 1 | try {} catch (e) { for (var e in y) {} }
-    |                               ^^ Duplicate binding 'e'"
+    |                             ^ Duplicate binding 'e'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (e) { for (var e of y) {} } 1`] = `
-"SyntaxError [1:30-1:32]: Duplicate binding 'e'
+"SyntaxError [1:28-1:29]: Duplicate binding 'e'
 > 1 | try {} catch (e) { for (var e of y) {} }
-    |                               ^^ Duplicate binding 'e'"
+    |                             ^ Duplicate binding 'e'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (e) { for (var e;;) {} } 1`] = `
-"SyntaxError [1:29-1:30]: Duplicate binding 'e'
+"SyntaxError [1:28-1:29]: Duplicate binding 'e'
 > 1 | try {} catch (e) { for (var e;;) {} }
-    |                              ^ Duplicate binding 'e'"
+    |                             ^ Duplicate binding 'e'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (e) { for (var e;;) {} } 2`] = `
-"SyntaxError [1:29-1:30]: Duplicate binding 'e'
+"SyntaxError [1:28-1:29]: Duplicate binding 'e'
 > 1 | try {} catch (e) { for (var e;;) {} }
-    |                              ^ Duplicate binding 'e'"
+    |                             ^ Duplicate binding 'e'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (e) { for (var e;;) {} } 3`] = `
-"SyntaxError [1:29-1:30]: Duplicate binding 'e'
+"SyntaxError [1:28-1:29]: Duplicate binding 'e'
 > 1 | try {} catch (e) { for (var e;;) {} }
-    |                              ^ Duplicate binding 'e'"
+    |                             ^ Duplicate binding 'e'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (e) { let e = x; } 1`] = `
-"SyntaxError [1:25-1:26]: 'e' shadowed a catch clause binding
+"SyntaxError [1:23-1:24]: 'e' shadowed a catch clause binding
 > 1 | try {} catch (e) { let e = x; }
-    |                          ^ 'e' shadowed a catch clause binding"
+    |                        ^ 'e' shadowed a catch clause binding"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (e) { let e = x; } 2`] = `
-"SyntaxError [1:25-1:26]: 'e' shadowed a catch clause binding
+"SyntaxError [1:23-1:24]: 'e' shadowed a catch clause binding
 > 1 | try {} catch (e) { let e = x; }
-    |                          ^ 'e' shadowed a catch clause binding"
+    |                        ^ 'e' shadowed a catch clause binding"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (e) { let e = x; } 3`] = `
-"SyntaxError [1:25-1:26]: 'e' shadowed a catch clause binding
+"SyntaxError [1:23-1:24]: 'e' shadowed a catch clause binding
 > 1 | try {} catch (e) { let e = x; }
-    |                          ^ 'e' shadowed a catch clause binding"
+    |                        ^ 'e' shadowed a catch clause binding"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (e) { var e = x; } 1`] = `
-"SyntaxError [1:25-1:26]: Duplicate binding 'e'
+"SyntaxError [1:23-1:24]: Duplicate binding 'e'
 > 1 | try {} catch (e) { var e = x; }
-    |                          ^ Duplicate binding 'e'"
+    |                        ^ Duplicate binding 'e'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (e) { var e = x; } 2`] = `
-"SyntaxError [1:25-1:26]: Duplicate binding 'e'
+"SyntaxError [1:23-1:24]: Duplicate binding 'e'
 > 1 | try {} catch (e) { var e = x; }
-    |                          ^ Duplicate binding 'e'"
+    |                        ^ Duplicate binding 'e'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (e) { var e = x; } 3`] = `
-"SyntaxError [1:25-1:26]: Duplicate binding 'e'
+"SyntaxError [1:23-1:24]: Duplicate binding 'e'
 > 1 | try {} catch (e) { var e = x; }
-    |                          ^ Duplicate binding 'e'"
+    |                        ^ Duplicate binding 'e'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (e) { var e = x; } 4`] = `
-"SyntaxError [1:25-1:26]: Duplicate binding 'e'
+"SyntaxError [1:23-1:24]: Duplicate binding 'e'
 > 1 | try {} catch (e) { var e = x; }
-    |                          ^ Duplicate binding 'e'"
+    |                        ^ Duplicate binding 'e'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (foo) { function foo() {} } 1`] = `
@@ -415,59 +415,59 @@ exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (foo) { function fo
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (foo) { let foo = 1; } 1`] = `
-"SyntaxError [1:29-1:30]: 'foo' shadowed a catch clause binding
+"SyntaxError [1:25-1:28]: 'foo' shadowed a catch clause binding
 > 1 | try {} catch (foo) { let foo = 1; }
-    |                              ^ 'foo' shadowed a catch clause binding"
+    |                          ^^^ 'foo' shadowed a catch clause binding"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (foo) { let foo; } 1`] = `
-"SyntaxError [1:28-1:29]: 'foo' shadowed a catch clause binding
+"SyntaxError [1:25-1:28]: 'foo' shadowed a catch clause binding
 > 1 | try {} catch (foo) { let foo; }
-    |                             ^ 'foo' shadowed a catch clause binding"
+    |                          ^^^ 'foo' shadowed a catch clause binding"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (foo) { let foo; } 2`] = `
-"SyntaxError [1:28-1:29]: 'foo' shadowed a catch clause binding
+"SyntaxError [1:25-1:28]: 'foo' shadowed a catch clause binding
 > 1 | try {} catch (foo) { let foo; }
-    |                             ^ 'foo' shadowed a catch clause binding"
+    |                          ^^^ 'foo' shadowed a catch clause binding"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (foo) { let foo; } 3`] = `
-"SyntaxError [1:28-1:29]: 'foo' shadowed a catch clause binding
+"SyntaxError [1:25-1:28]: 'foo' shadowed a catch clause binding
 > 1 | try {} catch (foo) { let foo; }
-    |                             ^ 'foo' shadowed a catch clause binding"
+    |                          ^^^ 'foo' shadowed a catch clause binding"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (foo) { let foo; } 4`] = `
-"SyntaxError [1:28-1:29]: 'foo' shadowed a catch clause binding
+"SyntaxError [1:25-1:28]: 'foo' shadowed a catch clause binding
 > 1 | try {} catch (foo) { let foo; }
-    |                             ^ 'foo' shadowed a catch clause binding"
+    |                          ^^^ 'foo' shadowed a catch clause binding"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (foo) { try {} catch (_) { var foo; } } 1`] = `
-"SyntaxError [1:47-1:48]: Duplicate binding 'foo'
+"SyntaxError [1:44-1:47]: Duplicate binding 'foo'
 > 1 | try {} catch (foo) { try {} catch (_) { var foo; } }
-    |                                                ^ Duplicate binding 'foo'"
+    |                                             ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (foo) { var foo; } 1`] = `
-"SyntaxError [1:28-1:29]: Duplicate binding 'foo'
+"SyntaxError [1:25-1:28]: Duplicate binding 'foo'
 > 1 | try {} catch (foo) { var foo; }
-    |                             ^ Duplicate binding 'foo'"
+    |                          ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (foo) { var foo; } 2`] = `
-"SyntaxError [1:28-1:29]: Duplicate binding 'foo'
+"SyntaxError [1:25-1:28]: Duplicate binding 'foo'
 > 1 | try {} catch (foo) { var foo; }
-    |                             ^ Duplicate binding 'foo'"
+    |                          ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (foo) {}  let foo;
 try {} catch (foo) {}  let foo; 1`] = `
-"SyntaxError [2:30-2:31]: Duplicate binding 'foo'
+"SyntaxError [2:27-2:30]: Duplicate binding 'foo'
   1 | try {} catch (foo) {}  let foo;
 > 2 | try {} catch (foo) {}  let foo;
-    |                               ^ Duplicate binding 'foo'"
+    |                            ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (foo) {if (1) function foo() {}} 1`] = `
@@ -489,31 +489,31 @@ exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (x) { { let x }  2`
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (x) { let x } 1`] = `
-"SyntaxError [1:25-1:26]: 'x' shadowed a catch clause binding
+"SyntaxError [1:23-1:24]: 'x' shadowed a catch clause binding
 > 1 | try {} catch (x) { let x }
-    |                          ^ 'x' shadowed a catch clause binding"
+    |                        ^ 'x' shadowed a catch clause binding"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch (x) { let x } 2`] = `
-"SyntaxError [1:25-1:26]: 'x' shadowed a catch clause binding
+"SyntaxError [1:23-1:24]: 'x' shadowed a catch clause binding
 > 1 | try {} catch (x) { let x }
-    |                          ^ 'x' shadowed a catch clause binding"
+    |                        ^ 'x' shadowed a catch clause binding"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch(e) { for(var e of 0); } 1`] = `
-"SyntaxError [1:28-1:30]: Duplicate binding 'e'
+"SyntaxError [1:26-1:27]: Duplicate binding 'e'
 > 1 | try {} catch(e) { for(var e of 0); }
-    |                             ^^ Duplicate binding 'e'"
+    |                           ^ Duplicate binding 'e'"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch(e) { let e; } 1`] = `
-"SyntaxError [1:23-1:24]: 'e' shadowed a catch clause binding
+"SyntaxError [1:22-1:23]: 'e' shadowed a catch clause binding
 > 1 | try {} catch(e) { let e; }
-    |                        ^ 'e' shadowed a catch clause binding"
+    |                       ^ 'e' shadowed a catch clause binding"
 `;
 
 exports[`Lexical - Try > Lexical - Try (fail) > try {} catch(e) { var e; } 1`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'e'
+"SyntaxError [1:22-1:23]: Duplicate binding 'e'
 > 1 | try {} catch(e) { var e; }
-    |                        ^ Duplicate binding 'e'"
+    |                       ^ Duplicate binding 'e'"
 `;

--- a/test/parser/module/__snapshots__/export.ts.snap
+++ b/test/parser/module/__snapshots__/export.ts.snap
@@ -55,9 +55,9 @@ exports[`Module - Export > Module - Export (fail) > const a = 0; export class a 
 `;
 
 exports[`Module - Export > Module - Export (fail) > const a = 0; export const a = 1; 1`] = `
-"SyntaxError [1:28-1:29]: Duplicate binding 'a'
+"SyntaxError [1:26-1:27]: Duplicate binding 'a'
 > 1 | const a = 0; export const a = 1;
-    |                             ^ Duplicate binding 'a'"
+    |                           ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > const a = 0; export function a(){}; 1`] = `
@@ -67,9 +67,9 @@ exports[`Module - Export > Module - Export (fail) > const a = 0; export function
 `;
 
 exports[`Module - Export > Module - Export (fail) > const a = 0; export let a; 1`] = `
-"SyntaxError [1:25-1:26]: Duplicate binding 'a'
+"SyntaxError [1:24-1:25]: Duplicate binding 'a'
 > 1 | const a = 0; export let a;
-    |                          ^ Duplicate binding 'a'"
+    |                         ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > const a = 1; export {a as "", a as ""} 1`] = `
@@ -530,10 +530,10 @@ export async function a() {} 1`] = `
 
 exports[`Module - Export > Module - Export (fail) > export async function a() {}
 export const a = 1; 1`] = `
-"SyntaxError [2:15-2:16]: Duplicate binding 'a'
+"SyntaxError [2:13-2:14]: Duplicate binding 'a'
   1 | export async function a() {}
 > 2 | export const a = 1;
-    |                ^ Duplicate binding 'a'"
+    |              ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > export async function a() {}
@@ -557,9 +557,9 @@ exports[`Module - Export > Module - Export (fail) > export async function f(){};
 `;
 
 exports[`Module - Export > Module - Export (fail) > export async function f(){}; const f = foo; 1`] = `
-"SyntaxError [1:37-1:38]: Duplicate binding 'f'
+"SyntaxError [1:35-1:36]: Duplicate binding 'f'
 > 1 | export async function f(){}; const f = foo;
-    |                                      ^ Duplicate binding 'f'"
+    |                                    ^ Duplicate binding 'f'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > export async function f(){}; export {f}; 1`] = `
@@ -655,33 +655,33 @@ exports[`Module - Export > Module - Export (fail) > export class x{}; export def
 `;
 
 exports[`Module - Export > Module - Export (fail) > export const [x, {x}] = y 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'x'
-> 1 | export const [x, {x}] = y
-    |                    ^ Duplicate binding 'x'"
-`;
-
-exports[`Module - Export > Module - Export (fail) > export const [x, x] = c 1`] = `
 "SyntaxError [1:18-1:19]: Duplicate binding 'x'
-> 1 | export const [x, x] = c
+> 1 | export const [x, {x}] = y
     |                   ^ Duplicate binding 'x'"
 `;
 
+exports[`Module - Export > Module - Export (fail) > export const [x, x] = c 1`] = `
+"SyntaxError [1:17-1:18]: Duplicate binding 'x'
+> 1 | export const [x, x] = c
+    |                  ^ Duplicate binding 'x'"
+`;
+
 exports[`Module - Export > Module - Export (fail) > export const {x:x, x:x} = c 1`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'x'
+"SyntaxError [1:21-1:22]: Duplicate binding 'x'
 > 1 | export const {x:x, x:x} = c
-    |                       ^ Duplicate binding 'x'"
+    |                      ^ Duplicate binding 'x'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > export const a = 0; export const a = 0; 1`] = `
-"SyntaxError [1:35-1:36]: Duplicate binding 'a'
+"SyntaxError [1:33-1:34]: Duplicate binding 'a'
 > 1 | export const a = 0; export const a = 0;
-    |                                    ^ Duplicate binding 'a'"
+    |                                  ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > export const a = b; let a = c 1`] = `
-"SyntaxError [1:26-1:27]: Duplicate binding 'a'
+"SyntaxError [1:24-1:25]: Duplicate binding 'a'
 > 1 | export const a = b; let a = c
-    |                           ^ Duplicate binding 'a'"
+    |                         ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > export const const1; 1`] = `
@@ -691,9 +691,9 @@ exports[`Module - Export > Module - Export (fail) > export const const1; 1`] = `
 `;
 
 exports[`Module - Export > Module - Export (fail) > export const x = x, x = y; 1`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'x'
+"SyntaxError [1:20-1:21]: Duplicate binding 'x'
 > 1 | export const x = x, x = y;
-    |                       ^ Duplicate binding 'x'"
+    |                     ^ Duplicate binding 'x'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > export const x = y; export {f}; 1`] = `
@@ -755,9 +755,9 @@ exports[`Module - Export > Module - Export (fail) > export default async x
 `;
 
 exports[`Module - Export > Module - Export (fail) > export default async x => { let x; }; 1`] = `
-"SyntaxError [1:33-1:34]: Duplicate binding 'x'
+"SyntaxError [1:32-1:33]: Duplicate binding 'x'
 > 1 | export default async x => { let x; };
-    |                                  ^ Duplicate binding 'x'"
+    |                                 ^ Duplicate binding 'x'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > export default await 1`] = `
@@ -827,27 +827,27 @@ exports[`Module - Export > Module - Export (fail) > export default function(){};
 `;
 
 exports[`Module - Export > Module - Export (fail) > export default function([a, a]){} 1`] = `
-"SyntaxError [1:29-1:30]: Duplicate binding 'a'
+"SyntaxError [1:28-1:29]: Duplicate binding 'a'
 > 1 | export default function([a, a]){}
-    |                              ^ Duplicate binding 'a'"
+    |                             ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > export default function(a){ const a = 0; } 1`] = `
-"SyntaxError [1:36-1:37]: Duplicate binding 'a'
+"SyntaxError [1:34-1:35]: Duplicate binding 'a'
 > 1 | export default function(a){ const a = 0; }
-    |                                     ^ Duplicate binding 'a'"
+    |                                   ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > export default function(a){ let a; } 1`] = `
-"SyntaxError [1:33-1:34]: Duplicate binding 'a'
+"SyntaxError [1:32-1:33]: Duplicate binding 'a'
 > 1 | export default function(a){ let a; }
-    |                                  ^ Duplicate binding 'a'"
+    |                                 ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > export default function(a, a){} 1`] = `
-"SyntaxError [1:28-1:29]: Duplicate binding 'a'
+"SyntaxError [1:27-1:28]: Duplicate binding 'a'
 > 1 | export default function(a, a){}
-    |                             ^ Duplicate binding 'a'"
+    |                            ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > export default let 1`] = `
@@ -941,15 +941,15 @@ exports[`Module - Export > Module - Export (fail) > export function f(){}; funct
 `;
 
 exports[`Module - Export > Module - Export (fail) > export function x(){}; export let [x] = y; 1`] = `
-"SyntaxError [1:36-1:37]: Duplicate binding 'x'
+"SyntaxError [1:35-1:36]: Duplicate binding 'x'
 > 1 | export function x(){}; export let [x] = y;
-    |                                     ^ Duplicate binding 'x'"
+    |                                    ^ Duplicate binding 'x'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > export function x(){}; export let [x] = y; 2`] = `
-"SyntaxError [1:36-1:37]: Duplicate binding 'x'
+"SyntaxError [1:35-1:36]: Duplicate binding 'x'
 > 1 | export function x(){}; export let [x] = y;
-    |                                     ^ Duplicate binding 'x'"
+    |                                    ^ Duplicate binding 'x'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > export function* () { } 1`] = `
@@ -965,15 +965,15 @@ exports[`Module - Export > Module - Export (fail) > export let ...x = y 1`] = `
 `;
 
 exports[`Module - Export > Module - Export (fail) > export let [x, x] = y; 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'x'
+"SyntaxError [1:15-1:16]: Duplicate binding 'x'
 > 1 | export let [x, x] = y;
-    |                 ^ Duplicate binding 'x'"
+    |                ^ Duplicate binding 'x'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > export let [x, x] = y; 2`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'x'
+"SyntaxError [1:15-1:16]: Duplicate binding 'x'
 > 1 | export let [x, x] = y;
-    |                 ^ Duplicate binding 'x'"
+    |                ^ Duplicate binding 'x'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > export let [x] = y; export {x}; 1`] = `
@@ -1003,15 +1003,15 @@ export async function a() {} 1`] = `
 `;
 
 exports[`Module - Export > Module - Export (fail) > export let a; export let a; 1`] = `
-"SyntaxError [1:26-1:27]: Duplicate binding 'a'
+"SyntaxError [1:25-1:26]: Duplicate binding 'a'
 > 1 | export let a; export let a;
-    |                           ^ Duplicate binding 'a'"
+    |                          ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > export let a; export let a; 2`] = `
-"SyntaxError [1:26-1:27]: Duplicate binding 'a'
+"SyntaxError [1:25-1:26]: Duplicate binding 'a'
 > 1 | export let a; export let a;
-    |                           ^ Duplicate binding 'a'"
+    |                          ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > export let await; 1`] = `
@@ -1021,39 +1021,39 @@ exports[`Module - Export > Module - Export (fail) > export let await; 1`] = `
 `;
 
 exports[`Module - Export > Module - Export (fail) > export let foo; export let foo; 1`] = `
-"SyntaxError [1:30-1:31]: Duplicate binding 'foo'
+"SyntaxError [1:27-1:30]: Duplicate binding 'foo'
 > 1 | export let foo; export let foo;
-    |                               ^ Duplicate binding 'foo'"
+    |                            ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > export let x = y, [...x] = y; 1`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'x'
+"SyntaxError [1:22-1:23]: Duplicate binding 'x'
 > 1 | export let x = y, [...x] = y;
-    |                        ^ Duplicate binding 'x'"
+    |                       ^ Duplicate binding 'x'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > export let x = y, [...x] = y; 2`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'x'
+"SyntaxError [1:22-1:23]: Duplicate binding 'x'
 > 1 | export let x = y, [...x] = y;
-    |                        ^ Duplicate binding 'x'"
+    |                       ^ Duplicate binding 'x'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > export let x = y, [x] = y; 1`] = `
-"SyntaxError [1:20-1:21]: Duplicate binding 'x'
+"SyntaxError [1:19-1:20]: Duplicate binding 'x'
 > 1 | export let x = y, [x] = y;
-    |                     ^ Duplicate binding 'x'"
+    |                    ^ Duplicate binding 'x'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > export let x = y, {...x} = y; 1`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'x'
+"SyntaxError [1:22-1:23]: Duplicate binding 'x'
 > 1 | export let x = y, {...x} = y;
-    |                        ^ Duplicate binding 'x'"
+    |                       ^ Duplicate binding 'x'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > export let x = y, {...x} = y; 2`] = `
-"SyntaxError [1:23-1:24]: Duplicate binding 'x'
+"SyntaxError [1:22-1:23]: Duplicate binding 'x'
 > 1 | export let x = y, {...x} = y;
-    |                        ^ Duplicate binding 'x'"
+    |                       ^ Duplicate binding 'x'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > export let x = y; export {f}; 1`] = `
@@ -1093,9 +1093,9 @@ exports[`Module - Export > Module - Export (fail) > export var a; export var a; 
 `;
 
 exports[`Module - Export > Module - Export (fail) > export var foo; export let foo; 1`] = `
-"SyntaxError [1:30-1:31]: Duplicate binding 'foo'
+"SyntaxError [1:27-1:30]: Duplicate binding 'foo'
 > 1 | export var foo; export let foo;
-    |                               ^ Duplicate binding 'foo'"
+    |                            ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > export var let = x; 1`] = `
@@ -1183,9 +1183,9 @@ exports[`Module - Export > Module - Export (fail) > let a; export class a {}; 1`
 `;
 
 exports[`Module - Export > Module - Export (fail) > let a; export const a = 0; 1`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'a'
+"SyntaxError [1:20-1:21]: Duplicate binding 'a'
 > 1 | let a; export const a = 0;
-    |                       ^ Duplicate binding 'a'"
+    |                     ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > let a; export function a(){}; 1`] = `
@@ -1195,21 +1195,21 @@ exports[`Module - Export > Module - Export (fail) > let a; export function a(){}
 `;
 
 exports[`Module - Export > Module - Export (fail) > let a; export let a; 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'a'
+"SyntaxError [1:18-1:19]: Duplicate binding 'a'
 > 1 | let a; export let a;
-    |                    ^ Duplicate binding 'a'"
+    |                   ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > let a; let a; 1`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'a'
+"SyntaxError [1:11-1:12]: Duplicate binding 'a'
 > 1 | let a; let a;
-    |             ^ Duplicate binding 'a'"
+    |            ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > let a; var a; 1`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'a'
+"SyntaxError [1:11-1:12]: Duplicate binding 'a'
 > 1 | let a; var a;
-    |             ^ Duplicate binding 'a'"
+    |            ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > let x = () => {export {x};} 1`] = `
@@ -1369,9 +1369,9 @@ exports[`Module - Export > Module - Export (fail) > var a; export class a {}; 1`
 `;
 
 exports[`Module - Export > Module - Export (fail) > var a; export const a = 0; 1`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'a'
+"SyntaxError [1:20-1:21]: Duplicate binding 'a'
 > 1 | var a; export const a = 0;
-    |                       ^ Duplicate binding 'a'"
+    |                     ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > var a; export function a(){}; 1`] = `
@@ -1381,15 +1381,15 @@ exports[`Module - Export > Module - Export (fail) > var a; export function a(){}
 `;
 
 exports[`Module - Export > Module - Export (fail) > var a; export let a; 1`] = `
-"SyntaxError [1:19-1:20]: Duplicate binding 'a'
+"SyntaxError [1:18-1:19]: Duplicate binding 'a'
 > 1 | var a; export let a;
-    |                    ^ Duplicate binding 'a'"
+    |                   ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > var a; let a; 1`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'a'
+"SyntaxError [1:11-1:12]: Duplicate binding 'a'
 > 1 | var a; let a;
-    |             ^ Duplicate binding 'a'"
+    |            ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Export > Module - Export (fail) > var canBeUndeclared; export {mustExist as canBeUndeclared}; 1`] = `

--- a/test/parser/module/__snapshots__/import.ts.snap
+++ b/test/parser/module/__snapshots__/import.ts.snap
@@ -1493,9 +1493,9 @@ exports[`Module - Import > Module - Import (fail) > {import {x} from "y";} 2`] =
 `;
 
 exports[`Module - Import > Module - Import (fail) > const foo = 12; import { foo } from "string"; 1`] = `
-"SyntaxError [1:29-1:30]: Duplicate binding 'foo'
+"SyntaxError [1:25-1:28]: Duplicate binding 'foo'
 > 1 | const foo = 12; import { foo } from "string";
-    |                              ^ Duplicate binding 'foo'"
+    |                          ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > do import {x} from "y"; while (x); 1`] = `
@@ -1535,9 +1535,9 @@ exports[`Module - Import > Module - Import (fail) > function f(){import {x} from
 `;
 
 exports[`Module - Import > Module - Import (fail) > function foo() { }; import { foo } from "string"; 1`] = `
-"SyntaxError [1:33-1:34]: Duplicate binding 'foo'
+"SyntaxError [1:29-1:32]: Duplicate binding 'foo'
 > 1 | function foo() { }; import { foo } from "string";
-    |                                  ^ Duplicate binding 'foo'"
+    |                              ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > if (false) import { default } from "module"; 1`] = `
@@ -1583,9 +1583,9 @@ exports[`Module - Import > Module - Import (fail) > import * as b, a from 'a' 1`
 `;
 
 exports[`Module - Import > Module - Import (fail) > import * as foo from "./f"; import { foo } from "./m"; 1`] = `
-"SyntaxError [1:41-1:42]: Duplicate binding 'foo'
+"SyntaxError [1:37-1:40]: Duplicate binding 'foo'
 > 1 | import * as foo from "./f"; import { foo } from "./m";
-    |                                          ^ Duplicate binding 'foo'"
+    |                                      ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import * as from 1`] = `
@@ -1673,15 +1673,15 @@ exports[`Module - Import > Module - Import (fail) > import { a } from; 1`] = `
 `;
 
 exports[`Module - Import > Module - Import (fail) > import { b as foo } from "./f"; import { "a" as foo } from "./m"; 1`] = `
-"SyntaxError [1:52-1:53]: Duplicate binding 'foo'
+"SyntaxError [1:41-1:44]: Duplicate binding 'foo'
 > 1 | import { b as foo } from "./f"; import { "a" as foo } from "./m";
-    |                                                     ^ Duplicate binding 'foo'"
+    |                                          ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import { foo } from "./f"; import { foo } from "./m"; 1`] = `
-"SyntaxError [1:40-1:41]: Duplicate binding 'foo'
+"SyntaxError [1:36-1:39]: Duplicate binding 'foo'
 > 1 | import { foo } from "./f"; import { foo } from "./m";
-    |                                         ^ Duplicate binding 'foo'"
+    |                                     ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import { foo } from "string 1`] = `
@@ -1739,9 +1739,9 @@ exports[`Module - Import > Module - Import (fail) > import { foo as bar,  1`] = 
 `;
 
 exports[`Module - Import > Module - Import (fail) > import { foo as bar, bar } from "string"; 1`] = `
-"SyntaxError [1:25-1:26]: Duplicate binding 'bar'
+"SyntaxError [1:21-1:24]: Duplicate binding 'bar'
 > 1 | import { foo as bar, bar } from "string";
-    |                          ^ Duplicate binding 'bar'"
+    |                      ^^^ Duplicate binding 'bar'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import { foo as switch } from "module"; 1`] = `
@@ -1775,15 +1775,15 @@ exports[`Module - Import > Module - Import (fail) > import { foo, , } from "modu
 `;
 
 exports[`Module - Import > Module - Import (fail) > import { foo, bar as foo } from "string"; 1`] = `
-"SyntaxError [1:25-1:26]: Duplicate binding 'foo'
+"SyntaxError [1:14-1:17]: Duplicate binding 'foo'
 > 1 | import { foo, bar as foo } from "string";
-    |                          ^ Duplicate binding 'foo'"
+    |               ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import { foo, foo } from "string"; 1`] = `
-"SyntaxError [1:18-1:19]: Duplicate binding 'foo'
+"SyntaxError [1:14-1:17]: Duplicate binding 'foo'
 > 1 | import { foo, foo } from "string";
-    |                   ^ Duplicate binding 'foo'"
+    |               ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import { implements } from "null" 1`] = `
@@ -1805,9 +1805,9 @@ exports[`Module - Import > Module - Import (fail) > import { switch } from "modu
 `;
 
 exports[`Module - Import > Module - Import (fail) > import { x, y, x } from "foo"; 1`] = `
-"SyntaxError [1:17-1:18]: Duplicate binding 'x'
+"SyntaxError [1:15-1:16]: Duplicate binding 'x'
 > 1 | import { x, y, x } from "foo";
-    |                  ^ Duplicate binding 'x'"
+    |                ^ Duplicate binding 'x'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {,} from 'a'; 1`] = `
@@ -1841,75 +1841,75 @@ exports[`Module - Import > Module - Import (fail) > import {a b} from "foo"; 1`]
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {a, a as a} from "foo" 1`] = `
-"SyntaxError [1:17-1:18]: Duplicate binding 'a'
+"SyntaxError [1:11-1:12]: Duplicate binding 'a'
 > 1 | import {a, a as a} from "foo"
-    |                  ^ Duplicate binding 'a'"
+    |            ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {a, a, b} from "foo" 1`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'a'
+"SyntaxError [1:11-1:12]: Duplicate binding 'a'
 > 1 | import {a, a, b} from "foo"
-    |             ^ Duplicate binding 'a'"
+    |            ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {a, a} from "foo" 1`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'a'
+"SyntaxError [1:11-1:12]: Duplicate binding 'a'
 > 1 | import {a, a} from "foo"
-    |             ^ Duplicate binding 'a'"
+    |            ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {a, a} from "foo"; 1`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'a'
+"SyntaxError [1:11-1:12]: Duplicate binding 'a'
 > 1 | import {a, a} from "foo";
-    |             ^ Duplicate binding 'a'"
+    |            ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {a, b as a} from "foo" 1`] = `
-"SyntaxError [1:17-1:18]: Duplicate binding 'a'
+"SyntaxError [1:11-1:12]: Duplicate binding 'a'
 > 1 | import {a, b as a} from "foo"
-    |                  ^ Duplicate binding 'a'"
+    |            ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {a, b as a} from "foo"; 1`] = `
-"SyntaxError [1:17-1:18]: Duplicate binding 'a'
+"SyntaxError [1:11-1:12]: Duplicate binding 'a'
 > 1 | import {a, b as a} from "foo";
-    |                  ^ Duplicate binding 'a'"
+    |            ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {a, b, a} from "foo" 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'a'
+"SyntaxError [1:14-1:15]: Duplicate binding 'a'
 > 1 | import {a, b, a} from "foo"
-    |                ^ Duplicate binding 'a'"
+    |               ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {a} from "foo"; import {a as a} from "foo" 1`] = `
-"SyntaxError [1:37-1:38]: Duplicate binding 'a'
+"SyntaxError [1:31-1:32]: Duplicate binding 'a'
 > 1 | import {a} from "foo"; import {a as a} from "foo"
-    |                                      ^ Duplicate binding 'a'"
+    |                                ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {a} from "foo"; import {a} from "foo"; 1`] = `
-"SyntaxError [1:32-1:33]: Duplicate binding 'a'
+"SyntaxError [1:31-1:32]: Duplicate binding 'a'
 > 1 | import {a} from "foo"; import {a} from "foo";
-    |                                 ^ Duplicate binding 'a'"
+    |                                ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {a} from "foo"; import {b as a} from "foo" 1`] = `
-"SyntaxError [1:37-1:38]: Duplicate binding 'a'
+"SyntaxError [1:31-1:32]: Duplicate binding 'a'
 > 1 | import {a} from "foo"; import {b as a} from "foo"
-    |                                      ^ Duplicate binding 'a'"
+    |                                ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {a} from "foo"; import {b as a} from "foo" 2`] = `
-"SyntaxError [1:37-1:38]: Duplicate binding 'a'
+"SyntaxError [1:31-1:32]: Duplicate binding 'a'
 > 1 | import {a} from "foo"; import {b as a} from "foo"
-    |                                      ^ Duplicate binding 'a'"
+    |                                ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {a} from "foo"; import {b, a} from "foo" 1`] = `
-"SyntaxError [1:35-1:36]: Duplicate binding 'a'
+"SyntaxError [1:34-1:35]: Duplicate binding 'a'
 > 1 | import {a} from "foo"; import {b, a} from "foo"
-    |                                    ^ Duplicate binding 'a'"
+    |                                   ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {a} from "foo"; import a from "foo" 1`] = `
@@ -1925,15 +1925,15 @@ exports[`Module - Import > Module - Import (fail) > import {await} from "foo"; 1
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {b as a, c as a} from "foo"; 1`] = `
-"SyntaxError [1:22-1:23]: Duplicate binding 'a'
+"SyntaxError [1:16-1:17]: Duplicate binding 'a'
 > 1 | import {b as a, c as a} from "foo";
-    |                       ^ Duplicate binding 'a'"
+    |                 ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {b, a, a} from "foo" 1`] = `
-"SyntaxError [1:15-1:16]: Duplicate binding 'a'
+"SyntaxError [1:14-1:15]: Duplicate binding 'a'
 > 1 | import {b, a, a} from "foo"
-    |                ^ Duplicate binding 'a'"
+    |               ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {b,,} from 'a'; 1`] = `
@@ -1997,27 +1997,27 @@ exports[`Module - Import > Module - Import (fail) > import a, *= from 'foo'; 1`]
 `;
 
 exports[`Module - Import > Module - Import (fail) > import a, {a} from "foo" 1`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'a'
+"SyntaxError [1:11-1:12]: Duplicate binding 'a'
 > 1 | import a, {a} from "foo"
-    |             ^ Duplicate binding 'a'"
+    |            ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import a, {a} from "foo"; 1`] = `
-"SyntaxError [1:12-1:13]: Duplicate binding 'a'
+"SyntaxError [1:11-1:12]: Duplicate binding 'a'
 > 1 | import a, {a} from "foo";
-    |             ^ Duplicate binding 'a'"
+    |            ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import a, {b as a} from "foo" 1`] = `
-"SyntaxError [1:17-1:18]: Duplicate binding 'a'
+"SyntaxError [1:11-1:12]: Duplicate binding 'a'
 > 1 | import a, {b as a} from "foo"
-    |                  ^ Duplicate binding 'a'"
+    |            ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import a, {b as a} from "foo"; 1`] = `
-"SyntaxError [1:17-1:18]: Duplicate binding 'a'
+"SyntaxError [1:11-1:12]: Duplicate binding 'a'
 > 1 | import a, {b as a} from "foo";
-    |                  ^ Duplicate binding 'a'"
+    |            ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import arguments, {x, y, z} from "foo"; 1`] = `

--- a/test/parser/module/__snapshots__/import.ts.snap
+++ b/test/parser/module/__snapshots__/import.ts.snap
@@ -1673,9 +1673,9 @@ exports[`Module - Import > Module - Import (fail) > import { a } from; 1`] = `
 `;
 
 exports[`Module - Import > Module - Import (fail) > import { b as foo } from "./f"; import { "a" as foo } from "./m"; 1`] = `
-"SyntaxError [1:41-1:44]: Duplicate binding 'foo'
+"SyntaxError [1:48-1:51]: Duplicate binding 'foo'
 > 1 | import { b as foo } from "./f"; import { "a" as foo } from "./m";
-    |                                          ^^^ Duplicate binding 'foo'"
+    |                                                 ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import { foo } from "./f"; import { foo } from "./m"; 1`] = `
@@ -1775,9 +1775,9 @@ exports[`Module - Import > Module - Import (fail) > import { foo, , } from "modu
 `;
 
 exports[`Module - Import > Module - Import (fail) > import { foo, bar as foo } from "string"; 1`] = `
-"SyntaxError [1:14-1:17]: Duplicate binding 'foo'
+"SyntaxError [1:21-1:24]: Duplicate binding 'foo'
 > 1 | import { foo, bar as foo } from "string";
-    |               ^^^ Duplicate binding 'foo'"
+    |                      ^^^ Duplicate binding 'foo'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import { foo, foo } from "string"; 1`] = `
@@ -1841,9 +1841,9 @@ exports[`Module - Import > Module - Import (fail) > import {a b} from "foo"; 1`]
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {a, a as a} from "foo" 1`] = `
-"SyntaxError [1:11-1:12]: Duplicate binding 'a'
+"SyntaxError [1:16-1:17]: Duplicate binding 'a'
 > 1 | import {a, a as a} from "foo"
-    |            ^ Duplicate binding 'a'"
+    |                 ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {a, a, b} from "foo" 1`] = `
@@ -1865,15 +1865,15 @@ exports[`Module - Import > Module - Import (fail) > import {a, a} from "foo"; 1`
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {a, b as a} from "foo" 1`] = `
-"SyntaxError [1:11-1:12]: Duplicate binding 'a'
+"SyntaxError [1:16-1:17]: Duplicate binding 'a'
 > 1 | import {a, b as a} from "foo"
-    |            ^ Duplicate binding 'a'"
+    |                 ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {a, b as a} from "foo"; 1`] = `
-"SyntaxError [1:11-1:12]: Duplicate binding 'a'
+"SyntaxError [1:16-1:17]: Duplicate binding 'a'
 > 1 | import {a, b as a} from "foo";
-    |            ^ Duplicate binding 'a'"
+    |                 ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {a, b, a} from "foo" 1`] = `
@@ -1883,9 +1883,9 @@ exports[`Module - Import > Module - Import (fail) > import {a, b, a} from "foo" 
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {a} from "foo"; import {a as a} from "foo" 1`] = `
-"SyntaxError [1:31-1:32]: Duplicate binding 'a'
+"SyntaxError [1:36-1:37]: Duplicate binding 'a'
 > 1 | import {a} from "foo"; import {a as a} from "foo"
-    |                                ^ Duplicate binding 'a'"
+    |                                     ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {a} from "foo"; import {a} from "foo"; 1`] = `
@@ -1895,15 +1895,15 @@ exports[`Module - Import > Module - Import (fail) > import {a} from "foo"; impor
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {a} from "foo"; import {b as a} from "foo" 1`] = `
-"SyntaxError [1:31-1:32]: Duplicate binding 'a'
+"SyntaxError [1:36-1:37]: Duplicate binding 'a'
 > 1 | import {a} from "foo"; import {b as a} from "foo"
-    |                                ^ Duplicate binding 'a'"
+    |                                     ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {a} from "foo"; import {b as a} from "foo" 2`] = `
-"SyntaxError [1:31-1:32]: Duplicate binding 'a'
+"SyntaxError [1:36-1:37]: Duplicate binding 'a'
 > 1 | import {a} from "foo"; import {b as a} from "foo"
-    |                                ^ Duplicate binding 'a'"
+    |                                     ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {a} from "foo"; import {b, a} from "foo" 1`] = `
@@ -1925,9 +1925,9 @@ exports[`Module - Import > Module - Import (fail) > import {await} from "foo"; 1
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {b as a, c as a} from "foo"; 1`] = `
-"SyntaxError [1:16-1:17]: Duplicate binding 'a'
+"SyntaxError [1:21-1:22]: Duplicate binding 'a'
 > 1 | import {b as a, c as a} from "foo";
-    |                 ^ Duplicate binding 'a'"
+    |                      ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import {b, a, a} from "foo" 1`] = `
@@ -2009,15 +2009,15 @@ exports[`Module - Import > Module - Import (fail) > import a, {a} from "foo"; 1`
 `;
 
 exports[`Module - Import > Module - Import (fail) > import a, {b as a} from "foo" 1`] = `
-"SyntaxError [1:11-1:12]: Duplicate binding 'a'
+"SyntaxError [1:16-1:17]: Duplicate binding 'a'
 > 1 | import a, {b as a} from "foo"
-    |            ^ Duplicate binding 'a'"
+    |                 ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import a, {b as a} from "foo"; 1`] = `
-"SyntaxError [1:11-1:12]: Duplicate binding 'a'
+"SyntaxError [1:16-1:17]: Duplicate binding 'a'
 > 1 | import a, {b as a} from "foo";
-    |            ^ Duplicate binding 'a'"
+    |                 ^ Duplicate binding 'a'"
 `;
 
 exports[`Module - Import > Module - Import (fail) > import arguments, {x, y, z} from "foo"; 1`] = `


### PR DESCRIPTION
The var/block name was added in scope without location information. Most of the time, the parser has moved to next token when reporting duplicate binding.

This fix retains location (start and end) information when var/block name is added.

The difference in snap files shows what this fixed.
