### PR TITLE
fix(parser): restrict private identifiers to in expressions

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3897,45 +3897,24 @@ function parseAwaitExpressionOrIdentifier(
 
   if (isIdentifier) {
     if (context & Context.InAwaitContext)
-      throw new ParseError(
-        start,
-        { index: parser.startIndex, line: parser.startLine, column: parser.startColumn },
-        Errors.InvalidAwaitAsIdentifier,
-      );
+      throw new ParseError(start, parser.startPosition, Errors.InvalidAwaitAsIdentifier);
     if (context & Context.Module)
-      throw new ParseError(
-        start,
-        { index: parser.startIndex, line: parser.startLine, column: parser.startColumn },
-        Errors.AwaitIdentInModuleOrAsyncFunc,
-      );
+      throw new ParseError(start, parser.startPosition, Errors.AwaitIdentInModuleOrAsyncFunc);
 
     if (context & Context.InArgumentList && context & Context.InAwaitContext)
-      throw new ParseError(
-        start,
-        { index: parser.startIndex, line: parser.startLine, column: parser.startColumn },
-        Errors.AwaitIdentInModuleOrAsyncFunc,
-      );
+      throw new ParseError(start, parser.startPosition, Errors.AwaitIdentInModuleOrAsyncFunc);
     // "await" can be identifier out of async func.
     return possibleIdentifierOrArrowFunc;
   }
 
   // "await" is start of await expression.
   if (context & Context.InArgumentList) {
-    throw new ParseError(
-      start,
-      { index: parser.startIndex, line: parser.startLine, column: parser.startColumn },
-      Errors.AwaitInParameter,
-    );
+    throw new ParseError(start, parser.startPosition, Errors.AwaitInParameter);
   }
 
   // await expression is only allowed in async func or at module top level.
   if (context & Context.InAwaitContext || (context & Context.Module && context & Context.InGlobal)) {
-    if (inNew)
-      throw new ParseError(
-        start,
-        { index: parser.startIndex, line: parser.startLine, column: parser.startColumn },
-        Errors.Unexpected,
-      );
+    if (inNew) throw new ParseError(start, parser.startPosition, Errors.Unexpected);
 
     const argument = parseLeftHandSideExpression(parser, context, privateScope, 0, 0, 1);
 
@@ -3952,12 +3931,7 @@ function parseAwaitExpressionOrIdentifier(
     );
   }
 
-  if (context & Context.Module)
-    throw new ParseError(
-      start,
-      { index: parser.startIndex, line: parser.startLine, column: parser.startColumn },
-      Errors.AwaitOutsideAsync,
-    );
+  if (context & Context.Module) throw new ParseError(start, parser.startPosition, Errors.AwaitOutsideAsync);
   // Fallback to identifier in script mode
   return possibleIdentifierOrArrowFunc;
 }
@@ -4667,7 +4641,7 @@ function parsePrimaryExpression(
       const { tokenStart } = parser;
       const expression = parsePrivateIdentifier(parser, context, privateScope, PropertyKind.None);
       if (parser.getToken() !== Token.InKeyword) {
-        throw new ParseError(tokenStart, parser.currentLocation, Errors.UnexpectedPrivateField);
+        throw new ParseError(tokenStart, parser.startPosition, Errors.UnexpectedPrivateField);
       }
       return expression;
     }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -4664,9 +4664,14 @@ function parsePrimaryExpression(
       return parseBigIntLiteral(parser, context);
     case Token.PrivateField: {
       if (!allowPrivateId) parser.report(Errors.UnexpectedToken, 'PrivateField');
+      const { tokenStart } = parser;
       const expression = parsePrivateIdentifier(parser, context, privateScope, PropertyKind.None);
       if (parser.getToken() !== Token.InKeyword) {
-        parser.report(Errors.UnexpectedToken, KeywordDescTable[parser.getToken() & Token.Type]);
+        throw new ParseError(
+          tokenStart,
+          { index: parser.startIndex, line: parser.startLine, column: parser.startColumn },
+          Errors.UnexpectedPrivateField,
+        );
       }
       return expression;
     }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -4667,11 +4667,7 @@ function parsePrimaryExpression(
       const { tokenStart } = parser;
       const expression = parsePrivateIdentifier(parser, context, privateScope, PropertyKind.None);
       if (parser.getToken() !== Token.InKeyword) {
-        throw new ParseError(
-          tokenStart,
-          { index: parser.startIndex, line: parser.startLine, column: parser.startColumn },
-          Errors.UnexpectedPrivateField,
-        );
+        throw new ParseError(tokenStart, parser.currentLocation, Errors.UnexpectedPrivateField);
       }
       return expression;
     }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -465,7 +465,19 @@ function parseExpressionOrLabelledStatement(
       break;
 
     default:
-      expr = parsePrimaryExpression(parser, context, privateScope, BindingKind.Empty, 0, 1, 0, 1, parser.tokenStart);
+      expr = parsePrimaryExpression(
+        parser,
+        context,
+        privateScope,
+        BindingKind.Empty,
+        0,
+        1,
+        0,
+        1,
+        parser.tokenStart,
+        Origin.None,
+        1,
+      );
   }
 
   return finishExpressionOrLabelledStatement(
@@ -3371,6 +3383,7 @@ function parseExpression(
     1,
     start,
     origin,
+    context & Context.DisallowIn ? 0 : 1,
   );
 
   expr = parseMemberOrUpdateExpression(parser, context, privateScope, expr, inGroup, 0, start);
@@ -3659,7 +3672,15 @@ function parseBinaryExpression(
           parser.tokenStart,
           precedence,
           t,
-          parseLeftHandSideExpression(parser, context, privateScope, 0, inGroup, 1),
+          parseLeftHandSideExpression(
+            parser,
+            context,
+            privateScope,
+            0,
+            inGroup,
+            1,
+            (context & Context.DisallowIn) === 0 && (Token.InKeyword & Token.Precedence) > precedence ? 1 : 0,
+          ),
         ),
         operator: KeywordDescTable[t & Token.Type],
       },
@@ -4096,6 +4117,7 @@ function parseLeftHandSideExpression(
   canAssign: 0 | 1,
   inGroup: 0 | 1,
   isLHS: 0 | 1,
+  allowPrivateId: 0 | 1 = 0,
 ): ESTree.Expression {
   // LeftHandSideExpression ::
   //   (PrimaryExpression | MemberExpression) ...
@@ -4111,6 +4133,8 @@ function parseLeftHandSideExpression(
     inGroup,
     isLHS,
     start,
+    Origin.None,
+    allowPrivateId,
   );
 
   return parseMemberOrUpdateExpression(parser, context, privateScope, expression, inGroup, 0, start);
@@ -4180,7 +4204,7 @@ function parseMemberOrUpdateExpression(
             ? AssignmentTargetKind.Invalid
             : AssignmentTargetKind.Simple;
 
-        const property = parsePropertyOrPrivatePropertyName(parser, context | Context.TaggedTemplate, privateScope);
+        const property = parsePropertyOrPrivatePropertyName(parser, context | Context.TaggedTemplate, privateScope, 1);
 
         expr = parser.finishNode<ESTree.MemberExpression>(
           {
@@ -4377,7 +4401,7 @@ function parseOptionalChain(
       start,
     );
   } else {
-    const property = parsePropertyOrPrivatePropertyName(parser, context, privateScope);
+    const property = parsePropertyOrPrivatePropertyName(parser, context, privateScope, 1);
     parser.assignable = AssignmentTargetKind.Invalid;
     node = parser.finishNode<ESTree.MemberExpression>(
       {
@@ -4407,12 +4431,13 @@ function parsePropertyOrPrivatePropertyName(
   parser: Parser,
   context: Context,
   privateScope: PrivateScope | undefined,
+  allowPrivateId: 0 | 1 = 0,
 ): any {
   if (
     (parser.getToken() & Token.IsIdentifier) === 0 &&
     parser.getToken() !== Token.EscapedReserved &&
     parser.getToken() !== Token.EscapedFutureReserved &&
-    parser.getToken() !== Token.PrivateField
+    (parser.getToken() !== Token.PrivateField || !allowPrivateId)
   ) {
     parser.report(Errors.InvalidDotProperty);
   }
@@ -4491,6 +4516,7 @@ function parsePrimaryExpression(
   isLHS: 0 | 1,
   start: Location,
   origin: Origin = Origin.None,
+  allowPrivateId: 0 | 1 = 0,
 ): any {
   // PrimaryExpression ::
   //   'this'
@@ -4636,8 +4662,14 @@ function parsePrimaryExpression(
       return parseNewExpression(parser, context, privateScope, inGroup);
     case Token.BigIntLiteral:
       return parseBigIntLiteral(parser, context);
-    case Token.PrivateField:
-      return parsePrivateIdentifier(parser, context, privateScope, PropertyKind.None);
+    case Token.PrivateField: {
+      if (!allowPrivateId) parser.report(Errors.UnexpectedToken, 'PrivateField');
+      const expression = parsePrivateIdentifier(parser, context, privateScope, PropertyKind.None);
+      if (parser.getToken() !== Token.InKeyword) {
+        parser.report(Errors.UnexpectedToken, KeywordDescTable[parser.getToken() & Token.Type]);
+      }
+      return expression;
+    }
     case Token.ImportKeyword:
       return parseImportCallOrMetaExpression(parser, context, privateScope, inNew, inGroup, start);
     case Token.LessThan:
@@ -7725,7 +7757,7 @@ function parseMemberExpressionNoCall(
 
       parser.assignable = AssignmentTargetKind.Simple;
 
-      const property = parsePropertyOrPrivatePropertyName(parser, context, privateScope);
+      const property = parsePropertyOrPrivatePropertyName(parser, context, privateScope, 1);
 
       return parseMemberExpressionNoCall(
         parser,
@@ -8464,7 +8496,7 @@ function parseDecorator(parser: Parser, context: Context, privateScope: PrivateS
     while (parser.getToken() === Token.Period) {
       nextToken(parser, (context | Context.AllowEscapedKeyword | Context.InGlobal) ^ Context.InGlobal);
 
-      const property = parsePropertyOrPrivatePropertyName(parser, context | Context.TaggedTemplate, privateScope);
+      const property = parsePropertyOrPrivatePropertyName(parser, context | Context.TaggedTemplate, privateScope, 1);
 
       memberExpression = parser.finishNode<ESTree.MemberExpression>(
         {
@@ -8944,6 +8976,8 @@ function parsePropertyDefinition(
       0,
       1,
       tokenStart,
+      Origin.None,
+      1,
     );
 
     if (

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -222,6 +222,14 @@ export class Parser {
     };
   }
 
+  get startPosition(): Location {
+    return {
+      index: this.startIndex,
+      line: this.startLine,
+      column: this.startColumn,
+    };
+  }
+
   get currentLocation(): Location {
     return { index: this.index, line: this.line, column: this.column };
   }

--- a/test/parser/expressions/__snapshots__/in.ts.snap
+++ b/test/parser/expressions/__snapshots__/in.ts.snap
@@ -195,18 +195,18 @@ class C { #field; m() { #field in #field in this; } } 1`] = `
 
 exports[`Expressions -In > Private identifiers outside in expressions (module with directive) > 'use strict';
 class C { #x; m() { #x; } } 1`] = `
-"SyntaxError [2:22-2:23]: Unexpected token: ';'
+"SyntaxError [2:20-2:22]: Unexpected private field
   1 | 'use strict';
 > 2 | class C { #x; m() { #x; } }
-    |                       ^ Unexpected token: ';'"
+    |                     ^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (module with directive) > 'use strict';
 class C { #x; m() { (#x); } } 1`] = `
-"SyntaxError [2:23-2:24]: Unexpected token: ')'
+"SyntaxError [2:21-2:23]: Unexpected private field
   1 | 'use strict';
 > 2 | class C { #x; m() { (#x); } }
-    |                        ^ Unexpected token: ')'"
+    |                      ^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (module with directive) > 'use strict';
@@ -227,10 +227,10 @@ class C { #x; m() { [#x]; } } 1`] = `
 
 exports[`Expressions -In > Private identifiers outside in expressions (module with directive) > 'use strict';
 class C { #x; m() { \`\${#x}\`; } } 1`] = `
-"SyntaxError [2:25-2:26]: Unexpected token: '}'
+"SyntaxError [2:23-2:25]: Unexpected private field
   1 | 'use strict';
 > 2 | class C { #x; m() { \`\${#x}\`; } }
-    |                          ^ Unexpected token: '}'"
+    |                        ^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (module with directive) > 'use strict';
@@ -256,15 +256,15 @@ exports[`Expressions -In > Private identifiers outside in expressions (module) >
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (module) > class C { #x; m() { #x; } } 1`] = `
-"SyntaxError [1:22-1:23]: Unexpected token: ';'
+"SyntaxError [1:20-1:22]: Unexpected private field
 > 1 | class C { #x; m() { #x; } }
-    |                       ^ Unexpected token: ';'"
+    |                     ^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (module) > class C { #x; m() { (#x); } } 1`] = `
-"SyntaxError [1:23-1:24]: Unexpected token: ')'
+"SyntaxError [1:21-1:23]: Unexpected private field
 > 1 | class C { #x; m() { (#x); } }
-    |                        ^ Unexpected token: ')'"
+    |                      ^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (module) > class C { #x; m() { ({ value: #x }); } } 1`] = `
@@ -280,9 +280,9 @@ exports[`Expressions -In > Private identifiers outside in expressions (module) >
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (module) > class C { #x; m() { \`\${#x}\`; } } 1`] = `
-"SyntaxError [1:25-1:26]: Unexpected token: '}'
+"SyntaxError [1:23-1:25]: Unexpected private field
 > 1 | class C { #x; m() { \`\${#x}\`; } }
-    |                          ^ Unexpected token: '}'"
+    |                        ^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (module) > class C { #x; m() { for (#x in []) {} } } 1`] = `
@@ -304,15 +304,15 @@ exports[`Expressions -In > Private identifiers outside in expressions (script sl
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (script sloppy) > class C { #x; m() { #x; } } 1`] = `
-"SyntaxError [1:22-1:23]: Unexpected token: ';'
+"SyntaxError [1:20-1:22]: Unexpected private field
 > 1 | class C { #x; m() { #x; } }
-    |                       ^ Unexpected token: ';'"
+    |                     ^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (script sloppy) > class C { #x; m() { (#x); } } 1`] = `
-"SyntaxError [1:23-1:24]: Unexpected token: ')'
+"SyntaxError [1:21-1:23]: Unexpected private field
 > 1 | class C { #x; m() { (#x); } }
-    |                        ^ Unexpected token: ')'"
+    |                      ^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (script sloppy) > class C { #x; m() { ({ value: #x }); } } 1`] = `
@@ -328,9 +328,9 @@ exports[`Expressions -In > Private identifiers outside in expressions (script sl
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (script sloppy) > class C { #x; m() { \`\${#x}\`; } } 1`] = `
-"SyntaxError [1:25-1:26]: Unexpected token: '}'
+"SyntaxError [1:23-1:25]: Unexpected private field
 > 1 | class C { #x; m() { \`\${#x}\`; } }
-    |                          ^ Unexpected token: '}'"
+    |                        ^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (script sloppy) > class C { #x; m() { for (#x in []) {} } } 1`] = `
@@ -355,18 +355,18 @@ class C { #field; m() { #field in #field in this; } } 1`] = `
 
 exports[`Expressions -In > Private identifiers outside in expressions (script strict) > 'use strict';
 class C { #x; m() { #x; } } 1`] = `
-"SyntaxError [2:22-2:23]: Unexpected token: ';'
+"SyntaxError [2:20-2:22]: Unexpected private field
   1 | 'use strict';
 > 2 | class C { #x; m() { #x; } }
-    |                       ^ Unexpected token: ';'"
+    |                     ^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (script strict) > 'use strict';
 class C { #x; m() { (#x); } } 1`] = `
-"SyntaxError [2:23-2:24]: Unexpected token: ')'
+"SyntaxError [2:21-2:23]: Unexpected private field
   1 | 'use strict';
 > 2 | class C { #x; m() { (#x); } }
-    |                        ^ Unexpected token: ')'"
+    |                      ^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (script strict) > 'use strict';
@@ -387,10 +387,10 @@ class C { #x; m() { [#x]; } } 1`] = `
 
 exports[`Expressions -In > Private identifiers outside in expressions (script strict) > 'use strict';
 class C { #x; m() { \`\${#x}\`; } } 1`] = `
-"SyntaxError [2:25-2:26]: Unexpected token: '}'
+"SyntaxError [2:23-2:25]: Unexpected private field
   1 | 'use strict';
 > 2 | class C { #x; m() { \`\${#x}\`; } }
-    |                          ^ Unexpected token: '}'"
+    |                        ^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (script strict) > 'use strict';

--- a/test/parser/expressions/__snapshots__/in.ts.snap
+++ b/test/parser/expressions/__snapshots__/in.ts.snap
@@ -195,18 +195,18 @@ class C { #field; m() { #field in #field in this; } } 1`] = `
 
 exports[`Expressions -In > Private identifiers outside in expressions (module with directive) > 'use strict';
 class C { #x; m() { #x; } } 1`] = `
-"SyntaxError [2:20-2:23]: Unexpected private field
+"SyntaxError [2:20-2:22]: Unexpected private field
   1 | 'use strict';
 > 2 | class C { #x; m() { #x; } }
-    |                     ^^^ Unexpected private field"
+    |                     ^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (module with directive) > 'use strict';
 class C { #x; m() { (#x); } } 1`] = `
-"SyntaxError [2:21-2:24]: Unexpected private field
+"SyntaxError [2:21-2:23]: Unexpected private field
   1 | 'use strict';
 > 2 | class C { #x; m() { (#x); } }
-    |                      ^^^ Unexpected private field"
+    |                      ^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (module with directive) > 'use strict';
@@ -227,10 +227,10 @@ class C { #x; m() { [#x]; } } 1`] = `
 
 exports[`Expressions -In > Private identifiers outside in expressions (module with directive) > 'use strict';
 class C { #x; m() { \`\${#x}\`; } } 1`] = `
-"SyntaxError [2:23-2:26]: Unexpected private field
+"SyntaxError [2:23-2:25]: Unexpected private field
   1 | 'use strict';
 > 2 | class C { #x; m() { \`\${#x}\`; } }
-    |                        ^^^ Unexpected private field"
+    |                        ^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (module with directive) > 'use strict';
@@ -256,15 +256,15 @@ exports[`Expressions -In > Private identifiers outside in expressions (module) >
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (module) > class C { #x; m() { #x; } } 1`] = `
-"SyntaxError [1:20-1:23]: Unexpected private field
+"SyntaxError [1:20-1:22]: Unexpected private field
 > 1 | class C { #x; m() { #x; } }
-    |                     ^^^ Unexpected private field"
+    |                     ^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (module) > class C { #x; m() { (#x); } } 1`] = `
-"SyntaxError [1:21-1:24]: Unexpected private field
+"SyntaxError [1:21-1:23]: Unexpected private field
 > 1 | class C { #x; m() { (#x); } }
-    |                      ^^^ Unexpected private field"
+    |                      ^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (module) > class C { #x; m() { ({ value: #x }); } } 1`] = `
@@ -280,9 +280,9 @@ exports[`Expressions -In > Private identifiers outside in expressions (module) >
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (module) > class C { #x; m() { \`\${#x}\`; } } 1`] = `
-"SyntaxError [1:23-1:26]: Unexpected private field
+"SyntaxError [1:23-1:25]: Unexpected private field
 > 1 | class C { #x; m() { \`\${#x}\`; } }
-    |                        ^^^ Unexpected private field"
+    |                        ^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (module) > class C { #x; m() { for (#x in []) {} } } 1`] = `
@@ -304,15 +304,15 @@ exports[`Expressions -In > Private identifiers outside in expressions (script sl
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (script sloppy) > class C { #x; m() { #x; } } 1`] = `
-"SyntaxError [1:20-1:23]: Unexpected private field
+"SyntaxError [1:20-1:22]: Unexpected private field
 > 1 | class C { #x; m() { #x; } }
-    |                     ^^^ Unexpected private field"
+    |                     ^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (script sloppy) > class C { #x; m() { (#x); } } 1`] = `
-"SyntaxError [1:21-1:24]: Unexpected private field
+"SyntaxError [1:21-1:23]: Unexpected private field
 > 1 | class C { #x; m() { (#x); } }
-    |                      ^^^ Unexpected private field"
+    |                      ^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (script sloppy) > class C { #x; m() { ({ value: #x }); } } 1`] = `
@@ -328,9 +328,9 @@ exports[`Expressions -In > Private identifiers outside in expressions (script sl
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (script sloppy) > class C { #x; m() { \`\${#x}\`; } } 1`] = `
-"SyntaxError [1:23-1:26]: Unexpected private field
+"SyntaxError [1:23-1:25]: Unexpected private field
 > 1 | class C { #x; m() { \`\${#x}\`; } }
-    |                        ^^^ Unexpected private field"
+    |                        ^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (script sloppy) > class C { #x; m() { for (#x in []) {} } } 1`] = `
@@ -355,18 +355,18 @@ class C { #field; m() { #field in #field in this; } } 1`] = `
 
 exports[`Expressions -In > Private identifiers outside in expressions (script strict) > 'use strict';
 class C { #x; m() { #x; } } 1`] = `
-"SyntaxError [2:20-2:23]: Unexpected private field
+"SyntaxError [2:20-2:22]: Unexpected private field
   1 | 'use strict';
 > 2 | class C { #x; m() { #x; } }
-    |                     ^^^ Unexpected private field"
+    |                     ^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (script strict) > 'use strict';
 class C { #x; m() { (#x); } } 1`] = `
-"SyntaxError [2:21-2:24]: Unexpected private field
+"SyntaxError [2:21-2:23]: Unexpected private field
   1 | 'use strict';
 > 2 | class C { #x; m() { (#x); } }
-    |                      ^^^ Unexpected private field"
+    |                      ^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (script strict) > 'use strict';
@@ -387,10 +387,10 @@ class C { #x; m() { [#x]; } } 1`] = `
 
 exports[`Expressions -In > Private identifiers outside in expressions (script strict) > 'use strict';
 class C { #x; m() { \`\${#x}\`; } } 1`] = `
-"SyntaxError [2:23-2:26]: Unexpected private field
+"SyntaxError [2:23-2:25]: Unexpected private field
   1 | 'use strict';
 > 2 | class C { #x; m() { \`\${#x}\`; } }
-    |                        ^^^ Unexpected private field"
+    |                        ^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (script strict) > 'use strict';

--- a/test/parser/expressions/__snapshots__/in.ts.snap
+++ b/test/parser/expressions/__snapshots__/in.ts.snap
@@ -184,3 +184,227 @@ exports[`Expressions -In > Expressions -In > x in async 1`] = `
   "type": "Program",
 }
 `;
+
+exports[`Expressions -In > Private identifiers outside in expressions (module with directive) > 'use strict';
+class C { #field; m() { #field in #field in this; } } 1`] = `
+"SyntaxError [2:34-2:35]: Unexpected token: 'PrivateField'
+  1 | 'use strict';
+> 2 | class C { #field; m() { #field in #field in this; } }
+    |                                   ^ Unexpected token: 'PrivateField'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (module with directive) > 'use strict';
+class C { #x; m() { #x; } } 1`] = `
+"SyntaxError [2:22-2:23]: Unexpected token: ';'
+  1 | 'use strict';
+> 2 | class C { #x; m() { #x; } }
+    |                       ^ Unexpected token: ';'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (module with directive) > 'use strict';
+class C { #x; m() { (#x); } } 1`] = `
+"SyntaxError [2:23-2:24]: Unexpected token: ')'
+  1 | 'use strict';
+> 2 | class C { #x; m() { (#x); } }
+    |                        ^ Unexpected token: ')'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (module with directive) > 'use strict';
+class C { #x; m() { ({ value: #x }); } } 1`] = `
+"SyntaxError [2:30-2:31]: Unexpected token: 'PrivateField'
+  1 | 'use strict';
+> 2 | class C { #x; m() { ({ value: #x }); } }
+    |                               ^ Unexpected token: 'PrivateField'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (module with directive) > 'use strict';
+class C { #x; m() { [#x]; } } 1`] = `
+"SyntaxError [2:21-2:22]: Unexpected token: 'PrivateField'
+  1 | 'use strict';
+> 2 | class C { #x; m() { [#x]; } }
+    |                      ^ Unexpected token: 'PrivateField'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (module with directive) > 'use strict';
+class C { #x; m() { \`\${#x}\`; } } 1`] = `
+"SyntaxError [2:25-2:26]: Unexpected token: '}'
+  1 | 'use strict';
+> 2 | class C { #x; m() { \`\${#x}\`; } }
+    |                          ^ Unexpected token: '}'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (module with directive) > 'use strict';
+class C { #x; m() { for (#x in []) {} } } 1`] = `
+"SyntaxError [2:25-2:26]: Unexpected token: 'PrivateField'
+  1 | 'use strict';
+> 2 | class C { #x; m() { for (#x in []) {} } }
+    |                          ^ Unexpected token: 'PrivateField'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (module with directive) > 'use strict';
+class C { #x; m() { typeof #x; } } 1`] = `
+"SyntaxError [2:27-2:28]: Unexpected token: 'PrivateField'
+  1 | 'use strict';
+> 2 | class C { #x; m() { typeof #x; } }
+    |                            ^ Unexpected token: 'PrivateField'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (module) > class C { #field; m() { #field in #field in this; } } 1`] = `
+"SyntaxError [1:34-1:35]: Unexpected token: 'PrivateField'
+> 1 | class C { #field; m() { #field in #field in this; } }
+    |                                   ^ Unexpected token: 'PrivateField'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (module) > class C { #x; m() { #x; } } 1`] = `
+"SyntaxError [1:22-1:23]: Unexpected token: ';'
+> 1 | class C { #x; m() { #x; } }
+    |                       ^ Unexpected token: ';'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (module) > class C { #x; m() { (#x); } } 1`] = `
+"SyntaxError [1:23-1:24]: Unexpected token: ')'
+> 1 | class C { #x; m() { (#x); } }
+    |                        ^ Unexpected token: ')'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (module) > class C { #x; m() { ({ value: #x }); } } 1`] = `
+"SyntaxError [1:30-1:31]: Unexpected token: 'PrivateField'
+> 1 | class C { #x; m() { ({ value: #x }); } }
+    |                               ^ Unexpected token: 'PrivateField'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (module) > class C { #x; m() { [#x]; } } 1`] = `
+"SyntaxError [1:21-1:22]: Unexpected token: 'PrivateField'
+> 1 | class C { #x; m() { [#x]; } }
+    |                      ^ Unexpected token: 'PrivateField'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (module) > class C { #x; m() { \`\${#x}\`; } } 1`] = `
+"SyntaxError [1:25-1:26]: Unexpected token: '}'
+> 1 | class C { #x; m() { \`\${#x}\`; } }
+    |                          ^ Unexpected token: '}'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (module) > class C { #x; m() { for (#x in []) {} } } 1`] = `
+"SyntaxError [1:25-1:26]: Unexpected token: 'PrivateField'
+> 1 | class C { #x; m() { for (#x in []) {} } }
+    |                          ^ Unexpected token: 'PrivateField'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (module) > class C { #x; m() { typeof #x; } } 1`] = `
+"SyntaxError [1:27-1:28]: Unexpected token: 'PrivateField'
+> 1 | class C { #x; m() { typeof #x; } }
+    |                            ^ Unexpected token: 'PrivateField'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (script sloppy) > class C { #field; m() { #field in #field in this; } } 1`] = `
+"SyntaxError [1:34-1:35]: Unexpected token: 'PrivateField'
+> 1 | class C { #field; m() { #field in #field in this; } }
+    |                                   ^ Unexpected token: 'PrivateField'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (script sloppy) > class C { #x; m() { #x; } } 1`] = `
+"SyntaxError [1:22-1:23]: Unexpected token: ';'
+> 1 | class C { #x; m() { #x; } }
+    |                       ^ Unexpected token: ';'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (script sloppy) > class C { #x; m() { (#x); } } 1`] = `
+"SyntaxError [1:23-1:24]: Unexpected token: ')'
+> 1 | class C { #x; m() { (#x); } }
+    |                        ^ Unexpected token: ')'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (script sloppy) > class C { #x; m() { ({ value: #x }); } } 1`] = `
+"SyntaxError [1:30-1:31]: Unexpected token: 'PrivateField'
+> 1 | class C { #x; m() { ({ value: #x }); } }
+    |                               ^ Unexpected token: 'PrivateField'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (script sloppy) > class C { #x; m() { [#x]; } } 1`] = `
+"SyntaxError [1:21-1:22]: Unexpected token: 'PrivateField'
+> 1 | class C { #x; m() { [#x]; } }
+    |                      ^ Unexpected token: 'PrivateField'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (script sloppy) > class C { #x; m() { \`\${#x}\`; } } 1`] = `
+"SyntaxError [1:25-1:26]: Unexpected token: '}'
+> 1 | class C { #x; m() { \`\${#x}\`; } }
+    |                          ^ Unexpected token: '}'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (script sloppy) > class C { #x; m() { for (#x in []) {} } } 1`] = `
+"SyntaxError [1:25-1:26]: Unexpected token: 'PrivateField'
+> 1 | class C { #x; m() { for (#x in []) {} } }
+    |                          ^ Unexpected token: 'PrivateField'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (script sloppy) > class C { #x; m() { typeof #x; } } 1`] = `
+"SyntaxError [1:27-1:28]: Unexpected token: 'PrivateField'
+> 1 | class C { #x; m() { typeof #x; } }
+    |                            ^ Unexpected token: 'PrivateField'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (script strict) > 'use strict';
+class C { #field; m() { #field in #field in this; } } 1`] = `
+"SyntaxError [2:34-2:35]: Unexpected token: 'PrivateField'
+  1 | 'use strict';
+> 2 | class C { #field; m() { #field in #field in this; } }
+    |                                   ^ Unexpected token: 'PrivateField'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (script strict) > 'use strict';
+class C { #x; m() { #x; } } 1`] = `
+"SyntaxError [2:22-2:23]: Unexpected token: ';'
+  1 | 'use strict';
+> 2 | class C { #x; m() { #x; } }
+    |                       ^ Unexpected token: ';'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (script strict) > 'use strict';
+class C { #x; m() { (#x); } } 1`] = `
+"SyntaxError [2:23-2:24]: Unexpected token: ')'
+  1 | 'use strict';
+> 2 | class C { #x; m() { (#x); } }
+    |                        ^ Unexpected token: ')'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (script strict) > 'use strict';
+class C { #x; m() { ({ value: #x }); } } 1`] = `
+"SyntaxError [2:30-2:31]: Unexpected token: 'PrivateField'
+  1 | 'use strict';
+> 2 | class C { #x; m() { ({ value: #x }); } }
+    |                               ^ Unexpected token: 'PrivateField'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (script strict) > 'use strict';
+class C { #x; m() { [#x]; } } 1`] = `
+"SyntaxError [2:21-2:22]: Unexpected token: 'PrivateField'
+  1 | 'use strict';
+> 2 | class C { #x; m() { [#x]; } }
+    |                      ^ Unexpected token: 'PrivateField'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (script strict) > 'use strict';
+class C { #x; m() { \`\${#x}\`; } } 1`] = `
+"SyntaxError [2:25-2:26]: Unexpected token: '}'
+  1 | 'use strict';
+> 2 | class C { #x; m() { \`\${#x}\`; } }
+    |                          ^ Unexpected token: '}'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (script strict) > 'use strict';
+class C { #x; m() { for (#x in []) {} } } 1`] = `
+"SyntaxError [2:25-2:26]: Unexpected token: 'PrivateField'
+  1 | 'use strict';
+> 2 | class C { #x; m() { for (#x in []) {} } }
+    |                          ^ Unexpected token: 'PrivateField'"
+`;
+
+exports[`Expressions -In > Private identifiers outside in expressions (script strict) > 'use strict';
+class C { #x; m() { typeof #x; } } 1`] = `
+"SyntaxError [2:27-2:28]: Unexpected token: 'PrivateField'
+  1 | 'use strict';
+> 2 | class C { #x; m() { typeof #x; } }
+    |                            ^ Unexpected token: 'PrivateField'"
+`;

--- a/test/parser/expressions/__snapshots__/in.ts.snap
+++ b/test/parser/expressions/__snapshots__/in.ts.snap
@@ -195,18 +195,18 @@ class C { #field; m() { #field in #field in this; } } 1`] = `
 
 exports[`Expressions -In > Private identifiers outside in expressions (module with directive) > 'use strict';
 class C { #x; m() { #x; } } 1`] = `
-"SyntaxError [2:20-2:22]: Unexpected private field
+"SyntaxError [2:20-2:23]: Unexpected private field
   1 | 'use strict';
 > 2 | class C { #x; m() { #x; } }
-    |                     ^^ Unexpected private field"
+    |                     ^^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (module with directive) > 'use strict';
 class C { #x; m() { (#x); } } 1`] = `
-"SyntaxError [2:21-2:23]: Unexpected private field
+"SyntaxError [2:21-2:24]: Unexpected private field
   1 | 'use strict';
 > 2 | class C { #x; m() { (#x); } }
-    |                      ^^ Unexpected private field"
+    |                      ^^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (module with directive) > 'use strict';
@@ -227,10 +227,10 @@ class C { #x; m() { [#x]; } } 1`] = `
 
 exports[`Expressions -In > Private identifiers outside in expressions (module with directive) > 'use strict';
 class C { #x; m() { \`\${#x}\`; } } 1`] = `
-"SyntaxError [2:23-2:25]: Unexpected private field
+"SyntaxError [2:23-2:26]: Unexpected private field
   1 | 'use strict';
 > 2 | class C { #x; m() { \`\${#x}\`; } }
-    |                        ^^ Unexpected private field"
+    |                        ^^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (module with directive) > 'use strict';
@@ -256,15 +256,15 @@ exports[`Expressions -In > Private identifiers outside in expressions (module) >
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (module) > class C { #x; m() { #x; } } 1`] = `
-"SyntaxError [1:20-1:22]: Unexpected private field
+"SyntaxError [1:20-1:23]: Unexpected private field
 > 1 | class C { #x; m() { #x; } }
-    |                     ^^ Unexpected private field"
+    |                     ^^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (module) > class C { #x; m() { (#x); } } 1`] = `
-"SyntaxError [1:21-1:23]: Unexpected private field
+"SyntaxError [1:21-1:24]: Unexpected private field
 > 1 | class C { #x; m() { (#x); } }
-    |                      ^^ Unexpected private field"
+    |                      ^^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (module) > class C { #x; m() { ({ value: #x }); } } 1`] = `
@@ -280,9 +280,9 @@ exports[`Expressions -In > Private identifiers outside in expressions (module) >
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (module) > class C { #x; m() { \`\${#x}\`; } } 1`] = `
-"SyntaxError [1:23-1:25]: Unexpected private field
+"SyntaxError [1:23-1:26]: Unexpected private field
 > 1 | class C { #x; m() { \`\${#x}\`; } }
-    |                        ^^ Unexpected private field"
+    |                        ^^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (module) > class C { #x; m() { for (#x in []) {} } } 1`] = `
@@ -304,15 +304,15 @@ exports[`Expressions -In > Private identifiers outside in expressions (script sl
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (script sloppy) > class C { #x; m() { #x; } } 1`] = `
-"SyntaxError [1:20-1:22]: Unexpected private field
+"SyntaxError [1:20-1:23]: Unexpected private field
 > 1 | class C { #x; m() { #x; } }
-    |                     ^^ Unexpected private field"
+    |                     ^^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (script sloppy) > class C { #x; m() { (#x); } } 1`] = `
-"SyntaxError [1:21-1:23]: Unexpected private field
+"SyntaxError [1:21-1:24]: Unexpected private field
 > 1 | class C { #x; m() { (#x); } }
-    |                      ^^ Unexpected private field"
+    |                      ^^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (script sloppy) > class C { #x; m() { ({ value: #x }); } } 1`] = `
@@ -328,9 +328,9 @@ exports[`Expressions -In > Private identifiers outside in expressions (script sl
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (script sloppy) > class C { #x; m() { \`\${#x}\`; } } 1`] = `
-"SyntaxError [1:23-1:25]: Unexpected private field
+"SyntaxError [1:23-1:26]: Unexpected private field
 > 1 | class C { #x; m() { \`\${#x}\`; } }
-    |                        ^^ Unexpected private field"
+    |                        ^^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (script sloppy) > class C { #x; m() { for (#x in []) {} } } 1`] = `
@@ -355,18 +355,18 @@ class C { #field; m() { #field in #field in this; } } 1`] = `
 
 exports[`Expressions -In > Private identifiers outside in expressions (script strict) > 'use strict';
 class C { #x; m() { #x; } } 1`] = `
-"SyntaxError [2:20-2:22]: Unexpected private field
+"SyntaxError [2:20-2:23]: Unexpected private field
   1 | 'use strict';
 > 2 | class C { #x; m() { #x; } }
-    |                     ^^ Unexpected private field"
+    |                     ^^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (script strict) > 'use strict';
 class C { #x; m() { (#x); } } 1`] = `
-"SyntaxError [2:21-2:23]: Unexpected private field
+"SyntaxError [2:21-2:24]: Unexpected private field
   1 | 'use strict';
 > 2 | class C { #x; m() { (#x); } }
-    |                      ^^ Unexpected private field"
+    |                      ^^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (script strict) > 'use strict';
@@ -387,10 +387,10 @@ class C { #x; m() { [#x]; } } 1`] = `
 
 exports[`Expressions -In > Private identifiers outside in expressions (script strict) > 'use strict';
 class C { #x; m() { \`\${#x}\`; } } 1`] = `
-"SyntaxError [2:23-2:25]: Unexpected private field
+"SyntaxError [2:23-2:26]: Unexpected private field
   1 | 'use strict';
 > 2 | class C { #x; m() { \`\${#x}\`; } }
-    |                        ^^ Unexpected private field"
+    |                        ^^^ Unexpected private field"
 `;
 
 exports[`Expressions -In > Private identifiers outside in expressions (script strict) > 'use strict';

--- a/test/parser/expressions/in.ts
+++ b/test/parser/expressions/in.ts
@@ -1,7 +1,36 @@
 import * as t from 'node:assert/strict';
 import { describe, it } from 'vitest';
 import { parseSource } from '../../../src/parser.ts';
-import { pass } from '../../test-utils.ts';
+import { fail, pass } from '../../test-utils.ts';
+
+const invalidPrivateIdentifierPositions = [
+  'class C { #x; m() { (#x); } }',
+  'class C { #x; m() { [#x]; } }',
+  'class C { #x; m() { typeof #x; } }',
+  'class C { #x; m() { #x; } }',
+  'class C { #x; m() { for (#x in []) {} } }',
+  'class C { #field; m() { #field in #field in this; } }',
+  'class C { #x; m() { ({ value: #x }); } }',
+  'class C { #x; m() { `${#x}`; } }',
+];
+
+const validPrivateIdentifierInExpressions = [
+  'class C { #x; m(obj) { #x in obj; } }',
+  'class C { #x; m(obj) { if (#x in obj) {} } }',
+  'class C { #x; m(obj) { #x in obj ? 1 : 0; } }',
+  'class C { #x; m(obj) { #x in obj && true; } }',
+  'class C { #x; m(obj) { false || #x in obj; } }',
+  'class C { #x; m(obj) { (#x in obj); } }',
+  'class C { #a; m(b, c) { (#a in b) in c; } }',
+  'class C { #x; y = #x in this; }',
+];
+
+const privateIdentifierModes = [
+  { name: 'script sloppy', prefix: '', sourceType: 'script' },
+  { name: 'script strict', prefix: "'use strict';\n", sourceType: 'script' },
+  { name: 'module', prefix: '', sourceType: 'module' },
+  { name: 'module with directive', prefix: "'use strict';\n", sourceType: 'module' },
+] as const;
 
 describe('Expressions -In', () => {
   for (const text of [
@@ -37,4 +66,19 @@ describe('Expressions -In', () => {
     { code: '"any-string"', options: { raw: true } },
     { code: '123', options: { raw: true } },
   ]);
+
+  for (const { name, prefix, sourceType } of privateIdentifierModes) {
+    fail(
+      `Private identifiers outside in expressions (${name})`,
+      invalidPrivateIdentifierPositions.map((code) => ({ code: prefix + code, options: { sourceType } })),
+    );
+
+    for (const code of validPrivateIdentifierInExpressions) {
+      it(`Private identifiers in expressions (${name}): ${code}`, () => {
+        t.doesNotThrow(() => {
+          parseSource(prefix + code, { sourceType });
+        });
+      });
+    }
+  }
 });

--- a/test/parser/miscellaneous/__snapshots__/private_methods.ts.snap
+++ b/test/parser/miscellaneous/__snapshots__/private_methods.ts.snap
@@ -1113,57 +1113,6 @@ exports[`Private methods > Private methods (pass) > class A { #foo = bar; } 1`] 
 }
 `;
 
-exports[`Private methods > Private methods (pass) > class A { #foo() { #bar } } 1`] = `
-{
-  "body": [
-    {
-      "body": {
-        "body": [
-          {
-            "computed": false,
-            "key": {
-              "name": "foo",
-              "type": "PrivateIdentifier",
-            },
-            "kind": "method",
-            "static": false,
-            "type": "MethodDefinition",
-            "value": {
-              "async": false,
-              "body": {
-                "body": [
-                  {
-                    "expression": {
-                      "name": "bar",
-                      "type": "PrivateIdentifier",
-                    },
-                    "type": "ExpressionStatement",
-                  },
-                ],
-                "type": "BlockStatement",
-              },
-              "generator": false,
-              "id": null,
-              "params": [],
-              "type": "FunctionExpression",
-            },
-          },
-        ],
-        "type": "ClassBody",
-      },
-      "id": {
-        "name": "A",
-        "type": "Identifier",
-      },
-      "superClass": null,
-      "type": "ClassDeclaration",
-    },
-  ],
-  "sourceType": "script",
-  "type": "Program",
-}
-`;
-
 exports[`Private methods > Private methods (pass) > class A { #key() {} } 1`] = `
 {
   "body": [

--- a/test/parser/miscellaneous/private_methods.ts
+++ b/test/parser/miscellaneous/private_methods.ts
@@ -389,7 +389,6 @@ describe('Private methods', () => {
     `,
     'class A { #key() {} }',
     'class A { #yield\n = 0; }',
-    'class A { #foo() { #bar } }',
     'class A { static #key; }',
     'class A { static #foo(bar) {} }',
     'class A { m() {} #a; }',

--- a/test262/whitelist.txt
+++ b/test262/whitelist.txt
@@ -1,6 +1,3 @@
-language/expressions/in/private-field-in-nested.js (default)
-language/expressions/in/private-field-in-nested.js (strict mode)
-language/expressions/in/private-field-invalid-assignment-reference.js (default)
 language/statements/block/labeled-continue.js (default)
 language/statements/block/labeled-continue.js (strict mode)
 staging/sm/fields/await-identifier-module-3.js (default)


### PR DESCRIPTION
ECMA-262 admits a private name in exactly one expression position, `RelationalExpression : [+In] PrivateIdentifier in ShiftExpression`, but Meriyah's primary-expression path returned one unconditionally, so `(#x)`, `[#x]`, `typeof #x`, `for (#x in [])`, and `#field in #field in this` all parsed.

This tightens early errors for the ergonomic brand-check support completed in #214, while keeping valid brand checks unchanged.

Three of the seven test262 whitelist lines covered this bug, and regeneration removed exactly those three while leaving the other four byte-identical; the assignment-reference fixture's strict scenario already failed through the existing strict-mode for-in target check, so only its default scenario leaked.

The parser now threads an explicit `allowPrivateId` authorization only to positions that may see a private name instead of using ambient state; the precedence-aware RHS guard rejects `#a in #b in this` while keeping `(#a in b) in c` and `false || #a in obj` legal.

The negative/positive matrix covers eight invalid and eight valid parser-test forms across script/module and directive/no-directive modes, including moving `class A { #foo() { #bar } }` from the positive suite into negative coverage; V8 and Acorn agree on every case, all 12 behavior legs on Node 20/22/24/26 passed with each leg at 139-143 files and 91,838-91,849 tests, and the Node 26 static chain passed, including 1 file with 6 production tests.
