### PR TITLE
fix(jsx): count line terminators and decode entities in attribute values

### DIFF
--- a/src/lexer/jsx.ts
+++ b/src/lexer/jsx.ts
@@ -37,12 +37,28 @@ function scanJSXString(parser: Parser): Token {
   const start = parser.index;
   while (char !== quote) {
     if (parser.index >= parser.end) parser.report(Errors.UnterminatedString);
+
+    // Unlike a normal string, a JSX attribute value may contain raw line
+    // terminators, and they have to be counted or every location after the
+    // attribute is off. `CharTypes` only covers the first 128 code points, so
+    // `<LS>` and `<PS>` are matched by code point like `scanString` does.
+    if (char === Chars.CarriageReturn) {
+      // `<CR><LF>` is one line terminator sequence, not two
+      if (parser.source.charCodeAt(parser.index + 1) === Chars.LineFeed) advanceChar(parser);
+      parser.column = -1;
+      parser.line++;
+    } else if (char === Chars.LineFeed || char === Chars.LineSeparator || char === Chars.ParagraphSeparator) {
+      parser.column = -1;
+      parser.line++;
+    }
+
     char = advanceChar(parser);
   }
 
   // check for unterminated string
   if (char !== quote) parser.report(Errors.UnterminatedString);
-  parser.tokenValue = parser.source.slice(start, parser.index);
+  // Decode HTML entities, same as `nextJSXToken` does for JSX text
+  parser.tokenValue = decodeHTMLStrict(parser.source.slice(start, parser.index));
   advanceChar(parser); // skip the quote
   if (parser.options.raw) parser.tokenRaw = parser.source.slice(parser.tokenIndex, parser.index);
   return Token.StringLiteral;

--- a/test/conformance/ast-alignment-test.ts
+++ b/test/conformance/ast-alignment-test.ts
@@ -15,6 +15,18 @@ const notAlignedTests = new Set([
   'language/expressions/template-literal/tv-line-continuation.js',
 ]);
 
+// `runTest` silently skips every fixture Acorn cannot parse, so a `parseAcorn`
+// that stopped working would skip all of them and this test would pass while
+// comparing nothing. The number of fixtures is checked as well, because a ratio
+// on its own is vacuously true when there are none to compare. Acorn parses
+// nearly every fixture, but both numbers move with the test262 pin, with
+// `test262/unsupported-features.txt` and with `test262/whitelist.txt`, so these
+// are floors rather than exact counts.
+const MINIMUM_FIXTURE_COUNT = 40_000;
+const MINIMUM_COMPARED_RATIO = 0.9;
+
+let comparedCount = 0;
+
 it(
   'AST alignment with Acorn',
   async () => {
@@ -28,8 +40,22 @@ it(
       t.equal(tests.length, 1);
     }
 
+    comparedCount = 0;
     for (const testCase of tests) {
       runTest(testCase);
+    }
+
+    if (!TEST262_FILE) {
+      t.ok(
+        tests.length >= MINIMUM_FIXTURE_COUNT,
+        `Loaded ${tests.length} test262 fixtures, expected at least ${MINIMUM_FIXTURE_COUNT}. ` +
+          'Nothing is compared when the fixtures are missing, so this has to be checked separately from the ratio below.',
+      );
+      t.ok(
+        comparedCount >= tests.length * MINIMUM_COMPARED_RATIO,
+        `Compared ${comparedCount} of ${tests.length} test262 fixtures against Acorn, expected at least ${MINIMUM_COMPARED_RATIO * 100}%. ` +
+          'Fixtures Acorn cannot parse are skipped, so a drop means Acorn is no longer parsing them and this test is comparing nothing.',
+      );
     }
   },
   Infinity,
@@ -52,6 +78,7 @@ function runTest(testCase: TestCase) {
   let passed;
 
   try {
+    comparedCount++;
     t.deepEqual(meriyahAst, acornAst);
     passed = true;
   } catch (error) {

--- a/test/conformance/jsx-ast-alignment-test.ts
+++ b/test/conformance/jsx-ast-alignment-test.ts
@@ -197,7 +197,7 @@ function fixAcornAst(ast: acorn.Program, text: string): MeriyahAst {
         return node;
       case 'JSXOpeningFragment':
         // Not in ESTree, `acorn-jsx` adds them, Babel doesn't
-        // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/estree-jsx/index.d.ts
+        // https://github.com/react/jsx/blob/main/AST.md#jsx-fragment
         delete node.attributes;
         delete node.selfClosing;
         return node;

--- a/test/conformance/jsx-ast-alignment-test.ts
+++ b/test/conformance/jsx-ast-alignment-test.ts
@@ -9,7 +9,22 @@ import { visitNode } from '../test-utils.ts';
 
 const { TEST_JSX_FILE } = process.env;
 
-const notAlignedTests: Set<string> = new Set([]);
+const notAlignedTests: Set<string> = new Set([
+  // `<A>foo&rbrace;</A>`. Meriyah decodes HTML entities in JSX text with the full
+  // https://html.spec.whatwg.org/entities.json table, `acorn-jsx` uses a smaller
+  // one, so entities that only exist in the full table (`&rbrace;`, `&AMP;`, ...)
+  // stay raw in Acorn and are decoded here. That is deliberate, see
+  // https://github.com/meriyah/meriyah/issues/133#issuecomment-770512949
+  '0044-16f0.jsx',
+]);
+
+// How many of the `jsx-test-suite` cases are actually compared against Acorn.
+// `runTest` silently skips every case Acorn cannot parse, so a `parseAcorn` that
+// lost its JSX support skips all of them and this test passes while comparing
+// nothing. `jsx-test-suite` is version pinned, so this is an exact number.
+const EXPECTED_COMPARED_COUNT = 40;
+
+let comparedCount = 0;
 
 it(
   'AST alignment with Acorn (JSX)',
@@ -20,8 +35,18 @@ it(
       t.equal(testCases.length, 1);
     }
 
+    comparedCount = 0;
     for (const testCase of testCases) {
       runTest(testCase);
+    }
+
+    if (!TEST_JSX_FILE) {
+      t.equal(
+        comparedCount,
+        EXPECTED_COMPARED_COUNT,
+        `Compared ${comparedCount} of ${testCases.length} 'jsx-test-suite' cases against Acorn, expected ${EXPECTED_COMPARED_COUNT}. ` +
+          'Cases Acorn cannot parse are skipped, so a drop means Acorn is no longer parsing JSX and this test is comparing nothing.',
+      );
     }
   },
   Infinity,
@@ -44,6 +69,7 @@ function runTest(testCase: (typeof jsxTestSuite)[number]) {
   let passed;
 
   try {
+    comparedCount++;
     t.deepEqual(meriyahAst, acornAst);
     passed = true;
   } catch (error) {
@@ -86,12 +112,12 @@ function parseMeriyah(text: string) {
 }
 
 type AcornAst = acorn.Program & { comments: acorn.Comment[] };
-let acornParser;
+let acornParser: typeof acorn.Parser | undefined;
 function parseAcorn(text: string) {
   acornParser ??= acorn.Parser.extend(acornJsx());
 
   const comments: acorn.Comment[] = [];
-  const ast = acorn.parse(text, {
+  const ast = acornParser.parse(text, {
     ecmaVersion: 'latest',
     locations: true,
     ranges: true,
@@ -135,10 +161,46 @@ function fixAcornAst(ast: acorn.Program, text: string): MeriyahAst {
     };
 
     switch (node.type) {
+      case 'Block':
+        return Object.assign(node, { type: 'MultiLine' });
       case 'Line': {
         const type = getSingleLineCommentType(node as acorn.Comment, text);
         return Object.assign(node, { type });
       }
+      case 'FunctionExpression':
+      case 'FunctionDeclaration':
+        // Depreacted property https://github.com/acornjs/acorn/pull/1361
+        if (node.expression === false) {
+          delete node.expression;
+        }
+        return node;
+      case 'ArrowFunctionExpression':
+        // Not in ESTree
+        if (node.id === null) {
+          delete node.id;
+        }
+        return node;
+      case 'ImportDeclaration':
+      case 'ImportExpression':
+        if (!('phase' in node)) {
+          node.phase = null;
+        }
+        return node;
+      case 'ClassExpression':
+      case 'ClassDeclaration':
+      case 'AccessorProperty':
+      case 'PropertyDefinition':
+      case 'MethodDefinition':
+        if (!('decorators' in node)) {
+          node.decorators = [];
+        }
+        return node;
+      case 'JSXOpeningFragment':
+        // Not in ESTree, `acorn-jsx` adds them, Babel doesn't
+        // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/estree-jsx/index.d.ts
+        delete node.attributes;
+        delete node.selfClosing;
+        return node;
     }
 
     return node;

--- a/test/parser/miscellaneous/__snapshots__/jsx.ts.snap
+++ b/test/parser/miscellaneous/__snapshots__/jsx.ts.snap
@@ -120,6 +120,24 @@ exports[`Miscellaneous - JSX > Miscellaneous - JSX (fail) > <Foo></Bar> 1`] = `
     |           ^ Expected corresponding JSX closing tag for Bar"
 `;
 
+exports[`Miscellaneous - JSX > Miscellaneous - JSX (fail) > <a b="x
+y 1`] = `
+"SyntaxError [1:5-2:1]: Unterminated string literal
+> 1 | <a b="x
+    |      ^^
+> 2 | y
+    | ^ Unterminated string literal"
+`;
+
+exports[`Miscellaneous - JSX > Miscellaneous - JSX (fail) > <a b="x␍␊
+y" 1`] = `
+"SyntaxError [1:5-2:2]: Expected '>'
+> 1 | <a b="x
+    |      ^^
+> 2 | y"
+    | ^^ Expected '>'"
+`;
+
 exports[`Miscellaneous - JSX > Miscellaneous - JSX (fail) > <a b=: /> 1`] = `
 "SyntaxError [1:5-1:6]: JSX value should be either an expression or a quoted JSX text
 > 1 | <a b=: />
@@ -2920,7 +2938,7 @@ exports[`Miscellaneous - JSX > Miscellaneous - JSX (pass) > <a b="&#xA2; &#x00A3
               "type": "JSXAttribute",
               "value": {
                 "type": "Literal",
-                "value": "&#xA2; &#x00A3;",
+                "value": "¢ £",
               },
             },
           ],
@@ -2937,6 +2955,256 @@ exports[`Miscellaneous - JSX > Miscellaneous - JSX (pass) > <a b="&#xA2; &#x00A3
     },
   ],
   "sourceType": "script",
+  "type": "Program",
+}
+`;
+
+exports[`Miscellaneous - JSX > Miscellaneous - JSX (pass) > <a b="&amp;&#38;&#x26;" />;
+var after = 1; 1`] = `
+{
+  "body": [
+    {
+      "end": 27,
+      "expression": {
+        "children": [],
+        "closingElement": null,
+        "end": 26,
+        "loc": {
+          "end": {
+            "column": 26,
+            "line": 1,
+          },
+          "start": {
+            "column": 0,
+            "line": 1,
+          },
+        },
+        "openingElement": {
+          "attributes": [
+            {
+              "end": 23,
+              "loc": {
+                "end": {
+                  "column": 23,
+                  "line": 1,
+                },
+                "start": {
+                  "column": 3,
+                  "line": 1,
+                },
+              },
+              "name": {
+                "end": 4,
+                "loc": {
+                  "end": {
+                    "column": 4,
+                    "line": 1,
+                  },
+                  "start": {
+                    "column": 3,
+                    "line": 1,
+                  },
+                },
+                "name": "b",
+                "range": [
+                  3,
+                  4,
+                ],
+                "start": 3,
+                "type": "JSXIdentifier",
+              },
+              "range": [
+                3,
+                23,
+              ],
+              "start": 3,
+              "type": "JSXAttribute",
+              "value": {
+                "end": 23,
+                "loc": {
+                  "end": {
+                    "column": 23,
+                    "line": 1,
+                  },
+                  "start": {
+                    "column": 5,
+                    "line": 1,
+                  },
+                },
+                "range": [
+                  5,
+                  23,
+                ],
+                "raw": ""&amp;&#38;&#x26;"",
+                "start": 5,
+                "type": "Literal",
+                "value": "&&&",
+              },
+            },
+          ],
+          "end": 26,
+          "loc": {
+            "end": {
+              "column": 26,
+              "line": 1,
+            },
+            "start": {
+              "column": 0,
+              "line": 1,
+            },
+          },
+          "name": {
+            "end": 2,
+            "loc": {
+              "end": {
+                "column": 2,
+                "line": 1,
+              },
+              "start": {
+                "column": 1,
+                "line": 1,
+              },
+            },
+            "name": "a",
+            "range": [
+              1,
+              2,
+            ],
+            "start": 1,
+            "type": "JSXIdentifier",
+          },
+          "range": [
+            0,
+            26,
+          ],
+          "selfClosing": true,
+          "start": 0,
+          "type": "JSXOpeningElement",
+        },
+        "range": [
+          0,
+          26,
+        ],
+        "start": 0,
+        "type": "JSXElement",
+      },
+      "loc": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": [
+        0,
+        27,
+      ],
+      "start": 0,
+      "type": "ExpressionStatement",
+    },
+    {
+      "declarations": [
+        {
+          "end": 41,
+          "id": {
+            "end": 37,
+            "loc": {
+              "end": {
+                "column": 9,
+                "line": 2,
+              },
+              "start": {
+                "column": 4,
+                "line": 2,
+              },
+            },
+            "name": "after",
+            "range": [
+              32,
+              37,
+            ],
+            "start": 32,
+            "type": "Identifier",
+          },
+          "init": {
+            "end": 41,
+            "loc": {
+              "end": {
+                "column": 13,
+                "line": 2,
+              },
+              "start": {
+                "column": 12,
+                "line": 2,
+              },
+            },
+            "range": [
+              40,
+              41,
+            ],
+            "raw": "1",
+            "start": 40,
+            "type": "Literal",
+            "value": 1,
+          },
+          "loc": {
+            "end": {
+              "column": 13,
+              "line": 2,
+            },
+            "start": {
+              "column": 4,
+              "line": 2,
+            },
+          },
+          "range": [
+            32,
+            41,
+          ],
+          "start": 32,
+          "type": "VariableDeclarator",
+        },
+      ],
+      "end": 42,
+      "kind": "var",
+      "loc": {
+        "end": {
+          "column": 14,
+          "line": 2,
+        },
+        "start": {
+          "column": 0,
+          "line": 2,
+        },
+      },
+      "range": [
+        28,
+        42,
+      ],
+      "start": 28,
+      "type": "VariableDeclaration",
+    },
+  ],
+  "end": 42,
+  "loc": {
+    "end": {
+      "column": 14,
+      "line": 2,
+    },
+    "start": {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": [
+    0,
+    42,
+  ],
+  "sourceType": "script",
+  "start": 0,
   "type": "Program",
 }
 `;
@@ -2975,6 +3243,1264 @@ exports[`Miscellaneous - JSX > Miscellaneous - JSX (pass) > <a b="&notanentity;"
     },
   ],
   "sourceType": "script",
+  "type": "Program",
+}
+`;
+
+exports[`Miscellaneous - JSX > Miscellaneous - JSX (pass) > <a b="x
+y" />;
+var after = 1; 1`] = `
+{
+  "body": [
+    {
+      "end": 14,
+      "expression": {
+        "children": [],
+        "closingElement": null,
+        "end": 13,
+        "loc": {
+          "end": {
+            "column": 5,
+            "line": 2,
+          },
+          "start": {
+            "column": 0,
+            "line": 1,
+          },
+        },
+        "openingElement": {
+          "attributes": [
+            {
+              "end": 10,
+              "loc": {
+                "end": {
+                  "column": 2,
+                  "line": 2,
+                },
+                "start": {
+                  "column": 3,
+                  "line": 1,
+                },
+              },
+              "name": {
+                "end": 4,
+                "loc": {
+                  "end": {
+                    "column": 4,
+                    "line": 1,
+                  },
+                  "start": {
+                    "column": 3,
+                    "line": 1,
+                  },
+                },
+                "name": "b",
+                "range": [
+                  3,
+                  4,
+                ],
+                "start": 3,
+                "type": "JSXIdentifier",
+              },
+              "range": [
+                3,
+                10,
+              ],
+              "start": 3,
+              "type": "JSXAttribute",
+              "value": {
+                "end": 10,
+                "loc": {
+                  "end": {
+                    "column": 2,
+                    "line": 2,
+                  },
+                  "start": {
+                    "column": 5,
+                    "line": 1,
+                  },
+                },
+                "range": [
+                  5,
+                  10,
+                ],
+                "raw": ""x
+y"",
+                "start": 5,
+                "type": "Literal",
+                "value": "x
+y",
+              },
+            },
+          ],
+          "end": 13,
+          "loc": {
+            "end": {
+              "column": 5,
+              "line": 2,
+            },
+            "start": {
+              "column": 0,
+              "line": 1,
+            },
+          },
+          "name": {
+            "end": 2,
+            "loc": {
+              "end": {
+                "column": 2,
+                "line": 1,
+              },
+              "start": {
+                "column": 1,
+                "line": 1,
+              },
+            },
+            "name": "a",
+            "range": [
+              1,
+              2,
+            ],
+            "start": 1,
+            "type": "JSXIdentifier",
+          },
+          "range": [
+            0,
+            13,
+          ],
+          "selfClosing": true,
+          "start": 0,
+          "type": "JSXOpeningElement",
+        },
+        "range": [
+          0,
+          13,
+        ],
+        "start": 0,
+        "type": "JSXElement",
+      },
+      "loc": {
+        "end": {
+          "column": 6,
+          "line": 2,
+        },
+        "start": {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": [
+        0,
+        14,
+      ],
+      "start": 0,
+      "type": "ExpressionStatement",
+    },
+    {
+      "declarations": [
+        {
+          "end": 28,
+          "id": {
+            "end": 24,
+            "loc": {
+              "end": {
+                "column": 9,
+                "line": 3,
+              },
+              "start": {
+                "column": 4,
+                "line": 3,
+              },
+            },
+            "name": "after",
+            "range": [
+              19,
+              24,
+            ],
+            "start": 19,
+            "type": "Identifier",
+          },
+          "init": {
+            "end": 28,
+            "loc": {
+              "end": {
+                "column": 13,
+                "line": 3,
+              },
+              "start": {
+                "column": 12,
+                "line": 3,
+              },
+            },
+            "range": [
+              27,
+              28,
+            ],
+            "raw": "1",
+            "start": 27,
+            "type": "Literal",
+            "value": 1,
+          },
+          "loc": {
+            "end": {
+              "column": 13,
+              "line": 3,
+            },
+            "start": {
+              "column": 4,
+              "line": 3,
+            },
+          },
+          "range": [
+            19,
+            28,
+          ],
+          "start": 19,
+          "type": "VariableDeclarator",
+        },
+      ],
+      "end": 29,
+      "kind": "var",
+      "loc": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 0,
+          "line": 3,
+        },
+      },
+      "range": [
+        15,
+        29,
+      ],
+      "start": 15,
+      "type": "VariableDeclaration",
+    },
+  ],
+  "end": 29,
+  "loc": {
+    "end": {
+      "column": 14,
+      "line": 3,
+    },
+    "start": {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": [
+    0,
+    29,
+  ],
+  "sourceType": "script",
+  "start": 0,
+  "type": "Program",
+}
+`;
+
+exports[`Miscellaneous - JSX > Miscellaneous - JSX (pass) > <a b="x y" />;
+var after = 1; 1`] = `
+{
+  "body": [
+    {
+      "end": 14,
+      "expression": {
+        "children": [],
+        "closingElement": null,
+        "end": 13,
+        "loc": {
+          "end": {
+            "column": 5,
+            "line": 2,
+          },
+          "start": {
+            "column": 0,
+            "line": 1,
+          },
+        },
+        "openingElement": {
+          "attributes": [
+            {
+              "end": 10,
+              "loc": {
+                "end": {
+                  "column": 2,
+                  "line": 2,
+                },
+                "start": {
+                  "column": 3,
+                  "line": 1,
+                },
+              },
+              "name": {
+                "end": 4,
+                "loc": {
+                  "end": {
+                    "column": 4,
+                    "line": 1,
+                  },
+                  "start": {
+                    "column": 3,
+                    "line": 1,
+                  },
+                },
+                "name": "b",
+                "range": [
+                  3,
+                  4,
+                ],
+                "start": 3,
+                "type": "JSXIdentifier",
+              },
+              "range": [
+                3,
+                10,
+              ],
+              "start": 3,
+              "type": "JSXAttribute",
+              "value": {
+                "end": 10,
+                "loc": {
+                  "end": {
+                    "column": 2,
+                    "line": 2,
+                  },
+                  "start": {
+                    "column": 5,
+                    "line": 1,
+                  },
+                },
+                "range": [
+                  5,
+                  10,
+                ],
+                "raw": ""x y"",
+                "start": 5,
+                "type": "Literal",
+                "value": "x y",
+              },
+            },
+          ],
+          "end": 13,
+          "loc": {
+            "end": {
+              "column": 5,
+              "line": 2,
+            },
+            "start": {
+              "column": 0,
+              "line": 1,
+            },
+          },
+          "name": {
+            "end": 2,
+            "loc": {
+              "end": {
+                "column": 2,
+                "line": 1,
+              },
+              "start": {
+                "column": 1,
+                "line": 1,
+              },
+            },
+            "name": "a",
+            "range": [
+              1,
+              2,
+            ],
+            "start": 1,
+            "type": "JSXIdentifier",
+          },
+          "range": [
+            0,
+            13,
+          ],
+          "selfClosing": true,
+          "start": 0,
+          "type": "JSXOpeningElement",
+        },
+        "range": [
+          0,
+          13,
+        ],
+        "start": 0,
+        "type": "JSXElement",
+      },
+      "loc": {
+        "end": {
+          "column": 6,
+          "line": 2,
+        },
+        "start": {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": [
+        0,
+        14,
+      ],
+      "start": 0,
+      "type": "ExpressionStatement",
+    },
+    {
+      "declarations": [
+        {
+          "end": 28,
+          "id": {
+            "end": 24,
+            "loc": {
+              "end": {
+                "column": 9,
+                "line": 3,
+              },
+              "start": {
+                "column": 4,
+                "line": 3,
+              },
+            },
+            "name": "after",
+            "range": [
+              19,
+              24,
+            ],
+            "start": 19,
+            "type": "Identifier",
+          },
+          "init": {
+            "end": 28,
+            "loc": {
+              "end": {
+                "column": 13,
+                "line": 3,
+              },
+              "start": {
+                "column": 12,
+                "line": 3,
+              },
+            },
+            "range": [
+              27,
+              28,
+            ],
+            "raw": "1",
+            "start": 27,
+            "type": "Literal",
+            "value": 1,
+          },
+          "loc": {
+            "end": {
+              "column": 13,
+              "line": 3,
+            },
+            "start": {
+              "column": 4,
+              "line": 3,
+            },
+          },
+          "range": [
+            19,
+            28,
+          ],
+          "start": 19,
+          "type": "VariableDeclarator",
+        },
+      ],
+      "end": 29,
+      "kind": "var",
+      "loc": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 0,
+          "line": 3,
+        },
+      },
+      "range": [
+        15,
+        29,
+      ],
+      "start": 15,
+      "type": "VariableDeclaration",
+    },
+  ],
+  "end": 29,
+  "loc": {
+    "end": {
+      "column": 14,
+      "line": 3,
+    },
+    "start": {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": [
+    0,
+    29,
+  ],
+  "sourceType": "script",
+  "start": 0,
+  "type": "Program",
+}
+`;
+
+exports[`Miscellaneous - JSX > Miscellaneous - JSX (pass) > <a b="x y" />;
+var after = 1; 1`] = `
+{
+  "body": [
+    {
+      "end": 14,
+      "expression": {
+        "children": [],
+        "closingElement": null,
+        "end": 13,
+        "loc": {
+          "end": {
+            "column": 5,
+            "line": 2,
+          },
+          "start": {
+            "column": 0,
+            "line": 1,
+          },
+        },
+        "openingElement": {
+          "attributes": [
+            {
+              "end": 10,
+              "loc": {
+                "end": {
+                  "column": 2,
+                  "line": 2,
+                },
+                "start": {
+                  "column": 3,
+                  "line": 1,
+                },
+              },
+              "name": {
+                "end": 4,
+                "loc": {
+                  "end": {
+                    "column": 4,
+                    "line": 1,
+                  },
+                  "start": {
+                    "column": 3,
+                    "line": 1,
+                  },
+                },
+                "name": "b",
+                "range": [
+                  3,
+                  4,
+                ],
+                "start": 3,
+                "type": "JSXIdentifier",
+              },
+              "range": [
+                3,
+                10,
+              ],
+              "start": 3,
+              "type": "JSXAttribute",
+              "value": {
+                "end": 10,
+                "loc": {
+                  "end": {
+                    "column": 2,
+                    "line": 2,
+                  },
+                  "start": {
+                    "column": 5,
+                    "line": 1,
+                  },
+                },
+                "range": [
+                  5,
+                  10,
+                ],
+                "raw": ""x y"",
+                "start": 5,
+                "type": "Literal",
+                "value": "x y",
+              },
+            },
+          ],
+          "end": 13,
+          "loc": {
+            "end": {
+              "column": 5,
+              "line": 2,
+            },
+            "start": {
+              "column": 0,
+              "line": 1,
+            },
+          },
+          "name": {
+            "end": 2,
+            "loc": {
+              "end": {
+                "column": 2,
+                "line": 1,
+              },
+              "start": {
+                "column": 1,
+                "line": 1,
+              },
+            },
+            "name": "a",
+            "range": [
+              1,
+              2,
+            ],
+            "start": 1,
+            "type": "JSXIdentifier",
+          },
+          "range": [
+            0,
+            13,
+          ],
+          "selfClosing": true,
+          "start": 0,
+          "type": "JSXOpeningElement",
+        },
+        "range": [
+          0,
+          13,
+        ],
+        "start": 0,
+        "type": "JSXElement",
+      },
+      "loc": {
+        "end": {
+          "column": 6,
+          "line": 2,
+        },
+        "start": {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": [
+        0,
+        14,
+      ],
+      "start": 0,
+      "type": "ExpressionStatement",
+    },
+    {
+      "declarations": [
+        {
+          "end": 28,
+          "id": {
+            "end": 24,
+            "loc": {
+              "end": {
+                "column": 9,
+                "line": 3,
+              },
+              "start": {
+                "column": 4,
+                "line": 3,
+              },
+            },
+            "name": "after",
+            "range": [
+              19,
+              24,
+            ],
+            "start": 19,
+            "type": "Identifier",
+          },
+          "init": {
+            "end": 28,
+            "loc": {
+              "end": {
+                "column": 13,
+                "line": 3,
+              },
+              "start": {
+                "column": 12,
+                "line": 3,
+              },
+            },
+            "range": [
+              27,
+              28,
+            ],
+            "raw": "1",
+            "start": 27,
+            "type": "Literal",
+            "value": 1,
+          },
+          "loc": {
+            "end": {
+              "column": 13,
+              "line": 3,
+            },
+            "start": {
+              "column": 4,
+              "line": 3,
+            },
+          },
+          "range": [
+            19,
+            28,
+          ],
+          "start": 19,
+          "type": "VariableDeclarator",
+        },
+      ],
+      "end": 29,
+      "kind": "var",
+      "loc": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 0,
+          "line": 3,
+        },
+      },
+      "range": [
+        15,
+        29,
+      ],
+      "start": 15,
+      "type": "VariableDeclaration",
+    },
+  ],
+  "end": 29,
+  "loc": {
+    "end": {
+      "column": 14,
+      "line": 3,
+    },
+    "start": {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": [
+    0,
+    29,
+  ],
+  "sourceType": "script",
+  "start": 0,
+  "type": "Program",
+}
+`;
+
+exports[`Miscellaneous - JSX > Miscellaneous - JSX (pass) > <a b="x␍␊
+y" />;
+var after = 1; 1`] = `
+{
+  "body": [
+    {
+      "end": 15,
+      "expression": {
+        "children": [],
+        "closingElement": null,
+        "end": 14,
+        "loc": {
+          "end": {
+            "column": 5,
+            "line": 2,
+          },
+          "start": {
+            "column": 0,
+            "line": 1,
+          },
+        },
+        "openingElement": {
+          "attributes": [
+            {
+              "end": 11,
+              "loc": {
+                "end": {
+                  "column": 2,
+                  "line": 2,
+                },
+                "start": {
+                  "column": 3,
+                  "line": 1,
+                },
+              },
+              "name": {
+                "end": 4,
+                "loc": {
+                  "end": {
+                    "column": 4,
+                    "line": 1,
+                  },
+                  "start": {
+                    "column": 3,
+                    "line": 1,
+                  },
+                },
+                "name": "b",
+                "range": [
+                  3,
+                  4,
+                ],
+                "start": 3,
+                "type": "JSXIdentifier",
+              },
+              "range": [
+                3,
+                11,
+              ],
+              "start": 3,
+              "type": "JSXAttribute",
+              "value": {
+                "end": 11,
+                "loc": {
+                  "end": {
+                    "column": 2,
+                    "line": 2,
+                  },
+                  "start": {
+                    "column": 5,
+                    "line": 1,
+                  },
+                },
+                "range": [
+                  5,
+                  11,
+                ],
+                "raw": ""x
+y"",
+                "start": 5,
+                "type": "Literal",
+                "value": "x
+y",
+              },
+            },
+          ],
+          "end": 14,
+          "loc": {
+            "end": {
+              "column": 5,
+              "line": 2,
+            },
+            "start": {
+              "column": 0,
+              "line": 1,
+            },
+          },
+          "name": {
+            "end": 2,
+            "loc": {
+              "end": {
+                "column": 2,
+                "line": 1,
+              },
+              "start": {
+                "column": 1,
+                "line": 1,
+              },
+            },
+            "name": "a",
+            "range": [
+              1,
+              2,
+            ],
+            "start": 1,
+            "type": "JSXIdentifier",
+          },
+          "range": [
+            0,
+            14,
+          ],
+          "selfClosing": true,
+          "start": 0,
+          "type": "JSXOpeningElement",
+        },
+        "range": [
+          0,
+          14,
+        ],
+        "start": 0,
+        "type": "JSXElement",
+      },
+      "loc": {
+        "end": {
+          "column": 6,
+          "line": 2,
+        },
+        "start": {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": [
+        0,
+        15,
+      ],
+      "start": 0,
+      "type": "ExpressionStatement",
+    },
+    {
+      "declarations": [
+        {
+          "end": 29,
+          "id": {
+            "end": 25,
+            "loc": {
+              "end": {
+                "column": 9,
+                "line": 3,
+              },
+              "start": {
+                "column": 4,
+                "line": 3,
+              },
+            },
+            "name": "after",
+            "range": [
+              20,
+              25,
+            ],
+            "start": 20,
+            "type": "Identifier",
+          },
+          "init": {
+            "end": 29,
+            "loc": {
+              "end": {
+                "column": 13,
+                "line": 3,
+              },
+              "start": {
+                "column": 12,
+                "line": 3,
+              },
+            },
+            "range": [
+              28,
+              29,
+            ],
+            "raw": "1",
+            "start": 28,
+            "type": "Literal",
+            "value": 1,
+          },
+          "loc": {
+            "end": {
+              "column": 13,
+              "line": 3,
+            },
+            "start": {
+              "column": 4,
+              "line": 3,
+            },
+          },
+          "range": [
+            20,
+            29,
+          ],
+          "start": 20,
+          "type": "VariableDeclarator",
+        },
+      ],
+      "end": 30,
+      "kind": "var",
+      "loc": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 0,
+          "line": 3,
+        },
+      },
+      "range": [
+        16,
+        30,
+      ],
+      "start": 16,
+      "type": "VariableDeclaration",
+    },
+  ],
+  "end": 30,
+  "loc": {
+    "end": {
+      "column": 14,
+      "line": 3,
+    },
+    "start": {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": [
+    0,
+    30,
+  ],
+  "sourceType": "script",
+  "start": 0,
+  "type": "Program",
+}
+`;
+
+exports[`Miscellaneous - JSX > Miscellaneous - JSX (pass) > <a b="x␍␊y" />;
+var after = 1; 1`] = `
+{
+  "body": [
+    {
+      "end": 14,
+      "expression": {
+        "children": [],
+        "closingElement": null,
+        "end": 13,
+        "loc": {
+          "end": {
+            "column": 5,
+            "line": 2,
+          },
+          "start": {
+            "column": 0,
+            "line": 1,
+          },
+        },
+        "openingElement": {
+          "attributes": [
+            {
+              "end": 10,
+              "loc": {
+                "end": {
+                  "column": 2,
+                  "line": 2,
+                },
+                "start": {
+                  "column": 3,
+                  "line": 1,
+                },
+              },
+              "name": {
+                "end": 4,
+                "loc": {
+                  "end": {
+                    "column": 4,
+                    "line": 1,
+                  },
+                  "start": {
+                    "column": 3,
+                    "line": 1,
+                  },
+                },
+                "name": "b",
+                "range": [
+                  3,
+                  4,
+                ],
+                "start": 3,
+                "type": "JSXIdentifier",
+              },
+              "range": [
+                3,
+                10,
+              ],
+              "start": 3,
+              "type": "JSXAttribute",
+              "value": {
+                "end": 10,
+                "loc": {
+                  "end": {
+                    "column": 2,
+                    "line": 2,
+                  },
+                  "start": {
+                    "column": 5,
+                    "line": 1,
+                  },
+                },
+                "range": [
+                  5,
+                  10,
+                ],
+                "raw": ""x
+y"",
+                "start": 5,
+                "type": "Literal",
+                "value": "x
+y",
+              },
+            },
+          ],
+          "end": 13,
+          "loc": {
+            "end": {
+              "column": 5,
+              "line": 2,
+            },
+            "start": {
+              "column": 0,
+              "line": 1,
+            },
+          },
+          "name": {
+            "end": 2,
+            "loc": {
+              "end": {
+                "column": 2,
+                "line": 1,
+              },
+              "start": {
+                "column": 1,
+                "line": 1,
+              },
+            },
+            "name": "a",
+            "range": [
+              1,
+              2,
+            ],
+            "start": 1,
+            "type": "JSXIdentifier",
+          },
+          "range": [
+            0,
+            13,
+          ],
+          "selfClosing": true,
+          "start": 0,
+          "type": "JSXOpeningElement",
+        },
+        "range": [
+          0,
+          13,
+        ],
+        "start": 0,
+        "type": "JSXElement",
+      },
+      "loc": {
+        "end": {
+          "column": 6,
+          "line": 2,
+        },
+        "start": {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": [
+        0,
+        14,
+      ],
+      "start": 0,
+      "type": "ExpressionStatement",
+    },
+    {
+      "declarations": [
+        {
+          "end": 28,
+          "id": {
+            "end": 24,
+            "loc": {
+              "end": {
+                "column": 9,
+                "line": 3,
+              },
+              "start": {
+                "column": 4,
+                "line": 3,
+              },
+            },
+            "name": "after",
+            "range": [
+              19,
+              24,
+            ],
+            "start": 19,
+            "type": "Identifier",
+          },
+          "init": {
+            "end": 28,
+            "loc": {
+              "end": {
+                "column": 13,
+                "line": 3,
+              },
+              "start": {
+                "column": 12,
+                "line": 3,
+              },
+            },
+            "range": [
+              27,
+              28,
+            ],
+            "raw": "1",
+            "start": 27,
+            "type": "Literal",
+            "value": 1,
+          },
+          "loc": {
+            "end": {
+              "column": 13,
+              "line": 3,
+            },
+            "start": {
+              "column": 4,
+              "line": 3,
+            },
+          },
+          "range": [
+            19,
+            28,
+          ],
+          "start": 19,
+          "type": "VariableDeclarator",
+        },
+      ],
+      "end": 29,
+      "kind": "var",
+      "loc": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 0,
+          "line": 3,
+        },
+      },
+      "range": [
+        15,
+        29,
+      ],
+      "start": 15,
+      "type": "VariableDeclaration",
+    },
+  ],
+  "end": 29,
+  "loc": {
+    "end": {
+      "column": 14,
+      "line": 3,
+    },
+    "start": {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": [
+    0,
+    29,
+  ],
+  "sourceType": "script",
+  "start": 0,
   "type": "Program",
 }
 `;
@@ -5222,7 +6748,7 @@ exports[`Miscellaneous - JSX > Miscellaneous - JSX (pass) > <div attr="&#0123;&h
               "type": "JSXAttribute",
               "value": {
                 "type": "Literal",
-                "value": "&#0123;&hellip;&#x7D;",
+                "value": "{…}",
               },
             },
           ],
@@ -8414,7 +9940,7 @@ exports[`Miscellaneous - JSX > Miscellaneous - JSX (pass) > <p q="Just my &#xA2;
               "type": "JSXAttribute",
               "value": {
                 "type": "Literal",
-                "value": "Just my &#xA2;2",
+                "value": "Just my ¢2",
               },
             },
           ],
@@ -9210,7 +10736,7 @@ exports[`Miscellaneous - JSX > Miscellaneous - JSX (pass) > <x y="&#123abc &#123
               "type": "JSXAttribute",
               "value": {
                 "type": "Literal",
-                "value": "&#123abc &#123;",
+                "value": "&#123abc {",
               },
             },
           ],

--- a/test/parser/miscellaneous/jsx.ts
+++ b/test/parser/miscellaneous/jsx.ts
@@ -1,6 +1,7 @@
 import * as t from 'node:assert/strict';
 import { outdent } from 'outdent';
 import { describe, it } from 'vitest';
+import type * as ESTree from '../../../src/estree.ts';
 import { parseSource } from '../../../src/parser.ts';
 import { fail, pass } from '../../test-utils.ts';
 
@@ -34,6 +35,50 @@ describe('Miscellaneous - JSX', () => {
       t.doesNotThrow(() => {
         parseSource(text, { jsx: true, webcompat: true });
       });
+    });
+  }
+
+  // Line terminators inside a JSX attribute value have to be counted, or every
+  // location after the attribute is wrong. https://github.com/meriyah/meriyah/issues/90
+  for (const [name, separator] of [
+    ['<LF>', '\n'],
+    ['<CR>', '\r'],
+    ['<CR><LF>', '\r\n'],
+    ['<LS>', '\u2028'],
+    ['<PS>', '\u2029'],
+  ] as const) {
+    it(`${name} in a JSX attribute value counts as one line`, () => {
+      // The attribute value holds one line terminator, `var after = 1;` follows
+      // one more, so the program ends on line 3.
+      const { loc } = parseSource(`<a b="x${separator}y" />;\nvar after = 1;`, { jsx: true, loc: true });
+
+      t.equal(loc?.end.line, 3);
+      t.equal(loc?.end.column, 14);
+    });
+  }
+
+  // `nextJSXToken` decodes HTML entities in JSX text, `scanJSXString` has to do
+  // the same for attribute values. https://github.com/meriyah/meriyah/issues/133
+  for (const [attributeValue, value] of [
+    ['&amp;', '&'],
+    ['&#38;', '&'],
+    ['&#x26;', '&'],
+    ['&nbsp;', '\u00a0'],
+    ['&#0123;&hellip;&#x7D;', '{…}'],
+    // Not entities, kept as is
+    ['&notanentity;', '&notanentity;'],
+    ['&amp', '&amp'],
+    ['&#;', '&#;'],
+  ] as const) {
+    it(`decodes ${attributeValue} in a JSX attribute value`, () => {
+      const ast = parseSource(`<a b="${attributeValue}" />`, { jsx: true, raw: true });
+      const element = (ast.body[0] as ESTree.ExpressionStatement).expression as ESTree.JSXElement;
+      const attribute = element.openingElement.attributes[0] as ESTree.JSXAttribute;
+      const literal = attribute.value as ESTree.StringLiteral;
+
+      t.equal(literal.value, value);
+      // The raw text is the source slice, decoding must not touch it
+      t.equal(literal.raw, `"${attributeValue}"`);
     });
   }
 
@@ -125,6 +170,9 @@ describe('Miscellaneous - JSX', () => {
     { code: '<div=/>', options: { jsx: true } },
     { code: '<div =/>', options: { jsx: true } },
     { code: '<div=+-%&([)]}.../>', options: { jsx: true } },
+    // The error location has to account for the line terminator in the attribute value
+    { code: '<a b="x\ny', options: { jsx: true } },
+    { code: '<a b="x\r\ny"', options: { jsx: true } },
   ]);
 
   pass('Miscellaneous - JSX (pass)', [
@@ -275,6 +323,12 @@ describe('Miscellaneous - JSX', () => {
     { code: '<x y="&#123abc &#123;" />', options: { jsx: true } },
     { code: '<a b="&#xA2; &#x00A3;"/>', options: { jsx: true } },
     { code: '<p q="Just my &#xA2;2" />', options: { jsx: true } },
+    { code: '<a b="&amp;&#38;&#x26;" />;\nvar after = 1;', options: { jsx: true, ranges: true, loc: true, raw: true } },
+    { code: '<a b="x\ny" />;\nvar after = 1;', options: { jsx: true, ranges: true, loc: true, raw: true } },
+    { code: '<a b="x\ry" />;\nvar after = 1;', options: { jsx: true, ranges: true, loc: true, raw: true } },
+    { code: '<a b="x\r\ny" />;\nvar after = 1;', options: { jsx: true, ranges: true, loc: true, raw: true } },
+    { code: '<a b="x\u2028y" />;\nvar after = 1;', options: { jsx: true, ranges: true, loc: true, raw: true } },
+    { code: '<a b="x\u2029y" />;\nvar after = 1;', options: { jsx: true, ranges: true, loc: true, raw: true } },
     { code: 'class C {  static a = <C.z></C.z> }', options: { jsx: true } },
 
     { code: '<n:a n:v />', options: { jsx: true } },


### PR DESCRIPTION
`scanJSXString` left `parser.line` unchanged when a JSX attribute value contained a line terminator, so the literal and every following node kept the wrong location — the same failure shape reported in #90. It also returned raw entity text instead of the strict decode already used for JSX text, following the #133 trail.

This counts LF, CR, CRLF, LS, and PS with the line-tracking idioms already used by `scanString`, then decodes the source slice with `decodeHTMLStrict` as `nextJSXToken` does. `Literal.raw`, byte ranges, and program acceptance stay unchanged; two error positions move to the correct line while their type and message stay the same.

The JSX alignment harness built an acorn-jsx parser but called plain acorn, so it compared 1 of 47 cases and skipped 46 before Meriyah ran. It now compares 40 with an exact-count assertion, while the test262 alignment harness adds a 40,000-fixture floor alongside its retained 90% comparison floor. The harness repair and parser fixes stay together because arming the harness alone makes cases `0010`, `0013`, and `0035` fail.

The focused oracle checks move 5 of 5 terminator forms and 12 of 12 valid entities into agreement with both acorn-jsx and Babel. Across Node 20/22/24/26, the plain suites pass with 91,757/91,757/91,759/91,759 tests, TEST262 with 91,760/91,760/91,762/91,762, and CI with 91,766/91,766/91,768/91,768; `npm run lint`, `npm run lint:snapshots`, `npm run build`, and `npm run production-test` also pass. The test262 whitelist is untouched.

On Node 22, the `dist/meriyah.mjs` parse benchmark was 8.95% slower at the median on a 1.62 MB attribute-heavy JSX corpus, with head slower in 7 of 7 alternating sweeps and a +6.17% to +26.20% range. The 47-case general JSX leg crossed zero (-10.22% to +9.27%), so I do not treat it as a stable directional result.

`0044-16f0.jsx` remains intentionally unaligned because Meriyah uses the full WHATWG entity table chosen in #133 while acorn-jsx leaves `&rbrace;` raw. The exact 40-case assertion is a hand-maintained ratchet over the version-pinned `jsx-test-suite`, in the same shape as #578.
