### PR TITLE
fix(parser): reject `await` in class field initializers

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -8929,9 +8929,11 @@ function parsePropertyDefinition(
 
     if (parser.getToken() === Token.Arguments) parser.report(Errors.StrictEvalArguments);
 
+    // Initializer[+In, ~Yield, ~Await]: a module top-level `await` must not reach the initializer either.
     const modifierFlags =
       Context.InYieldContext |
       Context.InAwaitContext |
+      Context.InGlobal |
       Context.InArgumentList |
       ((state & PropertyKind.Constructor) === 0 ? Context.SuperCall | Context.InConstructor : 0);
 

--- a/test/parser/miscellaneous/__snapshots__/public-fields.ts.snap
+++ b/test/parser/miscellaneous/__snapshots__/public-fields.ts.snap
@@ -1,5 +1,17 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Public fields > Public fields (fail) > (async () => class { x = await 1 }) 1`] = `
+"SyntaxError [1:25-1:30]: Await is only valid in async functions
+> 1 | (async () => class { x = await 1 })
+    |                          ^^^^^ Await is only valid in async functions"
+`;
+
+exports[`Public fields > Public fields (fail) > async () => class { x = await 1 }; 1`] = `
+"SyntaxError [1:24-1:29]: Await is only valid in async functions
+> 1 | async () => class { x = await 1 };
+    |                         ^^^^^ Await is only valid in async functions"
+`;
+
 exports[`Public fields > Public fields (fail) > class A { "x" = arguments; } 1`] = `
 "SyntaxError [1:16-1:25]: Unexpected eval or arguments in strict mode
 > 1 | class A { "x" = arguments; }
@@ -88,6 +100,36 @@ exports[`Public fields > Public fields (fail) > class C { #m = function() { retu
 "SyntaxError [1:95-1:96]: Private fields can't be accessed on super
 > 1 | class C { #m = function() { return "bar"; }; Child = class extends C { access() { return super.#m; } method() { return super.#m(); } } }
     |                                                                                                ^ Private fields can't be accessed on super"
+`;
+
+exports[`Public fields > Public fields (fail) > class C { static x = await 1 } 1`] = `
+"SyntaxError [1:21-1:26]: Await is only valid in async functions
+> 1 | class C { static x = await 1 }
+    |                      ^^^^^ Await is only valid in async functions"
+`;
+
+exports[`Public fields > Public fields (fail) > class C { x = () => await 1 } 1`] = `
+"SyntaxError [1:20-1:25]: Await is only valid in async functions
+> 1 | class C { x = () => await 1 }
+    |                     ^^^^^ Await is only valid in async functions"
+`;
+
+exports[`Public fields > Public fields (fail) > class C { x = (await 1) } 1`] = `
+"SyntaxError [1:15-1:20]: Await is only valid in async functions
+> 1 | class C { x = (await 1) }
+    |                ^^^^^ Await is only valid in async functions"
+`;
+
+exports[`Public fields > Public fields (fail) > class C { x = await 1 } 1`] = `
+"SyntaxError [1:14-1:19]: Await is only valid in async functions
+> 1 | class C { x = await 1 }
+    |               ^^^^^ Await is only valid in async functions"
+`;
+
+exports[`Public fields > Public fields (fail) > class C { x = class { y = await 1 } } 1`] = `
+"SyntaxError [1:26-1:31]: Await is only valid in async functions
+> 1 | class C { x = class { y = await 1 } }
+    |                           ^^^^^ Await is only valid in async functions"
 `;
 
 exports[`Public fields > Public fields (fail) > var C = class { x = () => arguments); } 1`] = `
@@ -658,6 +700,56 @@ exports[`Public fields > Public fields (pass) > { class X { static p = function(
   ],
   "sourceType": "script",
   "start": 0,
+  "type": "Program",
+}
+`;
+
+exports[`Public fields > Public fields (pass) > async function g() { return class { x = await }; } 1`] = `
+{
+  "body": [
+    {
+      "async": true,
+      "body": {
+        "body": [
+          {
+            "argument": {
+              "body": {
+                "body": [
+                  {
+                    "computed": false,
+                    "key": {
+                      "name": "x",
+                      "type": "Identifier",
+                    },
+                    "static": false,
+                    "type": "PropertyDefinition",
+                    "value": {
+                      "name": "await",
+                      "type": "Identifier",
+                    },
+                  },
+                ],
+                "type": "ClassBody",
+              },
+              "id": null,
+              "superClass": null,
+              "type": "ClassExpression",
+            },
+            "type": "ReturnStatement",
+          },
+        ],
+        "type": "BlockStatement",
+      },
+      "generator": false,
+      "id": {
+        "name": "g",
+        "type": "Identifier",
+      },
+      "params": [],
+      "type": "FunctionDeclaration",
+    },
+  ],
+  "sourceType": "script",
   "type": "Program",
 }
 `;
@@ -1443,6 +1535,44 @@ exports[`Public fields > Public fields (pass) > class A { set; } 1`] = `
 }
 `;
 
+exports[`Public fields > Public fields (pass) > class C { [await 1] = 1 } 1`] = `
+{
+  "body": [
+    {
+      "body": {
+        "body": [
+          {
+            "computed": true,
+            "key": {
+              "argument": {
+                "type": "Literal",
+                "value": 1,
+              },
+              "type": "AwaitExpression",
+            },
+            "static": false,
+            "type": "PropertyDefinition",
+            "value": {
+              "type": "Literal",
+              "value": 1,
+            },
+          },
+        ],
+        "type": "ClassBody",
+      },
+      "id": {
+        "name": "C",
+        "type": "Identifier",
+      },
+      "superClass": null,
+      "type": "ClassDeclaration",
+    },
+  ],
+  "sourceType": "module",
+  "type": "Program",
+}
+`;
+
 exports[`Public fields > Public fields (pass) > class C { static x } 1`] = `
 {
   "body": [
@@ -1567,6 +1697,126 @@ exports[`Public fields > Public fields (pass) > class C { static x } 1`] = `
   ],
   "sourceType": "script",
   "start": 0,
+  "type": "Program",
+}
+`;
+
+exports[`Public fields > Public fields (pass) > class C { x = 1 }; await 1; 1`] = `
+{
+  "body": [
+    {
+      "body": {
+        "body": [
+          {
+            "computed": false,
+            "key": {
+              "name": "x",
+              "type": "Identifier",
+            },
+            "static": false,
+            "type": "PropertyDefinition",
+            "value": {
+              "type": "Literal",
+              "value": 1,
+            },
+          },
+        ],
+        "type": "ClassBody",
+      },
+      "id": {
+        "name": "C",
+        "type": "Identifier",
+      },
+      "superClass": null,
+      "type": "ClassDeclaration",
+    },
+    {
+      "type": "EmptyStatement",
+    },
+    {
+      "expression": {
+        "argument": {
+          "type": "Literal",
+          "value": 1,
+        },
+        "type": "AwaitExpression",
+      },
+      "type": "ExpressionStatement",
+    },
+  ],
+  "sourceType": "module",
+  "type": "Program",
+}
+`;
+
+exports[`Public fields > Public fields (pass) > class C { x = async () => await 1 } 1`] = `
+{
+  "body": [
+    {
+      "body": {
+        "body": [
+          {
+            "computed": false,
+            "key": {
+              "name": "x",
+              "type": "Identifier",
+            },
+            "static": false,
+            "type": "PropertyDefinition",
+            "value": {
+              "async": true,
+              "body": {
+                "argument": {
+                  "type": "Literal",
+                  "value": 1,
+                },
+                "type": "AwaitExpression",
+              },
+              "expression": true,
+              "generator": false,
+              "params": [],
+              "type": "ArrowFunctionExpression",
+            },
+          },
+        ],
+        "type": "ClassBody",
+      },
+      "id": {
+        "name": "C",
+        "type": "Identifier",
+      },
+      "superClass": null,
+      "type": "ClassDeclaration",
+    },
+  ],
+  "sourceType": "module",
+  "type": "Program",
+}
+`;
+
+exports[`Public fields > Public fields (pass) > class C extends (await 1) {} 1`] = `
+{
+  "body": [
+    {
+      "body": {
+        "body": [],
+        "type": "ClassBody",
+      },
+      "id": {
+        "name": "C",
+        "type": "Identifier",
+      },
+      "superClass": {
+        "argument": {
+          "type": "Literal",
+          "value": 1,
+        },
+        "type": "AwaitExpression",
+      },
+      "type": "ClassDeclaration",
+    },
+  ],
+  "sourceType": "module",
   "type": "Program",
 }
 `;

--- a/test/parser/miscellaneous/public-fields.ts
+++ b/test/parser/miscellaneous/public-fields.ts
@@ -29,6 +29,13 @@ describe('Public fields', () => {
     { code: 'class A { a b() {} }' },
     { code: 'class A { a = 1, 2 }' },
     { code: 'class A { a = 1, b = 2 }' },
+    { code: 'class C { x = await 1 }', options: { sourceType: 'module' } },
+    { code: 'class C { static x = await 1 }', options: { sourceType: 'module' } },
+    { code: 'class C { x = (await 1) }', options: { sourceType: 'module' } },
+    { code: 'class C { x = () => await 1 }', options: { sourceType: 'module' } },
+    { code: 'class C { x = class { y = await 1 } }', options: { sourceType: 'module' } },
+    { code: 'async () => class { x = await 1 };', options: { sourceType: 'module' } },
+    { code: '(async () => class { x = await 1 })', options: { sourceType: 'module' } },
   ]);
 
   for (const text of [
@@ -126,6 +133,8 @@ describe('Public fields', () => {
     'async;\n a;',
     'await;',
     'await = 0;',
+    'x = await;',
+    'static x = await;',
     'await;\n a;',
     '\nx;\ny;\n\n',
     "static ['constructor'];",
@@ -192,6 +201,11 @@ describe('Public fields', () => {
   }
 
   pass('Public fields (pass)', [
+    { code: 'class C { [await 1] = 1 }', options: { sourceType: 'module' } },
+    { code: 'class C extends (await 1) {}', options: { sourceType: 'module' } },
+    { code: 'class C { x = async () => await 1 }', options: { sourceType: 'module' } },
+    { code: 'class C { x = 1 }; await 1;', options: { sourceType: 'module' } },
+    { code: 'async function g() { return class { x = await }; }' },
     { code: 'var C = class { static async #prototype() {} };', options: { ranges: true } },
     { code: 'class Foo { x = 1; }', options: { ranges: true } },
     { code: 'class A { set; }', options: { ranges: true } },

--- a/test262/whitelist.txt
+++ b/test262/whitelist.txt
@@ -1,2 +1,1 @@
-staging/sm/fields/await-identifier-module-3.js (default)
-staging/sm/fields/await-identifier-module-3.js (strict mode)
+


### PR DESCRIPTION
In modules, `class C { x = await 1 }` and classes inside concise async arrows accepted `await` expressions in field initializers.

Clearing `InGlobal` on entry to the initializer rejects those expressions while preserving `await` in computed keys, `extends` expressions and nested async arrows, and identifier use in scripts.

The new rejection cases fail before the fix and pass with it, the parser and test262 suites pass, and whitelist regeneration removes the two `await-identifier-module-3.js` lines.

This also allows valid object-literal accessor, async and generator method names written as escaped reserved words inside initializers, matching their existing behavior inside function bodies.
