### PR TITLE
fix(parser): allow constructor/accessor identifiers and using arrows

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1736,9 +1736,9 @@ function parseUsingDeclarationOrExpressionStatement(
   labels: ESTree.Labels,
   origin: Origin,
 ): ESTree.VariableDeclaration | ESTree.LabeledStatement | ESTree.ExpressionStatement {
-  const { tokenStart, tokenValue } = parser;
+  const { tokenStart, tokenValue, currentLocation } = parser;
   const token = parser.getToken();
-  const expression = parseIdentifier(parser, context);
+  let expression: ESTree.Identifier | ESTree.Expression = parseIdentifier(parser, context);
 
   if ((parser.flags & Flags.NewLine) === 0 && isResourceBindingStart(parser.getToken())) {
     if (
@@ -1764,6 +1764,28 @@ function parseUsingDeclarationOrExpressionStatement(
   }
 
   parser.assignable = AssignmentTargetKind.Simple;
+
+  if (parser.getToken() === Token.Arrow) {
+    let arrowScope: Scope | undefined = void 0;
+
+    if (parser.options.lexical)
+      arrowScope = createArrowHeadParsingScope(parser, context, tokenValue, tokenStart, currentLocation);
+
+    parser.flags = (parser.flags | Flags.NonSimpleParameterList) ^ Flags.NonSimpleParameterList;
+
+    expression = parseArrowFunctionExpression(
+      parser,
+      context,
+      arrowScope,
+      privateScope,
+      [expression],
+      /* isAsync */ 0,
+      tokenStart,
+    );
+
+    return parseExpressionStatement(parser, context, expression, tokenStart);
+  }
+
   return finishExpressionOrLabelledStatement(
     parser,
     context,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1738,7 +1738,7 @@ function parseUsingDeclarationOrExpressionStatement(
 ): ESTree.VariableDeclaration | ESTree.LabeledStatement | ESTree.ExpressionStatement {
   const { tokenStart, tokenValue, currentLocation } = parser;
   const token = parser.getToken();
-  let expression: ESTree.Identifier | ESTree.Expression = parseIdentifier(parser, context);
+  const expression = parseIdentifier(parser, context);
 
   if ((parser.flags & Flags.NewLine) === 0 && isResourceBindingStart(parser.getToken())) {
     if (
@@ -1773,7 +1773,7 @@ function parseUsingDeclarationOrExpressionStatement(
 
     parser.flags = (parser.flags | Flags.NonSimpleParameterList) ^ Flags.NonSimpleParameterList;
 
-    expression = parseArrowFunctionExpression(
+    const arrow = parseArrowFunctionExpression(
       parser,
       context,
       arrowScope,
@@ -1783,7 +1783,7 @@ function parseUsingDeclarationOrExpressionStatement(
       tokenStart,
     );
 
-    return parseExpressionStatement(parser, context, expression, tokenStart);
+    return parseExpressionStatement(parser, context, arrow, tokenStart);
   }
 
   return finishExpressionOrLabelledStatement(

--- a/src/token.ts
+++ b/src/token.ts
@@ -162,10 +162,10 @@ export const enum Token {
   AsKeyword          = 108 | Contextual | IsExpressionStart,
   AsyncKeyword       = 109 | Contextual | IsExpressionStart | IsIdentifier,
   AwaitKeyword       = 110 | Contextual | IsExpressionStart | IsIdentifier, // await is only reserved word in async functions or modules
-  ConstructorKeyword = 111 | Contextual,
+  ConstructorKeyword = 111 | Contextual | IsExpressionStart | IsIdentifier,
   GetKeyword         = 112 | Contextual | IsExpressionStart | IsIdentifier,
   SetKeyword         = 113 | Contextual | IsExpressionStart | IsIdentifier,
-  AccessorKeyword    = 114 | Contextual,
+  AccessorKeyword    = 114 | Contextual | IsExpressionStart | IsIdentifier,
   FromKeyword        = 115 | Contextual | IsExpressionStart | IsIdentifier,
   OfKeyword          = 116 | Contextual | IsInOrOf | IsExpressionStart | IsIdentifier,
   UsingKeyword       = 117 | Contextual | IsExpressionStart | IsIdentifier,

--- a/test/parser/expressions/await.ts
+++ b/test/parser/expressions/await.ts
@@ -43,6 +43,8 @@ describe('Expressions - Await', () => {
     'async function a() { await from }',
     'async function a() { await get }',
     'async function a() { await set }',
+    'async function a() { await constructor }',
+    'async function a() { await accessor }',
     'async function a() { await of }',
     'async function a() { await target }',
     'async function a() { await meta }',
@@ -65,6 +67,17 @@ describe('Expressions - Await', () => {
       });
     });
   }
+
+  it('keeps constructor and accessor class-body forms unchanged', () => {
+    for (const { code, options } of [
+      { code: 'class C { constructor() {} }', options: {} },
+      { code: 'class C{accessor x=1}', options: { next: true } },
+      { code: 'class C{accessor}', options: {} },
+      { code: 'class C{accessor=1}', options: {} },
+    ]) {
+      t.doesNotThrow(() => parseSource(code, options));
+    }
+  });
 
   for (const text of [
     '[await]',

--- a/test/parser/statements/using/__snapshots__/using.ts.snap
+++ b/test/parser/statements/using/__snapshots__/using.ts.snap
@@ -1,0 +1,29 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Statements - invalid using arrow expressions > async function f() { await using => 0; } 1`] = `
+"SyntaxError [1:33-1:35]: Unexpected token: '=>'
+> 1 | async function f() { await using => 0; }
+    |                                  ^^ Unexpected token: '=>'"
+`;
+
+exports[`Statements - invalid using arrow expressions > await using
+=> 0 1`] = `
+"SyntaxError [2:0-2:2]: Unexpected token: '=>'
+  1 | await using
+> 2 | => 0
+    | ^^ Unexpected token: '=>'"
+`;
+
+exports[`Statements - invalid using arrow expressions > await using => 0 1`] = `
+"SyntaxError [1:12-1:14]: Unexpected token: '=>'
+> 1 | await using => 0
+    |             ^^ Unexpected token: '=>'"
+`;
+
+exports[`Statements - invalid using arrow expressions > using
+=> 0 1`] = `
+"SyntaxError [2:0-2:2]: No line break is allowed after '=>'
+  1 | using
+> 2 | => 0
+    | ^^ No line break is allowed after '=>'"
+`;

--- a/test/parser/statements/using/using.ts
+++ b/test/parser/statements/using/using.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { type Options } from '../../../../src/options.ts';
 import { parseSource } from '../../../../src/parser.ts';
+import { fail } from '../../../test-utils.ts';
 
 const moduleOptions: Options = { sourceType: 'module' };
 const commonjsOptions: Options = { sourceType: 'commonjs' };
@@ -103,6 +104,36 @@ describe('Statements - using declarations', () => {
     ).not.toThrow();
   });
 
+  it('parses using as a bare arrow parameter at statement position', () => {
+    for (const lexical of [false, true]) {
+      const expressionBody = parseSource('using => 0', { lexical });
+      const blockBody = parseSource('using => {}', { lexical });
+
+      expect(expressionBody.body[0]).toMatchObject({
+        type: 'ExpressionStatement',
+        expression: {
+          type: 'ArrowFunctionExpression',
+          params: [{ type: 'Identifier', name: 'using' }],
+          body: { type: 'Literal', value: 0 },
+        },
+      });
+      expect(blockBody.body[0]).toMatchObject({
+        type: 'ExpressionStatement',
+        expression: {
+          type: 'ArrowFunctionExpression',
+          params: [{ type: 'Identifier', name: 'using' }],
+          body: { type: 'BlockStatement' },
+        },
+      });
+    }
+  });
+
+  it('keeps existing using arrow expression positions valid', () => {
+    for (const code of ['(using) => 0', 'x = using => 0', 'f(using => 0)', 'if (1) using => 0']) {
+      expect(() => parseSource(code)).not.toThrow();
+    }
+  });
+
   it('keeps using followed by property access out of the declaration grammar', () => {
     expect(() => parseSource('var using = []; using[index] = value;')).not.toThrow();
     expect(() => parseSource('async function f() { var using = []; await using[index]; }')).not.toThrow();
@@ -189,3 +220,10 @@ describe('Statements - using declarations', () => {
     });
   }
 });
+
+fail('Statements - invalid using arrow expressions', [
+  { code: 'await using => 0', options: moduleOptions },
+  'async function f() { await using => 0; }',
+  'using\n=> 0',
+  { code: 'await using\n=> 0', options: moduleOptions },
+]);


### PR DESCRIPTION
Finishes #377 for the two contextual keywords it did not retag: `constructor` and `accessor` now carry `IsExpressionStart | IsIdentifier`, matching `get`, `set`, `from`, and `of`. Without those flags, `await accessor` and `await constructor` collapsed to identifier-`await` and valid module and async forms errored under default parser options; `accessor` later inherited the same gap when auto-accessor support copied the `constructor` token shape. Four unique current `monaco-editor` files fail on published code such as `await accessor.get(...)` today, and all four parse with this change.

The post-fix contextual-keyword check left one residual divergence: bare `using => 0` and `using => {}` still failed at statement position. The statement path now uses the same arrow continuation as `let`, while the other `using` arrow positions and newline rule stay unchanged. `using` came from my #579 work, so this also locks a bug I found in that implementation. `await using => 0` deliberately stays a SyntaxError with `fail()` coverage — V8 and acorn reject it because an arrow used as an `await` operand needs parentheses. Setting `IsIdentifier` also makes `using constructor = x` and `using accessor = x` resource declarations; V8 and Babel accept both bindings.

The base-vs-fixed blast-radius probe covered all 43 `IsExpressionStart` / `IsIdentifier` read sites across 50 families: only eight intended flag deltas moved, with no Node-rejected acceptance. The plain, test262, and CI suites passed across Node 20, 22, 24, and 26 with up to 91,760 tests, along with lint, snapshot lint, build, and production tests; the test262 whitelist was unchanged.
