### PR TITLE
fix(jsx): compare namespaced tag names by text, and type the common.ts helpers

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -1,5 +1,5 @@
 import { Errors } from './errors.ts';
-import { type Labels } from './estree.ts';
+import type * as ESTree from './estree.ts';
 import { nextToken } from './lexer/scan.ts';
 import { type Parser } from './parser/parser.ts';
 import { KeywordDescTable, Token } from './token.ts';
@@ -219,16 +219,24 @@ export function consume(parser: Parser, context: Context, t: Token): void {
 }
 
 /**
+ * A node seen through the in-place rewrite `reinterpretToPattern` performs: the
+ * `type` discriminant is writable and the `operator` of an assignment is removable.
+ */
+type RewrittenNode = { type: ESTree.Node['type']; operator?: string };
+
+/**
  * Transforms a `LeftHandSideExpression` into a `AssignmentPattern` if possible,
  * otherwise it returns the original tree.
  *
  * @param parser Parser state
- * @param {*} node
+ * @param node Node to transform
  */
-export function reinterpretToPattern(parser: Parser, node: any): void {
+export function reinterpretToPattern(parser: Parser, node: ESTree.Node): void {
+  const rewritten: RewrittenNode = node;
+
   switch (node.type) {
     case 'ArrayExpression': {
-      node.type = 'ArrayPattern';
+      rewritten.type = 'ArrayPattern';
       const { elements } = node;
       for (let i = 0, n = elements.length; i < n; ++i) {
         const element = elements[i];
@@ -237,7 +245,7 @@ export function reinterpretToPattern(parser: Parser, node: any): void {
       return;
     }
     case 'ObjectExpression': {
-      node.type = 'ObjectPattern';
+      rewritten.type = 'ObjectPattern';
       const { properties } = node;
       for (let i = 0, n = properties.length; i < n; ++i) {
         reinterpretToPattern(parser, properties[i]);
@@ -245,16 +253,16 @@ export function reinterpretToPattern(parser: Parser, node: any): void {
       return;
     }
     case 'AssignmentExpression':
-      node.type = 'AssignmentPattern';
+      rewritten.type = 'AssignmentPattern';
       if (node.operator !== '=') parser.report(Errors.InvalidDestructuringTarget);
-      delete node.operator;
+      delete rewritten.operator;
       reinterpretToPattern(parser, node.left);
       return;
     case 'Property':
       reinterpretToPattern(parser, node.value);
       return;
     case 'SpreadElement':
-      node.type = 'RestElement';
+      rewritten.type = 'RestElement';
       reinterpretToPattern(parser, node.argument);
     // No default
   }
@@ -367,11 +375,10 @@ export function isStrictReservedWord(parser: Parser, context: Context, t: Token)
 /**
  * Checks if the property has any private field key
  *
- * @param parser Parser object
- * @param context  Context masks
+ * @param expr Expression to check
  */
-export function isPropertyWithPrivateFieldKey(expr: any): boolean {
-  return !expr.property ? false : expr.property.type === 'PrivateIdentifier';
+export function isPropertyWithPrivateFieldKey(expr: ESTree.Expression): boolean {
+  return expr.type === 'MemberExpression' && expr.property.type === 'PrivateIdentifier';
 }
 
 /**
@@ -384,7 +391,7 @@ export function isPropertyWithPrivateFieldKey(expr: any): boolean {
  */
 export function isValidLabel(
   parser: Parser,
-  labels: Labels | undefined,
+  labels: ESTree.Labels | undefined,
   name: string,
   isIterationStatement: 0 | 1,
 ): 0 | 1 {
@@ -415,8 +422,8 @@ export function isValidLabel(
  * @param labels Object holding the labels
  * @param name Current label
  */
-export function validateAndDeclareLabel(parser: Parser, labels: Labels, name: string): void {
-  let set: Labels | undefined = labels;
+export function validateAndDeclareLabel(parser: Parser, labels: ESTree.Labels, name: string): void {
+  let set: ESTree.Labels | undefined = labels;
   while (set) {
     if (set.names?.has(name)) parser.report(Errors.LabelRedeclaration, name);
     set = set.parent;
@@ -426,17 +433,14 @@ export function validateAndDeclareLabel(parser: Parser, labels: Labels, name: st
 }
 
 /** @internal */
-export function isEqualTagName(elementName: any): any {
+export function isEqualTagName(elementName: ESTree.JSXTagNameExpression): string {
   switch (elementName.type) {
     case 'JSXIdentifier':
       return elementName.name;
     case 'JSXNamespacedName':
-      return elementName.namespace + ':' + elementName.name;
+      return isEqualTagName(elementName.namespace) + ':' + elementName.name.name;
     case 'JSXMemberExpression':
       return isEqualTagName(elementName.object) + '.' + isEqualTagName(elementName.property);
-    /* istanbul ignore next */
-    default:
-    // ignore
   }
 }
 
@@ -451,7 +455,7 @@ export function isValidIdentifier(context: Context, t: Token): boolean {
   return (t & Token.Contextual) === Token.Contextual || (t & Token.FutureReserved) === Token.FutureReserved;
 }
 
-export function classifyIdentifier(parser: Parser, context: Context, t: Token): any {
+export function classifyIdentifier(parser: Parser, context: Context, t: Token): void {
   if ((t & Token.IsEvalOrArguments) === Token.IsEvalOrArguments) {
     if (context & Context.Strict) parser.report(Errors.StrictEvalArguments);
     parser.flags |= Flags.StrictEvalArguments;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3486,7 +3486,7 @@ function parseAssignmentExpression(
       (!isPattern && token === Token.Assign && ((left as ESTree.Expression).type as string) === 'ArrayExpression') ||
       ((left as ESTree.Expression).type as string) === 'ObjectExpression'
     ) {
-      reinterpretToPattern(parser, left);
+      reinterpretToPattern(parser, left!);
     }
 
     nextToken(parser, context | Context.AllowRegExp);
@@ -6007,7 +6007,7 @@ function parseSpreadOrRestElement(
     if (consumeOpt(parser, context | Context.AllowRegExp, Token.Assign)) {
       if (destructible & DestructuringKind.CannotDestruct) parser.report(Errors.CantAssignTo);
 
-      reinterpretToPattern(parser, argument);
+      reinterpretToPattern(parser, argument!);
 
       const right = parseExpression(parser, context, privateScope, 1, inGroup, parser.tokenStart);
 

--- a/test/parser/miscellaneous/__snapshots__/jsx.ts.snap
+++ b/test/parser/miscellaneous/__snapshots__/jsx.ts.snap
@@ -204,6 +204,12 @@ exports[`Miscellaneous - JSX > Miscellaneous - JSX (fail) > <a:b></b>; 1`] = `
     |          ^ Expected corresponding JSX closing tag for b"
 `;
 
+exports[`Miscellaneous - JSX > Miscellaneous - JSX (fail) > <a:b></c:d> 1`] = `
+"SyntaxError [1:10-1:11]: Expected corresponding JSX closing tag for c:d
+> 1 | <a:b></c:d>
+    |           ^ Expected corresponding JSX closing tag for c:d"
+`;
+
 exports[`Miscellaneous - JSX > Miscellaneous - JSX (fail) > <a>;</>; 1`] = `
 "SyntaxError [1:6-1:7]: Unexpected token: '>'
 > 1 | <a>;</>;
@@ -451,9 +457,9 @@ exports[`Miscellaneous - JSX > Miscellaneous - JSX (fail) > <p>{/}</p> 1`] = `
 `;
 
 exports[`Miscellaneous - JSX > Miscellaneous - JSX (fail) > <path></svg:path> 1`] = `
-"SyntaxError [1:16-1:17]: Expected corresponding JSX closing tag for [object Object]:[object Object]
+"SyntaxError [1:16-1:17]: Expected corresponding JSX closing tag for svg:path
 > 1 | <path></svg:path>
-    |                 ^ Expected corresponding JSX closing tag for [object Object]:[object Object]"
+    |                 ^ Expected corresponding JSX closing tag for svg:path"
 `;
 
 exports[`Miscellaneous - JSX > Miscellaneous - JSX (fail) > <tag \${"className"}="tag"></tag> 1`] = `

--- a/test/parser/miscellaneous/__snapshots__/jsx.ts.snap
+++ b/test/parser/miscellaneous/__snapshots__/jsx.ts.snap
@@ -210,6 +210,12 @@ exports[`Miscellaneous - JSX > Miscellaneous - JSX (fail) > <a:b></c:d> 1`] = `
     |           ^ Expected corresponding JSX closing tag for c:d"
 `;
 
+exports[`Miscellaneous - JSX > Miscellaneous - JSX (fail) > <a:x></b:x> 1`] = `
+"SyntaxError [1:10-1:11]: Expected corresponding JSX closing tag for b:x
+> 1 | <a:x></b:x>
+    |           ^ Expected corresponding JSX closing tag for b:x"
+`;
+
 exports[`Miscellaneous - JSX > Miscellaneous - JSX (fail) > <a>;</>; 1`] = `
 "SyntaxError [1:6-1:7]: Unexpected token: '>'
 > 1 | <a>;</>;
@@ -472,6 +478,12 @@ exports[`Miscellaneous - JSX > Miscellaneous - JSX (fail) > <tag className=></ta
 "SyntaxError [1:14-1:16]: Unexpected token: '=>'
 > 1 | <tag className=></tag>
     |               ^^ Unexpected token: '=>'"
+`;
+
+exports[`Miscellaneous - JSX > Miscellaneous - JSX (fail) > <x:a></x:b> 1`] = `
+"SyntaxError [1:10-1:11]: Expected corresponding JSX closing tag for x:b
+> 1 | <x:a></x:b>
+    |           ^ Expected corresponding JSX closing tag for x:b"
 `;
 
 exports[`Miscellaneous - JSX > Miscellaneous - JSX (fail) > <xyz. /> 1`] = `

--- a/test/parser/miscellaneous/jsx.ts
+++ b/test/parser/miscellaneous/jsx.ts
@@ -155,6 +155,8 @@ describe('Miscellaneous - JSX', () => {
     { code: '<:path />', options: { jsx: true } },
     { code: '<path></svg:path>', options: { jsx: true } },
     { code: '<a:b></c:d>', options: { jsx: true } },
+    { code: '<a:x></b:x>', options: { jsx: true } },
+    { code: '<x:a></x:b>', options: { jsx: true } },
     { code: '<foo.bar></foo.baz>', options: { jsx: true } },
     { code: '<chinese:alladinfoo.bar></foo.baz>', options: { jsx: true } },
     { code: '<foo:bar></foo.baz>', options: { jsx: true } },

--- a/test/parser/miscellaneous/jsx.ts
+++ b/test/parser/miscellaneous/jsx.ts
@@ -154,6 +154,7 @@ describe('Miscellaneous - JSX', () => {
     { code: '<f><g/></ff>;', options: { jsx: true } },
     { code: '<:path />', options: { jsx: true } },
     { code: '<path></svg:path>', options: { jsx: true } },
+    { code: '<a:b></c:d>', options: { jsx: true } },
     { code: '<foo.bar></foo.baz>', options: { jsx: true } },
     { code: '<chinese:alladinfoo.bar></foo.baz>', options: { jsx: true } },
     { code: '<foo:bar></foo.baz>', options: { jsx: true } },


### PR DESCRIPTION
Follow-up to #652 and #654. `src/common.ts` still had four helpers with `any` parameters or `any` return types. This replaces them with the types the functions actually work with, and typing one of them exposed a bug.

The bug: `isEqualTagName` handles `JSXNamespacedName` by concatenating `elementName.namespace + ':' + elementName.name`, which are two AST nodes, so every namespaced tag name stringified to `[object Object]:[object Object]`. All namespaced tag names therefore compared equal. `<a:b></c:d>` parsed without an error, and the message for `<path></svg:path>` was `Expected corresponding JSX closing tag for [object Object]:[object Object]`, which had been committed as a snapshot. It now recurses into `namespace` and reads `name.name`. I added `<a:b></c:d>` to the JSX fail list and the `<path></svg:path>` snapshot now says `svg:path`. With the switch exhaustive, the `default` branch and its `istanbul ignore next` are gone.

The typing changes:

- `reinterpretToPattern(parser, node)` takes `ESTree.Node` instead of `any`. It cannot take just the five node kinds its switch handles, because callers hand it a `for` statement's `init`, `parseAssignmentExpression`'s `left`, and arrow params, so it takes a node and narrows inside. It rewrites the node in place, and TypeScript will not let you assign a new `type` to a narrowed node, so the object is bound once through a small local view type where `type` is writable and `operator` is optional. No casts.
- `isPropertyWithPrivateFieldKey(expr)` takes `ESTree.Expression` and checks `expr.type === 'MemberExpression' && expr.property.type === 'PrivateIdentifier'`. Same behaviour: the only other node with a `property` that can reach it is `JSXMemberExpression`, whose `property` is a `JSXIdentifier`.
- `isEqualTagName(elementName)` takes `ESTree.JSXTagNameExpression` and returns `string`.
- `classifyIdentifier` returns `void`. It only reports and sets flags.

Two call sites in `src/parser.ts` pass values typed `... | null`. Both are non-null in practice: the first sits behind a guard that already dereferences `left.type`, and in the second every reachable branch assigns `argument` (the `null` only survives because the surrounding `parsePrimaryExpression` and `parseMemberOrUpdateExpression` still return `any`). I used a non-null assertion at both rather than widening the parameter to accept `null`, since the function dereferences `node.type` straight away.

Verified with `npm run lint:types`, the full `vitest run` including the test262 conformance and acorn alignment suites (91959 tests passing), `npm run build` plus the production tests, and eslint, prettier, cspell and knip.
