### PR TITLE
fix(parser): restrict continue targets to iteration statement labels

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -382,12 +382,19 @@ export function isPropertyWithPrivateFieldKey(expr: any): boolean {
  * @param isIterationStatement
  */
 export function isValidLabel(parser: Parser, labels: any, name: string, isIterationStatement: 0 | 1): 0 | 1 {
+  // A `continue` may only target a label of an iteration statement it is nested in, so
+  // the label has to be declared in the label set that iteration statement was parsed
+  // with. Label sets chain outwards and the set marked `loop` is an iteration statement
+  // body, so the set right above such a set holds that statement's own labels.
+  let isIterationLabelSet: 0 | 1 = 0;
+
   while (labels) {
     if (labels['$' + name]) {
-      if (isIterationStatement) parser.report(Errors.InvalidNestedStatement);
+      // A label is declared at most once per chain, so this is its only declaration.
+      if (isIterationStatement && !isIterationLabelSet) parser.report(Errors.InvalidNestedStatement);
       return 1;
     }
-    if (isIterationStatement && labels.loop) isIterationStatement = 0;
+    isIterationLabelSet = labels.loop ? 1 : 0;
     labels = labels['$'];
   }
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -391,7 +391,7 @@ export function isValidLabel(parser: Parser, labels: any, name: string, isIterat
   while (labels) {
     if (labels['$' + name]) {
       // A label is declared at most once per chain, so this is its only declaration.
-      if (isIterationStatement && !isIterationLabelSet) parser.report(Errors.InvalidNestedStatement);
+      if (isIterationStatement && !isIterationLabelSet) parser.report(Errors.InvalidNestedStatement, name);
       return 1;
     }
     isIterationLabelSet = labels.loop ? 1 : 0;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -336,7 +336,7 @@ const errorMessages: {
   [Errors.UnexpectedCharAfterObjLit]: 'Unexpected character after object literal property name',
   [Errors.InvalidKeyToken]: 'Invalid key token',
   [Errors.LabelRedeclaration]: "Label '%0' has already been declared",
-  [Errors.InvalidNestedStatement]: 'continue statement must be nested within an iteration statement',
+  [Errors.InvalidNestedStatement]: "Label '%0' does not denote an iteration statement",
   [Errors.UnknownLabel]: "Undefined label '%0'",
   [Errors.InvalidImportTail]: 'Trailing comma is disallowed inside import(...) arguments',
   [Errors.InvalidJSONImportBinding]: 'Invalid binding in JSON import',

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1235,9 +1235,10 @@ function parseContinueStatement(parser: Parser, context: Context, labels: ESTree
   let label: ESTree.Identifier | undefined | null = null;
   if ((parser.flags & Flags.NewLine) === 0 && parser.getToken() & Token.IsIdentifier) {
     const { tokenValue } = parser;
-    label = parseIdentifier(parser, context | Context.AllowRegExp);
+    // Validate before consuming the label so a reported error points at the label.
     if (!isValidLabel(parser, labels, tokenValue, /* requireIterationStatement */ 1))
       parser.report(Errors.UnknownLabel, tokenValue);
+    label = parseIdentifier(parser, context | Context.AllowRegExp);
   }
   matchOrInsertSemicolon(parser, context | Context.AllowRegExp);
   return parser.finishNode<ESTree.ContinueStatement>(
@@ -1267,9 +1268,10 @@ function parseBreakStatement(parser: Parser, context: Context, labels: ESTree.La
   let label: ESTree.Identifier | undefined | null = null;
   if ((parser.flags & Flags.NewLine) === 0 && parser.getToken() & Token.IsIdentifier) {
     const { tokenValue } = parser;
-    label = parseIdentifier(parser, context | Context.AllowRegExp);
+    // Validate before consuming the label so a reported error points at the label.
     if (!isValidLabel(parser, labels, tokenValue, /* requireIterationStatement */ 0))
       parser.report(Errors.UnknownLabel, tokenValue);
+    label = parseIdentifier(parser, context | Context.AllowRegExp);
   } else if ((context & (Context.InSwitch | Context.InIteration)) === 0) {
     parser.report(Errors.IllegalBreak);
   }

--- a/test/parser/expressions/__snapshots__/async-arrow.ts.snap
+++ b/test/parser/expressions/__snapshots__/async-arrow.ts.snap
@@ -2260,10 +2260,10 @@ exports[`Expressions - Async arrow > Expressions - Async arrow (fail) > asyncFn 
 
 exports[`Expressions - Async arrow > Expressions - Async arrow (fail) > break async 
  () => x 1`] = `
-"SyntaxError [2:1-2:2]: Undefined label 'async'
-  1 | break async 
-> 2 |  () => x
-    |  ^ Undefined label 'async'"
+"SyntaxError [1:6-1:11]: Undefined label 'async'
+> 1 | break async 
+    |       ^^^^^ Undefined label 'async'
+  2 |  () => x"
 `;
 
 exports[`Expressions - Async arrow > Expressions - Async arrow (fail) > class x extends async 

--- a/test/parser/statements/__snapshots__/break.ts.snap
+++ b/test/parser/statements/__snapshots__/break.ts.snap
@@ -352,6 +352,45 @@ x 1`] = `
 }
 `;
 
+exports[`Statements - Break > Statements - Break (pass) > a: { for (;;) { break a; } } 1`] = `
+{
+  "body": [
+    {
+      "body": {
+        "body": [
+          {
+            "body": {
+              "body": [
+                {
+                  "label": {
+                    "name": "a",
+                    "type": "Identifier",
+                  },
+                  "type": "BreakStatement",
+                },
+              ],
+              "type": "BlockStatement",
+            },
+            "init": null,
+            "test": null,
+            "type": "ForStatement",
+            "update": null,
+          },
+        ],
+        "type": "BlockStatement",
+      },
+      "label": {
+        "name": "a",
+        "type": "Identifier",
+      },
+      "type": "LabeledStatement",
+    },
+  ],
+  "sourceType": "script",
+  "type": "Program",
+}
+`;
+
 exports[`Statements - Break > Statements - Break (pass) > a: if (true) b: { break a; break b; }
 else b: { break a; break b; } 1`] = `
 {

--- a/test/parser/statements/__snapshots__/break.ts.snap
+++ b/test/parser/statements/__snapshots__/break.ts.snap
@@ -27,11 +27,11 @@ exports[`Statements - Break > Declarations - Break > (function(){
     } while(0);
     function OUT_FUNC(){}
 })(); 1`] = `
-"SyntaxError [7:32-7:33]: Undefined label 'LABEL_ANOTHER_LOOP'
+"SyntaxError [7:14-7:32]: Undefined label 'LABEL_ANOTHER_LOOP'
    5 |         if(x===10)
    6 |             return;
 >  7 |         break LABEL_ANOTHER_LOOP;
-     |                                 ^ Undefined label 'LABEL_ANOTHER_LOOP'
+     |               ^^^^^^^^^^^^^^^^^^ Undefined label 'LABEL_ANOTHER_LOOP'
    8 |         LABEL_IN_2 : y++;
    9 |         function IN_DO_FUNC(){}
   10 |     } while(0);"
@@ -52,11 +52,11 @@ exports[`Statements - Break > Declarations - Break > (function(){
   } while(0);
   function OUT_FUNC(){}
 })(); 1`] = `
-"SyntaxError [7:22-7:23]: Undefined label 'IN_DO_FUNC'
+"SyntaxError [7:12-7:22]: Undefined label 'IN_DO_FUNC'
    5 |       if(x===10)
    6 |           return;
 >  7 |       break IN_DO_FUNC;
-     |                       ^ Undefined label 'IN_DO_FUNC'
+     |             ^^^^^^^^^^ Undefined label 'IN_DO_FUNC'
    8 |       LABEL_IN_2 : y++;
    9 |       function IN_DO_FUNC(){}
   10 |   } while(0);"
@@ -77,11 +77,11 @@ exports[`Statements - Break > Declarations - Break > (function(){
   } while(0);
   function OUT_FUNC(){}
 })(); 1`] = `
-"SyntaxError [7:20-7:21]: Undefined label 'LABEL_IN'
+"SyntaxError [7:12-7:20]: Undefined label 'LABEL_IN'
    5 |       if(x===10)
    6 |           return;
 >  7 |       break LABEL_IN;
-     |                     ^ Undefined label 'LABEL_IN'
+     |             ^^^^^^^^ Undefined label 'LABEL_IN'
    8 |       LABEL_IN_2 : y++;
    9 |       function IN_DO_FUNC(){}
   10 |   } while(0);"
@@ -102,20 +102,20 @@ exports[`Statements - Break > Declarations - Break > (function(){
   } while(0);
   function OUT_FUNC(){}
 })(); 2`] = `
-"SyntaxError [7:20-7:21]: Undefined label 'LABEL_IN'
+"SyntaxError [7:12-7:20]: Undefined label 'LABEL_IN'
    5 |       if(x===10)
    6 |           return;
 >  7 |       break LABEL_IN;
-     |                     ^ Undefined label 'LABEL_IN'
+     |             ^^^^^^^^ Undefined label 'LABEL_IN'
    8 |       LABEL_IN_2 : y++;
    9 |       function IN_DO_FUNC(){}
   10 |   } while(0);"
 `;
 
 exports[`Statements - Break > Declarations - Break > {  break foo; var y=2; } 1`] = `
-"SyntaxError [1:12-1:13]: Undefined label 'foo'
+"SyntaxError [1:9-1:12]: Undefined label 'foo'
 > 1 | {  break foo; var y=2; }
-    |             ^ Undefined label 'foo'"
+    |          ^^^ Undefined label 'foo'"
 `;
 
 exports[`Statements - Break > Declarations - Break > { break } 1`] = `
@@ -135,11 +135,11 @@ exports[`Statements - Break > Declarations - Break > LABEL1 : do {
     (function(){break LABEL1;})();
     y++;
 } while(0); 1`] = `
-"SyntaxError [3:28-3:29]: Undefined label 'LABEL1'
+"SyntaxError [3:22-3:28]: Undefined label 'LABEL1'
   1 | LABEL1 : do {
   2 |     x++;
 > 3 |     (function(){break LABEL1;})();
-    |                             ^ Undefined label 'LABEL1'
+    |                       ^^^^^^ Undefined label 'LABEL1'
   4 |     y++;
   5 | } while(0);"
 `;
@@ -171,21 +171,21 @@ exports[`Statements - Break > Declarations - Break > break; break; 1`] = `
 `;
 
 exports[`Statements - Break > Declarations - Break > do     break y   ; while(true); 1`] = `
-"SyntaxError [1:17-1:18]: Undefined label 'y'
+"SyntaxError [1:13-1:14]: Undefined label 'y'
 > 1 | do     break y   ; while(true);
-    |                  ^ Undefined label 'y'"
+    |              ^ Undefined label 'y'"
 `;
 
 exports[`Statements - Break > Declarations - Break > do     if (x) break y   ; while(true); 1`] = `
-"SyntaxError [1:24-1:25]: Undefined label 'y'
+"SyntaxError [1:20-1:21]: Undefined label 'y'
 > 1 | do     if (x) break y   ; while(true);
-    |                         ^ Undefined label 'y'"
+    |                     ^ Undefined label 'y'"
 `;
 
 exports[`Statements - Break > Declarations - Break > for (;;)    if (x) break y   } 1`] = `
-"SyntaxError [1:29-1:30]: Undefined label 'y'
+"SyntaxError [1:25-1:26]: Undefined label 'y'
 > 1 | for (;;)    if (x) break y   }
-    |                              ^ Undefined label 'y'"
+    |                          ^ Undefined label 'y'"
 `;
 
 exports[`Statements - Break > Declarations - Break > function f(){    break    } 1`] = `
@@ -201,9 +201,9 @@ exports[`Statements - Break > Declarations - Break > function f(){    break    }
 `;
 
 exports[`Statements - Break > Declarations - Break > function f(){    break y   } 1`] = `
-"SyntaxError [1:27-1:28]: Undefined label 'y'
+"SyntaxError [1:23-1:24]: Undefined label 'y'
 > 1 | function f(){    break y   }
-    |                            ^ Undefined label 'y'"
+    |                        ^ Undefined label 'y'"
 `;
 
 exports[`Statements - Break > Declarations - Break > function f(){    if (x) break   } 1`] = `
@@ -213,33 +213,33 @@ exports[`Statements - Break > Declarations - Break > function f(){    if (x) bre
 `;
 
 exports[`Statements - Break > Declarations - Break > function f(){ do        if (x) break y   ; while(true);} 1`] = `
-"SyntaxError [1:41-1:42]: Undefined label 'y'
+"SyntaxError [1:37-1:38]: Undefined label 'y'
 > 1 | function f(){ do        if (x) break y   ; while(true);}
-    |                                          ^ Undefined label 'y'"
+    |                                      ^ Undefined label 'y'"
 `;
 
 exports[`Statements - Break > Declarations - Break > function f(){ for (;;)       break y   } 1`] = `
-"SyntaxError [1:39-1:40]: Undefined label 'y'
+"SyntaxError [1:35-1:36]: Undefined label 'y'
 > 1 | function f(){ for (;;)       break y   }
-    |                                        ^ Undefined label 'y'"
+    |                                    ^ Undefined label 'y'"
 `;
 
 exports[`Statements - Break > Declarations - Break > function f(){ switch (x){ case z:       break y   }} 1`] = `
-"SyntaxError [1:50-1:51]: Undefined label 'y'
+"SyntaxError [1:46-1:47]: Undefined label 'y'
 > 1 | function f(){ switch (x){ case z:       break y   }}
-    |                                                   ^ Undefined label 'y'"
+    |                                               ^ Undefined label 'y'"
 `;
 
 exports[`Statements - Break > Declarations - Break > function f(){ switch (x){ case z:       if (x) break y   }} 1`] = `
-"SyntaxError [1:57-1:58]: Undefined label 'y'
+"SyntaxError [1:53-1:54]: Undefined label 'y'
 > 1 | function f(){ switch (x){ case z:       if (x) break y   }}
-    |                                                          ^ Undefined label 'y'"
+    |                                                      ^ Undefined label 'y'"
 `;
 
 exports[`Statements - Break > Declarations - Break > function f(){ while (true)       break y   } 1`] = `
-"SyntaxError [1:43-1:44]: Undefined label 'y'
+"SyntaxError [1:39-1:40]: Undefined label 'y'
 > 1 | function f(){ while (true)       break y   }
-    |                                            ^ Undefined label 'y'"
+    |                                        ^ Undefined label 'y'"
 `;
 
 exports[`Statements - Break > Declarations - Break > if (x) break 1`] = `
@@ -255,9 +255,9 @@ exports[`Statements - Break > Declarations - Break > if (x) break 2`] = `
 `;
 
 exports[`Statements - Break > Declarations - Break > loop; while (true) { break loop1; } 1`] = `
-"SyntaxError [1:32-1:33]: Undefined label 'loop1'
+"SyntaxError [1:27-1:32]: Undefined label 'loop1'
 > 1 | loop; while (true) { break loop1; }
-    |                                 ^ Undefined label 'loop1'"
+    |                            ^^^^^ Undefined label 'loop1'"
 `;
 
 exports[`Statements - Break > Declarations - Break > loop1: function a() {}  while (true) { continue loop1; } 1`] = `
@@ -279,15 +279,15 @@ exports[`Statements - Break > Declarations - Break > loop1: while (true) { loop2
 `;
 
 exports[`Statements - Break > Declarations - Break > switch (x){ case z:    break y   } 1`] = `
-"SyntaxError [1:33-1:34]: Undefined label 'y'
+"SyntaxError [1:29-1:30]: Undefined label 'y'
 > 1 | switch (x){ case z:    break y   }
-    |                                  ^ Undefined label 'y'"
+    |                              ^ Undefined label 'y'"
 `;
 
 exports[`Statements - Break > Declarations - Break > switch (x){ case z:    if (x) break y   } 1`] = `
-"SyntaxError [1:40-1:41]: Undefined label 'y'
+"SyntaxError [1:36-1:37]: Undefined label 'y'
 > 1 | switch (x){ case z:    if (x) break y   }
-    |                                         ^ Undefined label 'y'"
+    |                                     ^ Undefined label 'y'"
 `;
 
 exports[`Statements - Break > Declarations - Break > var x=0,y=0;
@@ -316,9 +316,9 @@ try{
 `;
 
 exports[`Statements - Break > Declarations - Break > x: foo; break x; 1`] = `
-"SyntaxError [1:15-1:16]: Undefined label 'x'
+"SyntaxError [1:14-1:15]: Undefined label 'x'
 > 1 | x: foo; break x;
-    |                ^ Undefined label 'x'"
+    |               ^ Undefined label 'x'"
 `;
 
 exports[`Statements - Break > Statements - Break (pass) > L: let

--- a/test/parser/statements/__snapshots__/continue.ts.snap
+++ b/test/parser/statements/__snapshots__/continue.ts.snap
@@ -51,45 +51,45 @@ y++;
 `;
 
 exports[`Statements - Continue > Declarations - Continue > a: { b: for (;;) { continue a; } } 1`] = `
-"SyntaxError [1:29-1:30]: continue statement must be nested within an iteration statement
+"SyntaxError [1:28-1:29]: Label 'a' does not denote an iteration statement
 > 1 | a: { b: for (;;) { continue a; } }
-    |                              ^ continue statement must be nested within an iteration statement"
+    |                             ^ Label 'a' does not denote an iteration statement"
 `;
 
 exports[`Statements - Continue > Declarations - Continue > a: { for (;;) { continue a; } } 1`] = `
-"SyntaxError [1:26-1:27]: continue statement must be nested within an iteration statement
+"SyntaxError [1:25-1:26]: Label 'a' does not denote an iteration statement
 > 1 | a: { for (;;) { continue a; } }
-    |                           ^ continue statement must be nested within an iteration statement"
+    |                          ^ Label 'a' does not denote an iteration statement"
 `;
 
 exports[`Statements - Continue > Declarations - Continue > a: for (;;) { b: { for (;;) continue b; } } 1`] = `
-"SyntaxError [1:38-1:39]: continue statement must be nested within an iteration statement
+"SyntaxError [1:37-1:38]: Label 'b' does not denote an iteration statement
 > 1 | a: for (;;) { b: { for (;;) continue b; } }
-    |                                       ^ continue statement must be nested within an iteration statement"
+    |                                      ^ Label 'b' does not denote an iteration statement"
 `;
 
 exports[`Statements - Continue > Declarations - Continue > a: if (x) for (;;) { continue a; } 1`] = `
-"SyntaxError [1:31-1:32]: continue statement must be nested within an iteration statement
+"SyntaxError [1:30-1:31]: Label 'a' does not denote an iteration statement
 > 1 | a: if (x) for (;;) { continue a; }
-    |                                ^ continue statement must be nested within an iteration statement"
+    |                               ^ Label 'a' does not denote an iteration statement"
 `;
 
 exports[`Statements - Continue > Declarations - Continue > a: switch (x) { default: for (;;) continue a; } 1`] = `
-"SyntaxError [1:44-1:45]: continue statement must be nested within an iteration statement
+"SyntaxError [1:43-1:44]: Label 'a' does not denote an iteration statement
 > 1 | a: switch (x) { default: for (;;) continue a; }
-    |                                             ^ continue statement must be nested within an iteration statement"
+    |                                            ^ Label 'a' does not denote an iteration statement"
 `;
 
 exports[`Statements - Continue > Declarations - Continue > a: try { for (;;) continue a; } finally {} 1`] = `
-"SyntaxError [1:28-1:29]: continue statement must be nested within an iteration statement
+"SyntaxError [1:27-1:28]: Label 'a' does not denote an iteration statement
 > 1 | a: try { for (;;) continue a; } finally {}
-    |                             ^ continue statement must be nested within an iteration statement"
+    |                            ^ Label 'a' does not denote an iteration statement"
 `;
 
 exports[`Statements - Continue > Declarations - Continue > ce: while(true) { continue fapper; } 1`] = `
-"SyntaxError [1:33-1:34]: Undefined label 'fapper'
+"SyntaxError [1:27-1:33]: Undefined label 'fapper'
 > 1 | ce: while(true) { continue fapper; }
-    |                                  ^ Undefined label 'fapper'"
+    |                            ^^^^^^ Undefined label 'fapper'"
 `;
 
 exports[`Statements - Continue > Declarations - Continue > continue
@@ -145,33 +145,33 @@ exports[`Statements - Continue > Declarations - Continue > continue; continue; 1
 `;
 
 exports[`Statements - Continue > Declarations - Continue > do     continue y   ; while(true); 1`] = `
-"SyntaxError [1:20-1:21]: Undefined label 'y'
+"SyntaxError [1:16-1:17]: Undefined label 'y'
 > 1 | do     continue y   ; while(true);
-    |                     ^ Undefined label 'y'"
+    |                 ^ Undefined label 'y'"
 `;
 
 exports[`Statements - Continue > Declarations - Continue > do     if (x) continue y   ; while(true); 1`] = `
-"SyntaxError [1:27-1:28]: Undefined label 'y'
+"SyntaxError [1:23-1:24]: Undefined label 'y'
 > 1 | do     if (x) continue y   ; while(true);
-    |                            ^ Undefined label 'y'"
+    |                        ^ Undefined label 'y'"
 `;
 
 exports[`Statements - Continue > Declarations - Continue > do     if (x) continue y   ; while(true); 2`] = `
-"SyntaxError [1:27-1:28]: Undefined label 'y'
+"SyntaxError [1:23-1:24]: Undefined label 'y'
 > 1 | do     if (x) continue y   ; while(true);
-    |                            ^ Undefined label 'y'"
+    |                        ^ Undefined label 'y'"
 `;
 
 exports[`Statements - Continue > Declarations - Continue > do {  test262: {  continue test262; } } while (a) 1`] = `
-"SyntaxError [1:34-1:35]: continue statement must be nested within an iteration statement
+"SyntaxError [1:27-1:34]: Label 'test262' does not denote an iteration statement
 > 1 | do {  test262: {  continue test262; } } while (a)
-    |                                   ^ continue statement must be nested within an iteration statement"
+    |                            ^^^^^^^ Label 'test262' does not denote an iteration statement"
 `;
 
 exports[`Statements - Continue > Declarations - Continue > for (;;)    continue y  1`] = `
-"SyntaxError [1:22-1:23]: Undefined label 'y'
+"SyntaxError [1:21-1:22]: Undefined label 'y'
 > 1 | for (;;)    continue y 
-    |                       ^ Undefined label 'y'"
+    |                      ^ Undefined label 'y'"
 `;
 
 exports[`Statements - Continue > Declarations - Continue > function f(){    continue    } 1`] = `
@@ -223,39 +223,39 @@ exports[`Statements - Continue > Declarations - Continue > function f(){   { con
 `;
 
 exports[`Statements - Continue > Declarations - Continue > function f(){ do        if (x) continue y   ; while(true);} 1`] = `
-"SyntaxError [1:44-1:45]: Undefined label 'y'
+"SyntaxError [1:40-1:41]: Undefined label 'y'
 > 1 | function f(){ do        if (x) continue y   ; while(true);}
-    |                                             ^ Undefined label 'y'"
+    |                                         ^ Undefined label 'y'"
 `;
 
 exports[`Statements - Continue > Declarations - Continue > function f(){ do        if (x) continue y   ; while(true);} 2`] = `
-"SyntaxError [1:44-1:45]: Undefined label 'y'
+"SyntaxError [1:40-1:41]: Undefined label 'y'
 > 1 | function f(){ do        if (x) continue y   ; while(true);}
-    |                                             ^ Undefined label 'y'"
+    |                                         ^ Undefined label 'y'"
 `;
 
 exports[`Statements - Continue > Declarations - Continue > function f(){ for (;;)       if (x) continue y   } 1`] = `
-"SyntaxError [1:49-1:50]: Undefined label 'y'
+"SyntaxError [1:45-1:46]: Undefined label 'y'
 > 1 | function f(){ for (;;)       if (x) continue y   }
-    |                                                  ^ Undefined label 'y'"
+    |                                              ^ Undefined label 'y'"
 `;
 
 exports[`Statements - Continue > Declarations - Continue > function f(){ for (;;)       if (x) continue y   }} 1`] = `
-"SyntaxError [1:49-1:50]: Undefined label 'y'
+"SyntaxError [1:45-1:46]: Undefined label 'y'
 > 1 | function f(){ for (;;)       if (x) continue y   }}
-    |                                                  ^ Undefined label 'y'"
+    |                                              ^ Undefined label 'y'"
 `;
 
 exports[`Statements - Continue > Declarations - Continue > function f(){ while (true)       if (x) continue y   } 1`] = `
-"SyntaxError [1:53-1:54]: Undefined label 'y'
+"SyntaxError [1:49-1:50]: Undefined label 'y'
 > 1 | function f(){ while (true)       if (x) continue y   }
-    |                                                      ^ Undefined label 'y'"
+    |                                                  ^ Undefined label 'y'"
 `;
 
 exports[`Statements - Continue > Declarations - Continue > function f(){ while (true)       if (x) continue y   }} 1`] = `
-"SyntaxError [1:53-1:54]: Undefined label 'y'
+"SyntaxError [1:49-1:50]: Undefined label 'y'
 > 1 | function f(){ while (true)       if (x) continue y   }}
-    |                                                      ^ Undefined label 'y'"
+    |                                                  ^ Undefined label 'y'"
 `;
 
 exports[`Statements - Continue > Declarations - Continue > if (x) continue y 1`] = `
@@ -275,11 +275,11 @@ exports[`Statements - Continue > Declarations - Continue > label: {
     continue label;
   }
 } 1`] = `
-"SyntaxError [3:18-3:19]: continue statement must be nested within an iteration statement
+"SyntaxError [3:13-3:18]: Label 'label' does not denote an iteration statement
   1 | label: {
   2 |   for ( ;; ) {
 > 3 |     continue label;
-    |                   ^ continue statement must be nested within an iteration statement
+    |              ^^^^^ Label 'label' does not denote an iteration statement
   4 |   }
   5 | }"
 `;
@@ -417,15 +417,15 @@ LABEL2 : do {
 `;
 
 exports[`Statements - Continue > Declarations - Continue > while (true)    if (x) continue y   } 1`] = `
-"SyntaxError [1:36-1:37]: Undefined label 'y'
+"SyntaxError [1:32-1:33]: Undefined label 'y'
 > 1 | while (true)    if (x) continue y   }
-    |                                     ^ Undefined label 'y'"
+    |                                 ^ Undefined label 'y'"
 `;
 
 exports[`Statements - Continue > Declarations - Continue > while (true) continue x; 1`] = `
-"SyntaxError [1:23-1:24]: Undefined label 'x'
+"SyntaxError [1:22-1:23]: Undefined label 'x'
 > 1 | while (true) continue x;
-    |                        ^ Undefined label 'x'"
+    |                       ^ Undefined label 'x'"
 `;
 
 exports[`Statements - Continue > Statements - Continue > () => { do        if (x) continue   ; while(true);} 1`] = `

--- a/test/parser/statements/__snapshots__/continue.ts.snap
+++ b/test/parser/statements/__snapshots__/continue.ts.snap
@@ -50,6 +50,42 @@ y++;
   5 | } while(0);"
 `;
 
+exports[`Statements - Continue > Declarations - Continue > a: { b: for (;;) { continue a; } } 1`] = `
+"SyntaxError [1:29-1:30]: continue statement must be nested within an iteration statement
+> 1 | a: { b: for (;;) { continue a; } }
+    |                              ^ continue statement must be nested within an iteration statement"
+`;
+
+exports[`Statements - Continue > Declarations - Continue > a: { for (;;) { continue a; } } 1`] = `
+"SyntaxError [1:26-1:27]: continue statement must be nested within an iteration statement
+> 1 | a: { for (;;) { continue a; } }
+    |                           ^ continue statement must be nested within an iteration statement"
+`;
+
+exports[`Statements - Continue > Declarations - Continue > a: for (;;) { b: { for (;;) continue b; } } 1`] = `
+"SyntaxError [1:38-1:39]: continue statement must be nested within an iteration statement
+> 1 | a: for (;;) { b: { for (;;) continue b; } }
+    |                                       ^ continue statement must be nested within an iteration statement"
+`;
+
+exports[`Statements - Continue > Declarations - Continue > a: if (x) for (;;) { continue a; } 1`] = `
+"SyntaxError [1:31-1:32]: continue statement must be nested within an iteration statement
+> 1 | a: if (x) for (;;) { continue a; }
+    |                                ^ continue statement must be nested within an iteration statement"
+`;
+
+exports[`Statements - Continue > Declarations - Continue > a: switch (x) { default: for (;;) continue a; } 1`] = `
+"SyntaxError [1:44-1:45]: continue statement must be nested within an iteration statement
+> 1 | a: switch (x) { default: for (;;) continue a; }
+    |                                             ^ continue statement must be nested within an iteration statement"
+`;
+
+exports[`Statements - Continue > Declarations - Continue > a: try { for (;;) continue a; } finally {} 1`] = `
+"SyntaxError [1:28-1:29]: continue statement must be nested within an iteration statement
+> 1 | a: try { for (;;) continue a; } finally {}
+    |                             ^ continue statement must be nested within an iteration statement"
+`;
+
 exports[`Statements - Continue > Declarations - Continue > ce: while(true) { continue fapper; } 1`] = `
 "SyntaxError [1:33-1:34]: Undefined label 'fapper'
 > 1 | ce: while(true) { continue fapper; }
@@ -232,6 +268,20 @@ exports[`Statements - Continue > Declarations - Continue > if (x) continue; 1`] 
 "SyntaxError [1:7-1:15]: Illegal continue statement
 > 1 | if (x) continue;
     |        ^^^^^^^^ Illegal continue statement"
+`;
+
+exports[`Statements - Continue > Declarations - Continue > label: {
+  for ( ;; ) {
+    continue label;
+  }
+} 1`] = `
+"SyntaxError [3:18-3:19]: continue statement must be nested within an iteration statement
+  1 | label: {
+  2 |   for ( ;; ) {
+> 3 |     continue label;
+    |                   ^ continue statement must be nested within an iteration statement
+  4 |   }
+  5 | }"
 `;
 
 exports[`Statements - Continue > Declarations - Continue > loop1: while (true) { loop1: function a() { continue loop1; } } 1`] = `
@@ -456,6 +506,47 @@ exports[`Statements - Continue > Statements - Continue > __proto__: while (true)
 }
 `;
 
+exports[`Statements - Continue > Statements - Continue > a: b: for (;;) { continue a; } 1`] = `
+{
+  "body": [
+    {
+      "body": {
+        "body": {
+          "body": {
+            "body": [
+              {
+                "label": {
+                  "name": "a",
+                  "type": "Identifier",
+                },
+                "type": "ContinueStatement",
+              },
+            ],
+            "type": "BlockStatement",
+          },
+          "init": null,
+          "test": null,
+          "type": "ForStatement",
+          "update": null,
+        },
+        "label": {
+          "name": "b",
+          "type": "Identifier",
+        },
+        "type": "LabeledStatement",
+      },
+      "label": {
+        "name": "a",
+        "type": "Identifier",
+      },
+      "type": "LabeledStatement",
+    },
+  ],
+  "sourceType": "script",
+  "type": "Program",
+}
+`;
+
 exports[`Statements - Continue > Statements - Continue > a: do continue a; while(1); 1`] = `
 {
   "body": [
@@ -473,6 +564,140 @@ exports[`Statements - Continue > Statements - Continue > a: do continue a; while
           "value": 1,
         },
         "type": "DoWhileStatement",
+      },
+      "label": {
+        "name": "a",
+        "type": "Identifier",
+      },
+      "type": "LabeledStatement",
+    },
+  ],
+  "sourceType": "script",
+  "type": "Program",
+}
+`;
+
+exports[`Statements - Continue > Statements - Continue > a: for (;;) { for (;;) continue a; } 1`] = `
+{
+  "body": [
+    {
+      "body": {
+        "body": {
+          "body": [
+            {
+              "body": {
+                "label": {
+                  "name": "a",
+                  "type": "Identifier",
+                },
+                "type": "ContinueStatement",
+              },
+              "init": null,
+              "test": null,
+              "type": "ForStatement",
+              "update": null,
+            },
+          ],
+          "type": "BlockStatement",
+        },
+        "init": null,
+        "test": null,
+        "type": "ForStatement",
+        "update": null,
+      },
+      "label": {
+        "name": "a",
+        "type": "Identifier",
+      },
+      "type": "LabeledStatement",
+    },
+  ],
+  "sourceType": "script",
+  "type": "Program",
+}
+`;
+
+exports[`Statements - Continue > Statements - Continue > a: for (;;) { switch (x) { case 1: continue a; } } 1`] = `
+{
+  "body": [
+    {
+      "body": {
+        "body": {
+          "body": [
+            {
+              "cases": [
+                {
+                  "consequent": [
+                    {
+                      "label": {
+                        "name": "a",
+                        "type": "Identifier",
+                      },
+                      "type": "ContinueStatement",
+                    },
+                  ],
+                  "test": {
+                    "type": "Literal",
+                    "value": 1,
+                  },
+                  "type": "SwitchCase",
+                },
+              ],
+              "discriminant": {
+                "name": "x",
+                "type": "Identifier",
+              },
+              "type": "SwitchStatement",
+            },
+          ],
+          "type": "BlockStatement",
+        },
+        "init": null,
+        "test": null,
+        "type": "ForStatement",
+        "update": null,
+      },
+      "label": {
+        "name": "a",
+        "type": "Identifier",
+      },
+      "type": "LabeledStatement",
+    },
+  ],
+  "sourceType": "script",
+  "type": "Program",
+}
+`;
+
+exports[`Statements - Continue > Statements - Continue > a: for (;;) b: for (;;) continue b; 1`] = `
+{
+  "body": [
+    {
+      "body": {
+        "body": {
+          "body": {
+            "body": {
+              "label": {
+                "name": "b",
+                "type": "Identifier",
+              },
+              "type": "ContinueStatement",
+            },
+            "init": null,
+            "test": null,
+            "type": "ForStatement",
+            "update": null,
+          },
+          "label": {
+            "name": "b",
+            "type": "Identifier",
+          },
+          "type": "LabeledStatement",
+        },
+        "init": null,
+        "test": null,
+        "type": "ForStatement",
+        "update": null,
       },
       "label": {
         "name": "a",
@@ -589,6 +814,53 @@ exports[`Statements - Continue > Statements - Continue > a: while (0) { continue
         "test": {
           "type": "Literal",
           "value": 0,
+        },
+        "type": "WhileStatement",
+      },
+      "label": {
+        "name": "a",
+        "type": "Identifier",
+      },
+      "type": "LabeledStatement",
+    },
+  ],
+  "sourceType": "script",
+  "type": "Program",
+}
+`;
+
+exports[`Statements - Continue > Statements - Continue > a: while (x) { b: { continue a; } } 1`] = `
+{
+  "body": [
+    {
+      "body": {
+        "body": {
+          "body": [
+            {
+              "body": {
+                "body": [
+                  {
+                    "label": {
+                      "name": "a",
+                      "type": "Identifier",
+                    },
+                    "type": "ContinueStatement",
+                  },
+                ],
+                "type": "BlockStatement",
+              },
+              "label": {
+                "name": "b",
+                "type": "Identifier",
+              },
+              "type": "LabeledStatement",
+            },
+          ],
+          "type": "BlockStatement",
+        },
+        "test": {
+          "name": "x",
+          "type": "Identifier",
         },
         "type": "WhileStatement",
       },
@@ -768,6 +1040,46 @@ exports[`Statements - Continue > Statements - Continue > for (;;)  { if (x) cont
               "type": "Identifier",
             },
             "type": "IfStatement",
+          },
+        ],
+        "type": "BlockStatement",
+      },
+      "init": null,
+      "test": null,
+      "type": "ForStatement",
+      "update": null,
+    },
+  ],
+  "sourceType": "script",
+  "type": "Program",
+}
+`;
+
+exports[`Statements - Continue > Statements - Continue > for (;;) { a: for (;;) continue a; } 1`] = `
+{
+  "body": [
+    {
+      "body": {
+        "body": [
+          {
+            "body": {
+              "body": {
+                "label": {
+                  "name": "a",
+                  "type": "Identifier",
+                },
+                "type": "ContinueStatement",
+              },
+              "init": null,
+              "test": null,
+              "type": "ForStatement",
+              "update": null,
+            },
+            "label": {
+              "name": "a",
+              "type": "Identifier",
+            },
+            "type": "LabeledStatement",
           },
         ],
         "type": "BlockStatement",

--- a/test/parser/statements/__snapshots__/labeled.ts.snap
+++ b/test/parser/statements/__snapshots__/labeled.ts.snap
@@ -97,9 +97,9 @@ exports[`Statements - Labeled > Statements - Labeled (fail) > bar: function* x()
 `;
 
 exports[`Statements - Labeled > Statements - Labeled (fail) > do { test262: { continue test262; } } while (false) 1`] = `
-"SyntaxError [1:32-1:33]: continue statement must be nested within an iteration statement
+"SyntaxError [1:25-1:32]: Label 'test262' does not denote an iteration statement
 > 1 | do { test262: { continue test262; } } while (false)
-    |                                 ^ continue statement must be nested within an iteration statement"
+    |                          ^^^^^^^ Label 'test262' does not denote an iteration statement"
 `;
 
 exports[`Statements - Labeled > Statements - Labeled (fail) > false: ; 1`] = `
@@ -253,15 +253,15 @@ exports[`Statements - Labeled > Statements - Labeled (fail) > yield: { function 
 `;
 
 exports[`Statements - Labeled > Statements - Labeled (fail) > yield: { function *f(){ break await; } } 2`] = `
-"SyntaxError [1:35-1:36]: Undefined label 'await'
+"SyntaxError [1:30-1:35]: Undefined label 'await'
 > 1 | yield: { function *f(){ break await; } }
-    |                                    ^ Undefined label 'await'"
+    |                               ^^^^^ Undefined label 'await'"
 `;
 
 exports[`Statements - Labeled > Statements - Labeled (fail) > yield: { function *f(){ break await; } } 3`] = `
-"SyntaxError [1:35-1:36]: Undefined label 'await'
+"SyntaxError [1:30-1:35]: Undefined label 'await'
 > 1 | yield: { function *f(){ break await; } }
-    |                                    ^ Undefined label 'await'"
+    |                               ^^^^^ Undefined label 'await'"
 `;
 
 exports[`Statements - Labeled > Statements - Labeled (fail) > yield: 1; 1`] = `

--- a/test/parser/statements/break.ts
+++ b/test/parser/statements/break.ts
@@ -160,5 +160,6 @@ describe('Statements - Break', () => {
     { code: 'this', options: { ranges: true } },
     'foo: switch (x) { case x: if (foo) {break foo;} }',
     { code: 'switch (x) { case x: break; }', options: { ranges: true } },
+    'a: { for (;;) { break a; } }',
   ]);
 });

--- a/test/parser/statements/continue.ts
+++ b/test/parser/statements/continue.ts
@@ -95,6 +95,19 @@ describe('Statements - Continue', () => {
     'switch (x){ case z:    if (x) continue   }',
     'switch (x){ case z:    continue y   }',
     'switch (x){ case z:    if (x) continue y   }',
+    'a: { for (;;) { continue a; } }',
+    'a: { b: for (;;) { continue a; } }',
+    'a: if (x) for (;;) { continue a; }',
+    'a: switch (x) { default: for (;;) continue a; }',
+    'a: try { for (;;) continue a; } finally {}',
+    'a: for (;;) { b: { for (;;) continue b; } }',
+    outdent`
+      label: {
+        for ( ;; ) {
+          continue label;
+        }
+      }
+    `,
   ]);
 
   pass('Statements - Continue', [
@@ -113,5 +126,11 @@ describe('Statements - Continue', () => {
     'while (true) {  continue   }',
     'foo: while(true)continue foo;',
     'foo: while (true) { if (x) continue foo; }',
+    'a: b: for (;;) { continue a; }',
+    'a: for (;;) { for (;;) continue a; }',
+    'a: for (;;) b: for (;;) continue b;',
+    'for (;;) { a: for (;;) continue a; }',
+    'a: while (x) { b: { continue a; } }',
+    'a: for (;;) { switch (x) { case 1: continue a; } }',
   ]);
 });

--- a/test262/whitelist.txt
+++ b/test262/whitelist.txt
@@ -1,4 +1,2 @@
-language/statements/block/labeled-continue.js (default)
-language/statements/block/labeled-continue.js (strict mode)
 staging/sm/fields/await-identifier-module-3.js (default)
 staging/sm/fields/await-identifier-module-3.js (strict mode)


### PR DESCRIPTION
`a: { for (;;) { continue a; } }` parses. A `continue` may only target a label of an iteration statement it is nested in, and `a` here labels a block, so ContainsUndefinedContinueTarget makes it an early SyntaxError. The same hole accepts a label on an `if`, on a `switch` case, on a `try` block, and on a block nested inside a loop. V8 and Acorn reject all of them, and the whitelisted test262 fixture `language/statements/block/labeled-continue.js` is exactly this shape.

`isValidLabel` in `src/common.ts` walks the label set chain outwards from the `continue` and cleared its "must be inside an iteration statement" requirement at the first set marked `loop`, then accepted the label wherever it turned up further out. Any loop between the `continue` and the label satisfied the check, whatever statement the label was actually attached to.

`parseIterationStatementBody` marks an iteration statement's body set with `loop`, and a labelled statement declares its label into the set it is itself parsed with, so the set directly above a `loop` set holds that iteration statement's own labels. The walk now tracks whether the set it is looking at is such a set, and only accepts a `continue` label declared there. `break` passes `isIterationStatement` as 0 and is untouched, so `a: { for (;;) { break a; } }` still parses; there is a test for that.

Verification on Node 22 against `main` at 56416fa. The seven newly rejected shapes fail on unmodified `main` with "Expect a ParserError thrown" and pass with the change; six accepted shapes are added alongside them, including `a: b: for (;;) { continue a; }`, `a: for (;;) { for (;;) continue a; }` and `a: while (x) { b: { continue a; } }`. `vitest run` is 91860 passing over 139 files with no existing snapshot touched. Full test262 at the pinned commit 7710052 goes from 8694 to 8696 invalid programs rejected while valid programs accepted stays at 94569, so nothing valid was tightened out, and the two `labeled-continue.js` whitelist lines come out. The ast alignment, jsx alignment and production suites pass, and `eslint`, `prettier --check`, `tsc`, `cspell`, `knip` and `generate-unicode.mjs --check` are clean.
