### PR TITLE
refactor: type `Labels` as a chained label set

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -1,4 +1,5 @@
 import { Errors } from './errors.ts';
+import { type Labels } from './estree.ts';
 import { nextToken } from './lexer/scan.ts';
 import { type Parser } from './parser/parser.ts';
 import { KeywordDescTable, Token } from './token.ts';
@@ -381,7 +382,12 @@ export function isPropertyWithPrivateFieldKey(expr: any): boolean {
  * @param name Current label
  * @param isIterationStatement
  */
-export function isValidLabel(parser: Parser, labels: any, name: string, isIterationStatement: 0 | 1): 0 | 1 {
+export function isValidLabel(
+  parser: Parser,
+  labels: Labels | undefined,
+  name: string,
+  isIterationStatement: 0 | 1,
+): 0 | 1 {
   // A `continue` may only target a label of an iteration statement it is nested in, so
   // the label has to be declared in the label set that iteration statement was parsed
   // with. Label sets chain outwards and the set marked `loop` is an iteration statement
@@ -389,13 +395,13 @@ export function isValidLabel(parser: Parser, labels: any, name: string, isIterat
   let isIterationLabelSet: 0 | 1 = 0;
 
   while (labels) {
-    if (labels['$' + name]) {
+    if (labels[`$${name}`]) {
       // A label is declared at most once per chain, so this is its only declaration.
       if (isIterationStatement && !isIterationLabelSet) parser.report(Errors.InvalidNestedStatement, name);
       return 1;
     }
     isIterationLabelSet = labels.loop ? 1 : 0;
-    labels = labels['$'];
+    labels = labels.$;
   }
 
   return 0;
@@ -409,14 +415,14 @@ export function isValidLabel(parser: Parser, labels: any, name: string, isIterat
  * @param labels Object holding the labels
  * @param name Current label
  */
-export function validateAndDeclareLabel(parser: Parser, labels: any, name: string): void {
-  let set = labels;
+export function validateAndDeclareLabel(parser: Parser, labels: Labels, name: string): void {
+  let set: Labels | undefined = labels;
   while (set) {
-    if (set['$' + name]) parser.report(Errors.LabelRedeclaration, name);
-    set = set['$'];
+    if (set[`$${name}`]) parser.report(Errors.LabelRedeclaration, name);
+    set = set.$;
   }
 
-  labels['$' + name] = 1;
+  labels[`$${name}`] = 1;
 }
 
 /** @internal */

--- a/src/estree.ts
+++ b/src/estree.ts
@@ -27,7 +27,10 @@ export interface Labels {
   $?: Labels;
   /** Marks the label set an iteration statement body is parsed with. */
   loop?: 1;
-  /** A label declared in this set, keyed by `$` followed by its name. */
+  /**
+   * A label declared in this set, keyed by `$` followed by its name. Always `1`;
+   * `Labels` is in the union only because the `$` key above matches this pattern.
+   */
   [label: `$${string}`]: Labels | 1 | undefined;
 }
 

--- a/src/estree.ts
+++ b/src/estree.ts
@@ -18,7 +18,18 @@ export interface Position {
   column: number;
 }
 
-export type Labels = any;
+/**
+ * The label set a statement is parsed with, chained outwards through `$` to the
+ * set of the statement it is nested in.
+ */
+export interface Labels {
+  /** The label set of the enclosing statement. */
+  $?: Labels;
+  /** Marks the label set an iteration statement body is parsed with. */
+  loop?: 1;
+  /** A label declared in this set, keyed by `$` followed by its name. */
+  [label: `$${string}`]: Labels | 1 | undefined;
+}
 
 export type IdentifierOrExpression = Identifier | Expression | ArrowFunctionExpression;
 


### PR DESCRIPTION
`Labels` was `export type Labels = any`, so nothing in the label-set walk was checked. Neither the shape of the sets the parser builds nor the keys the helpers read off them. `isValidLabel` and `validateAndDeclareLabel` took `labels: any` on top of that.

I typed it as the object the parser actually builds. `$` links to the label set of the enclosing statement, `loop` is set only by `parseIterationStatementBody` to mark an iteration statement body's set, and a declared label is keyed by `$` followed by its name. The template literal index signature is the reason to prefer this over a plain `[key: string]` signature: it rejects keys that are not `$`-prefixed, which is the invariant the two helpers rely on.

The only runtime-adjacent change is that the three lookups index with a template literal instead of `'$' + name`, because a pattern index signature cannot be indexed by a plain `string`. The keys produced are identical, so there is no behaviour change and no snapshot moved.

I checked that the type fails on misuse rather than just passing: `labels.loop = 2`, `labels['plain' + name]`, `labels.$ = 1` and passing a string to `isValidLabel` each produce a compile error (TS2322, TS7053, TS2322, TS2345). All four compiled silently under `any`.

`vitest run` is 91949 passing over 139 files. `tsc`, `eslint`, `prettier --check`, `cspell` and `knip` are clean. The ast alignment and jsx alignment suites pass against test262 at `77100523`.

Fixes #650
