### PR TITLE
refactor: separate the label parent link from label entries

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -395,13 +395,13 @@ export function isValidLabel(
   let isIterationLabelSet: 0 | 1 = 0;
 
   while (labels) {
-    if (labels[`$${name}`]) {
+    if (labels.names?.has(name)) {
       // A label is declared at most once per chain, so this is its only declaration.
       if (isIterationStatement && !isIterationLabelSet) parser.report(Errors.InvalidNestedStatement, name);
       return 1;
     }
     isIterationLabelSet = labels.loop ? 1 : 0;
-    labels = labels.$;
+    labels = labels.parent;
   }
 
   return 0;
@@ -418,11 +418,11 @@ export function isValidLabel(
 export function validateAndDeclareLabel(parser: Parser, labels: Labels, name: string): void {
   let set: Labels | undefined = labels;
   while (set) {
-    if (set[`$${name}`]) parser.report(Errors.LabelRedeclaration, name);
-    set = set.$;
+    if (set.names?.has(name)) parser.report(Errors.LabelRedeclaration, name);
+    set = set.parent;
   }
 
-  labels[`$${name}`] = 1;
+  (labels.names ??= new Set()).add(name);
 }
 
 /** @internal */

--- a/src/estree.ts
+++ b/src/estree.ts
@@ -19,19 +19,16 @@ export interface Position {
 }
 
 /**
- * The label set a statement is parsed with, chained outwards through `$` to the
- * set of the statement it is nested in.
+ * The label set a statement is parsed with, chained outwards through `parent` to
+ * the set of the statement it is nested in.
  */
 export interface Labels {
   /** The label set of the enclosing statement. */
-  $?: Labels;
+  parent?: Labels;
   /** Marks the label set an iteration statement body is parsed with. */
   loop?: 1;
-  /**
-   * A label declared in this set, keyed by `$` followed by its name. Always `1`;
-   * `Labels` is in the union only because the `$` key above matches this pattern.
-   */
-  [label: `$${string}`]: Labels | 1 | undefined;
+  /** The labels declared in this set. Created on the first declaration. */
+  names?: Set<string>;
 }
 
 export type IdentifierOrExpression = Identifier | Expression | ArrowFunctionExpression;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -571,7 +571,7 @@ function parseBlock<T extends ESTree.BlockStatement | ESTree.StaticBlock = ESTre
 
   consume(parser, context | Context.AllowRegExp, Token.LeftBrace);
   while (parser.getToken() !== Token.RightBrace) {
-    body.push(parseStatementListItem(parser, context, scope, privateScope, { $: labels }) as any);
+    body.push(parseStatementListItem(parser, context, scope, privateScope, { parent: labels }) as any);
   }
 
   consume(parser, context | Context.AllowRegExp, Token.RightBrace);
@@ -1057,7 +1057,7 @@ function parseConsequentOrAlternative(
     // Disallow if web compatibility is off
     !parser.options.webcompat ||
     parser.getToken() !== Token.FunctionKeyword
-    ? parseStatement(parser, context, scope, privateScope, { $: labels }, 0)
+    ? parseStatement(parser, context, scope, privateScope, { parent: labels }, 0)
     : parseFunctionDeclaration(
         parser,
         context,
@@ -1119,7 +1119,7 @@ function parseSwitchStatement(
       parser.getToken() !== Token.DefaultKeyword
     ) {
       const statement = parseStatementListItem(parser, context | Context.InSwitch, scope, privateScope, {
-        $: labels,
+        parent: labels,
       });
 
       if (
@@ -1210,7 +1210,7 @@ function parseIterationStatementBody(
     ((context | Context.DisallowIn) ^ Context.DisallowIn) | Context.InIteration,
     scope,
     privateScope,
-    { loop: 1, $: labels },
+    { loop: 1, parent: labels },
     0,
   );
 }
@@ -1386,7 +1386,7 @@ function parseTryStatement(
 
   const firstScope = scope?.createChildScope(ScopeKind.TryStatement);
 
-  const block = parseBlock(parser, context, firstScope, privateScope, { $: labels });
+  const block = parseBlock(parser, context, firstScope, privateScope, { parent: labels });
   const { tokenStart } = parser;
   const handler = consumeOpt(parser, context | Context.AllowRegExp, Token.CatchKeyword)
     ? parseCatchBlock(parser, context, scope, privateScope, labels, tokenStart)
@@ -1397,7 +1397,7 @@ function parseTryStatement(
   if (parser.getToken() === Token.FinallyKeyword) {
     nextToken(parser, context | Context.AllowRegExp);
     const finalizerScope = scope?.createChildScope(ScopeKind.CatchStatement);
-    const block = parseBlock(parser, context, finalizerScope, privateScope, { $: labels });
+    const block = parseBlock(parser, context, finalizerScope, privateScope, { parent: labels });
     finalizer = block;
   }
 
@@ -1464,7 +1464,7 @@ function parseCatchBlock(
 
   const additionalScope = scope?.createChildScope(ScopeKind.CatchBlock);
 
-  const body = parseBlock(parser, context, additionalScope, privateScope, { $: labels });
+  const body = parseBlock(parser, context, additionalScope, privateScope, { parent: labels });
 
   return parser.finishNode<ESTree.CatchClause>(
     {


### PR DESCRIPTION
Follow-up to #652, where @3cp said he would merge that one and then look at separating the two and improving readability.

In #652 `Labels` typed its entries as `Labels | 1 | undefined`, because the parent link lived in the same object as the declared labels under the key `$`, which matches the `` `$${string}` `` index signature. The union existed to accommodate one key, which made the type dishonest about what a label entry is.

This gives the parent link and the entries separate fields:

```ts
export interface Labels {
  parent?: Labels;
  loop?: 1;
  names?: Set<string>;
}
```

No union and no index signature. The `$` prefix on label names existed to keep names like `__proto__` and `toString` away from `Object.prototype`. A `Set` has no such hazard, so the prefix goes away too and the call sites read directly: `labels.names?.has(name)` and `labels = labels.parent`.

I also considered keeping the flat object and moving the parent to a `$$` key. That does not work: a label may be named `$`, so its entry key would be `$$` and collide with the parent. A `unique symbol` key avoids the collision but reads worse than a named field.

`names` is optional and created on the first declaration rather than at construction. Every block, switch case, loop body and try block builds a label set, and almost none of them declare a label, so the common path still allocates exactly one object literal and the five `{}` roots are unchanged.

There is no benchmark script in the repo, so I measured by hand: built `dist/meriyah.mjs` on `main` and on this branch and parsed `typescript.js` (about 9 MB), 7 runs per build, twice per side. Medians were within a few milliseconds of each other in both directions, inside run-to-run noise.

Behaviour is unchanged. Verified with `npm run lint:types`, `npx vitest run` (91949 tests, 139 files, all passing), `TEST262=1 npx vitest run test/conformance` for the ast-alignment, jsx-ast-alignment and test262-parser tests, and `npm run lint` (eslint, prettier, cspell, knip).
