### PR TITLE
refactor: type callee and class field values in estree

### DIFF
--- a/src/estree.ts
+++ b/src/estree.ts
@@ -345,7 +345,7 @@ export interface ChainExpression extends _Node {
 
 export interface CallExpression extends _Node {
   type: 'CallExpression';
-  callee: any; //Expression | Super;
+  callee: Expression | Super;
   arguments: (Expression | SpreadElement)[];
   optional: boolean;
 }
@@ -368,7 +368,7 @@ export interface ClassBody extends _Node {
 export interface AccessorProperty extends _Node {
   type: 'AccessorProperty';
   key: PrivateIdentifier | Expression;
-  value: any;
+  value: Expression | null;
   decorators?: Decorator[];
   computed: boolean;
   static: boolean;
@@ -377,7 +377,7 @@ export interface AccessorProperty extends _Node {
 export interface PropertyDefinition extends _Node {
   type: 'PropertyDefinition';
   key: PrivateIdentifier | Expression;
-  value: any;
+  value: Expression | null;
   decorators?: Decorator[];
   computed: boolean;
   static: boolean;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -7978,7 +7978,7 @@ function parseAsyncArrowOrCallExpression(
   parser: Parser,
   context: Context,
   privateScope: PrivateScope | undefined,
-  callee: ESTree.Identifier | void,
+  callee: ESTree.Identifier,
   canAssign: 0 | 1,
   kind: BindingKind,
   flags: Flags,


### PR DESCRIPTION
Three fields in `src/estree.ts` were typed `any`. `CallExpression.callee` even carried the intended type in a trailing comment. This replaces them with the types the spec and the parser already imply:

- `CallExpression.callee`: `any` to `Expression | Super` (comment removed)
- `PropertyDefinition.value`: `any` to `Expression | null`
- `AccessorProperty.value`: `any` to `Expression | null`

These match ESTree (es2015 `CallExpression.callee`, es2022 `PropertyDefinition.value` and `AccessorProperty.value`), and they match what the parser actually builds. I checked every construction site rather than trusting the spec alone.

One knock-on change in `src/parser.ts`: `parseAsyncArrowOrCallExpression` declared `callee: ESTree.Identifier | void`, but all three callers pass an `ESTree.Identifier`. The `| void` was never reachable and was the only thing the old `any` was hiding, so I dropped it. No `as any` added anywhere.

For the class fields, `parsePropertyDefinition` already declares its local as `ESTree.Expression | null`, so the new field types are exact, not just spec-shaped.

Verified with `npm run lint:types`, the full `vitest` suite under `CI=1` (91952 tests, including the AST alignment and test262 conformance runs), the production test after a build, plus eslint, prettier, cspell and knip. I also temporarily assigned a wrong node type at one call site and confirmed `tsc` rejects it, then reverted.

Same approach as #652.
