### PR TITLE
fix(jsx): count line terminators in JSXText

### DIFF
--- a/src/lexer/jsx.ts
+++ b/src/lexer/jsx.ts
@@ -1,5 +1,5 @@
 import { Chars } from '../chars.ts';
-import { type Context } from '../common.ts';
+import { type Context, Flags } from '../common.ts';
 import { Errors } from '../errors.ts';
 import { type Parser } from '../parser/parser.ts';
 import { Token } from '../token.ts';
@@ -100,15 +100,30 @@ export function nextJSXToken(parser: Parser) {
   }
 
   let state = LexerState.None;
+  let hasCarriageReturn = false;
 
   while (parser.index < parser.end) {
-    const type = CharTypes[parser.source.charCodeAt(parser.index)];
+    const char = parser.source.charCodeAt(parser.index);
 
-    if (type & CharFlags.CarriageReturn) {
+    // `CharTypes` only covers the first 128 code points, and the
+    // `CarriageReturn`/`LineFeed` flags it does have are swapped relative to
+    // the conventional `\r`/`\n` mapping used everywhere else in this file
+    // (`scanJSXString`, `scanString`, `scanTemplate`, `comments.ts`). Matching
+    // by code point, like `scanJSXString` already does, makes `<CR><LF>` one
+    // line terminator (not two), `<LF><CR>` two line terminators (not one),
+    // and counts `<LS>` / `<PS>` as line terminators at all.
+    if (char === Chars.CarriageReturn) {
       state |= LexerState.NewLine | LexerState.LastIsCR;
+      hasCarriageReturn = true;
       scanNewLine(parser);
-    } else if (type & CharFlags.LineFeed) {
+    } else if (char === Chars.LineFeed) {
       consumeLineFeed(parser, state);
+      state = (state & ~LexerState.LastIsCR) | LexerState.NewLine;
+    } else if (char === Chars.LineSeparator || char === Chars.ParagraphSeparator) {
+      parser.flags |= Flags.NewLine;
+      parser.currentChar = parser.source.charCodeAt(++parser.index);
+      parser.column = 0;
+      parser.line++;
       state = (state & ~LexerState.LastIsCR) | LexerState.NewLine;
     } else {
       advanceChar(parser);
@@ -120,7 +135,12 @@ export function nextJSXToken(parser: Parser) {
   // No text, next char is "}" or ">"
   if (parser.tokenIndex === parser.index) parser.report(Errors.Unexpected);
 
-  const raw = parser.source.slice(parser.tokenIndex, parser.index);
+  // Normalize `<CR><LF>` to `<LF>` in the decoded value, matching Babel and
+  // acorn-jsx. A lone `<CR>` is intentionally kept, the same way those parsers
+  // keep it. `scanTemplate` already does the equivalent normalization for
+  // template raw text.
+  const sourceSlice = parser.source.slice(parser.tokenIndex, parser.index);
+  const raw = hasCarriageReturn ? sourceSlice.replaceAll('\r\n', '\n') : sourceSlice;
   if (parser.options.raw) parser.tokenRaw = raw;
   parser.tokenValue = decodeHTMLStrict(raw);
   parser.setToken(Token.JSXText);

--- a/test/parser/miscellaneous/jsx.ts
+++ b/test/parser/miscellaneous/jsx.ts
@@ -64,7 +64,7 @@ describe('Miscellaneous - JSX', () => {
   // one (instead of two), and skipped `<LS>` / `<PS>` entirely. The decoded
   // `JSXText.value` also kept `<CR><LF>` raw instead of normalizing it to
   // `<LF>`, which Babel and acorn-jsx both do.
-  for (const [name, source, wantValue, wantEndLine] of [
+  for (const [name, source, expectedValue, expectedEndLine] of [
     ['<LF>', '<a>foo\nbar</a>', 'foo\nbar', 2],
     ['<CR>', '<a>foo\rbar</a>', 'foo\rbar', 2],
     ['<CR><LF>', '<a>foo\r\nbar</a>', 'foo\nbar', 2],

--- a/test/parser/miscellaneous/jsx.ts
+++ b/test/parser/miscellaneous/jsx.ts
@@ -57,6 +57,41 @@ describe('Miscellaneous - JSX', () => {
     });
   }
 
+  // `nextJSXToken` previously looked up line terminators through `CharTypes`,
+  // which has the `CarriageReturn`/`LineFeed` flags swapped relative to the
+  // conventional `\r`/`\n` mapping and only covers the first 128 code points.
+  // That made `<CR><LF>` two line terminators (instead of one), `<LF><CR>`
+  // one (instead of two), and skipped `<LS>` / `<PS>` entirely. The decoded
+  // `JSXText.value` also kept `<CR><LF>` raw instead of normalizing it to
+  // `<LF>`, which Babel and acorn-jsx both do.
+  for (const [name, source, wantValue, wantEndLine] of [
+    ['<LF>', '<a>foo\nbar</a>', 'foo\nbar', 2],
+    ['<CR>', '<a>foo\rbar</a>', 'foo\rbar', 2],
+    ['<CR><LF>', '<a>foo\r\nbar</a>', 'foo\nbar', 2],
+    ['<LF><CR>', '<a>foo\n\rbar</a>', 'foo\n\rbar', 3],
+    ['<LS>', '<a>foo\u2028bar</a>', 'foo\u2028bar', 2],
+    ['<PS>', '<a>foo\u2029bar</a>', 'foo\u2029bar', 2],
+    ['two <CR><LF>', '<a>\r\n\r\n</a>', '\n\n', 3],
+  ] as const) {
+    it(`${name} in JSX text counts as one line terminator`, () => {
+      const ast = parseSource(source, { jsx: true, loc: true });
+      const element = (ast.body[0] as ESTree.ExpressionStatement).expression as ESTree.JSXElement;
+      const text = element.children[0] as ESTree.JSXText;
+
+      t.equal(text.value, wantValue);
+      t.equal(text.loc?.end.line, wantEndLine);
+    });
+  }
+
+  it('normalizes <CR><LF> to <LF> in JSX text value but keeps a lone <CR>', () => {
+    const ast = parseSource('<a>foo\r\nbar\rbaz</a>', { jsx: true });
+    const element = (ast.body[0] as ESTree.ExpressionStatement).expression as ESTree.JSXElement;
+    const text = element.children[0] as ESTree.JSXText;
+
+    // `<CR><LF>` -> `<LF>`, lone `<CR>` stays.
+    t.equal(text.value, 'foo\nbar\rbaz');
+  });
+
   // `nextJSXToken` decodes HTML entities in JSX text, `scanJSXString` has to do
   // the same for attribute values. https://github.com/meriyah/meriyah/issues/133
   for (const [attributeValue, value] of [

--- a/test/parser/miscellaneous/jsx.ts
+++ b/test/parser/miscellaneous/jsx.ts
@@ -78,8 +78,8 @@ describe('Miscellaneous - JSX', () => {
       const element = (ast.body[0] as ESTree.ExpressionStatement).expression as ESTree.JSXElement;
       const text = element.children[0] as ESTree.JSXText;
 
-      t.equal(text.value, wantValue);
-      t.equal(text.loc?.end.line, wantEndLine);
+      t.equal(text.value, expectedValue);
+      t.equal(text.loc?.end.line, expectedEndLine);
     });
   }
 


### PR DESCRIPTION
`nextJSXToken` counted JSXText line breaks incorrectly. It used mismatched character flags, so CRLF was counted twice, LFCR was counted once, and Unicode line separators were missed. The fix checks CR, LF, LS, and PS directly, treats CRLF as one terminator, normalizes CRLF to LF in JSXText values, and adds regression coverage for each case.