### PR TITLE
fix(parser): report yield-in-parameter errors at the yield token

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3830,10 +3830,15 @@ function parseYieldExpressionOrIdentifier(
   //     yield [no LineTerminator here] AssignmentExpression[?In, Yield]
   //     yield [no LineTerminator here] * AssignmentExpression[?In, Yield]
 
-  if (inGroup) parser.destructible |= DestructuringKind.Yield;
+  if (inGroup) {
+    if ((parser.destructible & DestructuringKind.Yield) === 0) {
+      parser.firstYieldLocation ??= { start, end: parser.currentLocation };
+    }
+    parser.destructible |= DestructuringKind.Yield;
+  }
   if (context & Context.InYieldContext) {
     nextToken(parser, context | Context.AllowRegExp);
-    if (context & Context.InArgumentList) parser.report(Errors.YieldInParameter);
+    if (context & Context.InArgumentList) throw new ParseError(start, parser.startPosition, Errors.YieldInParameter);
     if (!canAssign) parser.report(Errors.CantAssignTo);
     if (parser.getToken() === Token.QuestionMark) parser.report(Errors.InvalidTernaryYield);
 
@@ -6955,6 +6960,7 @@ function parseMethodFormals(
   parser.flags = (parser.flags | Flags.NonSimpleParameterList) ^ Flags.NonSimpleParameterList;
   parser.strictReservedRange = null;
   parser.firstAwaitLocation = null;
+  parser.firstYieldLocation = null;
 
   if (parser.getToken() === Token.RightParen) {
     if (kind & PropertyKind.Setter) {
@@ -7117,6 +7123,8 @@ function parseParenthesizedExpression(
   parser.destructible &= ~(DestructuringKind.Yield | DestructuringKind.Await);
   const previousFirstAwaitLocation = parser.firstAwaitLocation;
   parser.firstAwaitLocation = null;
+  const previousFirstYieldLocation = parser.firstYieldLocation;
+  parser.firstYieldLocation = null;
 
   let expr;
   let expressions: ESTree.Expression[] = [];
@@ -7253,6 +7261,9 @@ function parseParenthesizedExpression(
       if (previousFirstAwaitLocation) {
         parser.firstAwaitLocation = previousFirstAwaitLocation;
       }
+      if (previousFirstYieldLocation) {
+        parser.firstYieldLocation = previousFirstYieldLocation;
+      }
 
       return parser.options.preserveParens
         ? parser.finishNode<ESTree.ParenthesizedExpression>(
@@ -7312,6 +7323,8 @@ function parseParenthesizedExpression(
       parser.report(Errors.AwaitInParameter);
     }
     if (context & (Context.Strict | Context.InYieldContext) && destructible & DestructuringKind.Yield) {
+      const loc = parser.firstYieldLocation!;
+      if (loc) throw new ParseError(loc.start, loc.end, Errors.YieldInParameter);
       parser.report(Errors.YieldInParameter);
     }
     if (isNonSimpleParameterList) parser.flags |= Flags.NonSimpleParameterList;
@@ -7320,6 +7333,9 @@ function parseParenthesizedExpression(
 
     if (previousFirstAwaitLocation) {
       parser.firstAwaitLocation = previousFirstAwaitLocation;
+    }
+    if (previousFirstYieldLocation) {
+      parser.firstYieldLocation = previousFirstYieldLocation;
     }
 
     return parseParenthesizedArrow(
@@ -7348,6 +7364,9 @@ function parseParenthesizedExpression(
 
   if (previousFirstAwaitLocation) {
     parser.firstAwaitLocation = previousFirstAwaitLocation;
+  }
+  if (previousFirstYieldLocation) {
+    parser.firstYieldLocation = previousFirstYieldLocation;
   }
 
   return parser.options.preserveParens
@@ -7632,6 +7651,7 @@ function parseFormalParametersOrFormalList(
   parser.flags = (parser.flags | Flags.NonSimpleParameterList) ^ Flags.NonSimpleParameterList;
   parser.strictReservedRange = null;
   parser.firstAwaitLocation = null;
+  parser.firstYieldLocation = null;
 
   const params: ESTree.Parameter[] = [];
 
@@ -7990,6 +8010,8 @@ function parseAsyncArrowOrCallExpression(
 
   const previousFirstAwaitLocation = parser.firstAwaitLocation;
   parser.firstAwaitLocation = null;
+  const previousFirstYieldLocation = parser.firstYieldLocation;
+  parser.firstYieldLocation = null;
 
   context = (context | Context.DisallowIn) ^ Context.DisallowIn;
 
@@ -8006,6 +8028,7 @@ function parseAsyncArrowOrCallExpression(
     }
 
     if (previousFirstAwaitLocation) parser.firstAwaitLocation = previousFirstAwaitLocation;
+    if (previousFirstYieldLocation) parser.firstYieldLocation = previousFirstYieldLocation;
 
     return parser.finishNode<ESTree.CallExpression>(
       {
@@ -8127,6 +8150,7 @@ function parseAsyncArrowOrCallExpression(
       }
 
       if (previousFirstAwaitLocation) parser.firstAwaitLocation = previousFirstAwaitLocation;
+      if (previousFirstYieldLocation) parser.firstYieldLocation = previousFirstYieldLocation;
 
       return parser.finishNode<ESTree.CallExpression>(
         {
@@ -8160,8 +8184,11 @@ function parseAsyncArrowOrCallExpression(
       if (loc) throw new ParseError(loc.start, loc.end, Errors.AwaitInParameter);
       parser.report(Errors.AwaitInParameter);
     }
-    if (context & (Context.Strict | Context.InYieldContext) && destructible & DestructuringKind.Yield)
+    if (context & (Context.Strict | Context.InYieldContext) && destructible & DestructuringKind.Yield) {
+      const loc = parser.firstYieldLocation!;
+      if (loc) throw new ParseError(loc.start, loc.end, Errors.YieldInParameter);
       parser.report(Errors.YieldInParameter);
+    }
     if (isNonSimpleParameterList) parser.flags |= Flags.NonSimpleParameterList;
 
     return parseParenthesizedArrow(
@@ -8191,6 +8218,7 @@ function parseAsyncArrowOrCallExpression(
   }
 
   if (previousFirstAwaitLocation) parser.firstAwaitLocation = previousFirstAwaitLocation;
+  if (previousFirstYieldLocation) parser.firstYieldLocation = previousFirstYieldLocation;
 
   return parser.finishNode<ESTree.CallExpression>(
     {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -138,6 +138,11 @@ export class Parser {
   firstAwaitLocation: { start: Location; end: Location } | null = null;
 
   /**
+   * Location of the first 'yield' keyword seen. Used to report deferred errors in arrow parameters.
+   */
+  firstYieldLocation: { start: Location; end: Location } | null = null;
+
+  /**
    * Holds leading decorators before "export" or "class" keywords
    */
   leadingDecorators: {

--- a/test/parser/declarations/__snapshots__/async-function.ts.snap
+++ b/test/parser/declarations/__snapshots__/async-function.ts.snap
@@ -749,10 +749,10 @@ exports[`Declarations - Async Function > Declarations - Async Function (fail) > 
 exports[`Declarations - Async Function > Declarations - Async Function (fail) > function* wrap() {
 async(a = yield b) => a
 } 1`] = `
-"SyntaxError [2:19-2:21]: Yield expression not allowed in formal parameter
+"SyntaxError [2:10-2:15]: Yield expression not allowed in formal parameter
   1 | function* wrap() {
 > 2 | async(a = yield b) => a
-    |                    ^^ Yield expression not allowed in formal parameter
+    |           ^^^^^ Yield expression not allowed in formal parameter
   3 | }"
 `;
 

--- a/test/parser/expressions/__snapshots__/arrow.ts.snap
+++ b/test/parser/expressions/__snapshots__/arrow.ts.snap
@@ -1141,33 +1141,33 @@ exports[`Expressions - Arrow > Expressions - Array (fail) > (foo ? bar : baz, a)
 `;
 
 exports[`Expressions - Arrow > Expressions - Array (fail) > (function *g([x = class extends (a ? null : yield) { }] = [null]) { }); 1`] = `
-"SyntaxError [1:49-1:50]: Yield expression not allowed in formal parameter
+"SyntaxError [1:44-1:49]: Yield expression not allowed in formal parameter
 > 1 | (function *g([x = class extends (a ? null : yield) { }] = [null]) { });
-    |                                                  ^ Yield expression not allowed in formal parameter"
+    |                                             ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Arrow > Expressions - Array (fail) > (function *g(x = class { [y = (yield, 1)]() { } }) { }); 1`] = `
-"SyntaxError [1:36-1:37]: Yield expression not allowed in formal parameter
+"SyntaxError [1:31-1:36]: Yield expression not allowed in formal parameter
 > 1 | (function *g(x = class { [y = (yield, 1)]() { } }) { });
-    |                                     ^ Yield expression not allowed in formal parameter"
+    |                                ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Arrow > Expressions - Array (fail) > (function *g(x = class extends (yield) { }) { }); 1`] = `
-"SyntaxError [1:37-1:38]: Yield expression not allowed in formal parameter
+"SyntaxError [1:32-1:37]: Yield expression not allowed in formal parameter
 > 1 | (function *g(x = class extends (yield) { }) { });
-    |                                      ^ Yield expression not allowed in formal parameter"
+    |                                 ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Arrow > Expressions - Array (fail) > (function *g(z = ( [x=(yield)]) => {}) { }); 1`] = `
-"SyntaxError [1:28-1:29]: Yield expression not allowed in formal parameter
+"SyntaxError [1:23-1:28]: Yield expression not allowed in formal parameter
 > 1 | (function *g(z = ( [x=(yield)]) => {}) { });
-    |                             ^ Yield expression not allowed in formal parameter"
+    |                        ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Arrow > Expressions - Array (fail) > (function *g(z = ( x=yield) => {}) { }); 1`] = `
-"SyntaxError [1:26-1:27]: Yield expression not allowed in formal parameter
+"SyntaxError [1:21-1:26]: Yield expression not allowed in formal parameter
 > 1 | (function *g(z = ( x=yield) => {}) { });
-    |                           ^ Yield expression not allowed in formal parameter"
+    |                      ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Arrow > Expressions - Array (fail) > (if) => {} 1`] = `

--- a/test/parser/expressions/__snapshots__/async-arrow.ts.snap
+++ b/test/parser/expressions/__snapshots__/async-arrow.ts.snap
@@ -2429,9 +2429,9 @@ exports[`Expressions - Async arrow > Expressions - Async arrow (fail) > function
 `;
 
 exports[`Expressions - Async arrow > Expressions - Async arrow (fail) > function* g(){ async (a = yield, b = (c) => 1) => 1; } 1`] = `
-"SyntaxError [1:47-1:49]: Yield expression not allowed in formal parameter
+"SyntaxError [1:26-1:31]: Yield expression not allowed in formal parameter
 > 1 | function* g(){ async (a = yield, b = (c) => 1) => 1; }
-    |                                                ^^ Yield expression not allowed in formal parameter"
+    |                           ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Async arrow > Expressions - Async arrow (fail) > if (x) async 

--- a/test/parser/expressions/__snapshots__/await.ts.snap
+++ b/test/parser/expressions/__snapshots__/await.ts.snap
@@ -1083,9 +1083,9 @@ exports[`Expressions - Await > Expressions - Await (fail) > function method() { 
 `;
 
 exports[`Expressions - Await > Expressions - Await (fail) > function* wrap() { async(a = yield b) => a }; 1`] = `
-"SyntaxError [1:38-1:40]: Yield expression not allowed in formal parameter
+"SyntaxError [1:29-1:34]: Yield expression not allowed in formal parameter
 > 1 | function* wrap() { async(a = yield b) => a };
-    |                                       ^^ Yield expression not allowed in formal parameter"
+    |                              ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Await > Expressions - Await (fail) > let f = () => (y=await foo) => y; 1`] = `

--- a/test/parser/expressions/__snapshots__/group.ts.snap
+++ b/test/parser/expressions/__snapshots__/group.ts.snap
@@ -1758,15 +1758,15 @@ exports[`Expressions - Group > Expressions - Group (fail) > function *f(){ yield
 `;
 
 exports[`Expressions - Group > Expressions - Group (fail) > function *f(x = (yield) = f) {} 1`] = `
-"SyntaxError [1:22-1:23]: Yield expression not allowed in formal parameter
+"SyntaxError [1:17-1:22]: Yield expression not allowed in formal parameter
 > 1 | function *f(x = (yield) = f) {}
-    |                       ^ Yield expression not allowed in formal parameter"
+    |                  ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Group > Expressions - Group (fail) > function *f(x = delete ((yield) = f)) {} 1`] = `
-"SyntaxError [1:30-1:31]: Yield expression not allowed in formal parameter
+"SyntaxError [1:25-1:30]: Yield expression not allowed in formal parameter
 > 1 | function *f(x = delete ((yield) = f)) {}
-    |                               ^ Yield expression not allowed in formal parameter"
+    |                          ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Group > Expressions - Group (fail) > if => {} 1`] = `

--- a/test/parser/expressions/__snapshots__/super.ts.snap
+++ b/test/parser/expressions/__snapshots__/super.ts.snap
@@ -103,9 +103,9 @@ exports[`Expressions - Super > Expressions - Super (fail) > async(foo) => { supe
 `;
 
 exports[`Expressions - Super > Expressions - Super (fail) > class A extends B { *g2(a = 1 + (yield 2)) { } } 1`] = `
-"SyntaxError [1:39-1:40]: Yield expression not allowed in formal parameter
+"SyntaxError [1:33-1:38]: Yield expression not allowed in formal parameter
 > 1 | class A extends B { *g2(a = 1 + (yield 2)) { } }
-    |                                        ^ Yield expression not allowed in formal parameter"
+    |                                  ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Super > Expressions - Super (fail) > class A extends B { constructor() { (super)() } } 1`] = `
@@ -1069,9 +1069,9 @@ exports[`Expressions - Super > Expressions - Super (fail) > function* a(b){ supe
 `;
 
 exports[`Expressions - Super > Expressions - Super (fail) > function* foo(a = 1 + (yield 2)) { super.foo() } 1`] = `
-"SyntaxError [1:29-1:30]: Yield expression not allowed in formal parameter
+"SyntaxError [1:23-1:28]: Yield expression not allowed in formal parameter
 > 1 | function* foo(a = 1 + (yield 2)) { super.foo() }
-    |                              ^ Yield expression not allowed in formal parameter"
+    |                        ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Super > Expressions - Super (fail) > g={f: function f(){ super() }] 1`] = `
@@ -1219,9 +1219,9 @@ exports[`Expressions - Super > Expressions - Super (fail) > var f = function*() 
 `;
 
 exports[`Expressions - Super > Expressions - Super (fail) > var foo = function*(a = 1 + (yield 2)) { super.foo()  1`] = `
-"SyntaxError [1:35-1:36]: Yield expression not allowed in formal parameter
+"SyntaxError [1:29-1:34]: Yield expression not allowed in formal parameter
 > 1 | var foo = function*(a = 1 + (yield 2)) { super.foo() 
-    |                                    ^ Yield expression not allowed in formal parameter"
+    |                              ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Super > Expressions - Super (fail) > var gen = { async *method() { super(); } } 1`] = `

--- a/test/parser/expressions/__snapshots__/yield.ts.snap
+++ b/test/parser/expressions/__snapshots__/yield.ts.snap
@@ -67,15 +67,15 @@ exports[`Expressions - Yield > Expressions - Yield (fail) > (a=yield) {} 1`] = `
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > (function *(x, ...yield){}) 1`] = `
-"SyntaxError [1:23-1:24]: Yield expression not allowed in formal parameter
+"SyntaxError [1:18-1:23]: Yield expression not allowed in formal parameter
 > 1 | (function *(x, ...yield){})
-    |                        ^ Yield expression not allowed in formal parameter"
+    |                   ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > (function *f(){  ({*g(x=yield){}})  }) 1`] = `
-"SyntaxError [1:29-1:30]: Yield expression not allowed in formal parameter
+"SyntaxError [1:24-1:29]: Yield expression not allowed in formal parameter
 > 1 | (function *f(){  ({*g(x=yield){}})  })
-    |                              ^ Yield expression not allowed in formal parameter"
+    |                         ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > (x = delete ((yield) = f)) => {} 1`] = `
@@ -333,9 +333,9 @@ exports[`Expressions - Yield > Expressions - Yield (fail) > function *f() { yiel
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){  ({*g(x=yield){}})  } 1`] = `
-"SyntaxError [1:28-1:29]: Yield expression not allowed in formal parameter
+"SyntaxError [1:23-1:28]: Yield expression not allowed in formal parameter
 > 1 | function *f(){  ({*g(x=yield){}})  }
-    |                             ^ Yield expression not allowed in formal parameter"
+    |                        ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){  class x extends yield y{}  } 1`] = `
@@ -345,15 +345,15 @@ exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){  clas
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){  class x{*foo(a=yield x){}}  } 1`] = `
-"SyntaxError [1:37-1:38]: Yield expression not allowed in formal parameter
+"SyntaxError [1:31-1:36]: Yield expression not allowed in formal parameter
 > 1 | function *f(){  class x{*foo(a=yield x){}}  }
-    |                                      ^ Yield expression not allowed in formal parameter"
+    |                                ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){  class x{*foo(a=yield){}}  } 1`] = `
-"SyntaxError [1:36-1:37]: Yield expression not allowed in formal parameter
+"SyntaxError [1:31-1:36]: Yield expression not allowed in formal parameter
 > 1 | function *f(){  class x{*foo(a=yield){}}  }
-    |                                     ^ Yield expression not allowed in formal parameter"
+    |                                ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){  class x{constructor(a=yield x){}}  } 1`] = `
@@ -375,9 +375,9 @@ exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){  clas
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){  return (x=yield) => x;  } 1`] = `
-"SyntaxError [1:33-1:35]: Yield expression not allowed in formal parameter
+"SyntaxError [1:26-1:31]: Yield expression not allowed in formal parameter
 > 1 | function *f(){  return (x=yield) => x;  }
-    |                                  ^^ Yield expression not allowed in formal parameter"
+    |                           ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){  return *(x=yield y) => x;  } 1`] = `
@@ -405,27 +405,27 @@ exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){  retu
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){  return function*(x=yield y) {};  } 1`] = `
-"SyntaxError [1:41-1:42]: Yield expression not allowed in formal parameter
+"SyntaxError [1:35-1:40]: Yield expression not allowed in formal parameter
 > 1 | function *f(){  return function*(x=yield y) {};  }
-    |                                          ^ Yield expression not allowed in formal parameter"
+    |                                    ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){  return function*(x=yield) {};  } 1`] = `
-"SyntaxError [1:40-1:41]: Yield expression not allowed in formal parameter
+"SyntaxError [1:35-1:40]: Yield expression not allowed in formal parameter
 > 1 | function *f(){  return function*(x=yield) {};  }
-    |                                         ^ Yield expression not allowed in formal parameter"
+    |                                    ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){  x = {*foo(a=yield x){}}  } 1`] = `
-"SyntaxError [1:34-1:35]: Yield expression not allowed in formal parameter
+"SyntaxError [1:28-1:33]: Yield expression not allowed in formal parameter
 > 1 | function *f(){  x = {*foo(a=yield x){}}  }
-    |                                   ^ Yield expression not allowed in formal parameter"
+    |                             ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){  x = {*foo(a=yield){}}  } 1`] = `
-"SyntaxError [1:33-1:34]: Yield expression not allowed in formal parameter
+"SyntaxError [1:28-1:33]: Yield expression not allowed in formal parameter
 > 1 | function *f(){  x = {*foo(a=yield){}}  }
-    |                                  ^ Yield expression not allowed in formal parameter"
+    |                             ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){  x = {foo(a=yield x){}}  } 1`] = `
@@ -441,15 +441,15 @@ exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){  x = 
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){ ([x] = yield x) => {} } 1`] = `
-"SyntaxError [1:31-1:33]: Yield expression not allowed in formal parameter
+"SyntaxError [1:22-1:27]: Yield expression not allowed in formal parameter
 > 1 | function *f(){ ([x] = yield x) => {} }
-    |                                ^^ Yield expression not allowed in formal parameter"
+    |                       ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){ ({x} = yield x) => {} } 1`] = `
-"SyntaxError [1:31-1:33]: Yield expression not allowed in formal parameter
+"SyntaxError [1:22-1:27]: Yield expression not allowed in formal parameter
 > 1 | function *f(){ ({x} = yield x) => {} }
-    |                                ^^ Yield expression not allowed in formal parameter"
+    |                       ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){ (yield) = 1; } 1`] = `
@@ -459,39 +459,39 @@ exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){ (yiel
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){ async (x = (yield y)) => {} } 1`] = `
-"SyntaxError [1:37-1:39]: Yield expression not allowed in formal parameter
+"SyntaxError [1:27-1:32]: Yield expression not allowed in formal parameter
 > 1 | function *f(){ async (x = (yield y)) => {} }
-    |                                      ^^ Yield expression not allowed in formal parameter"
+    |                            ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){ async (x = (yield)) => {} } 1`] = `
-"SyntaxError [1:35-1:37]: Yield expression not allowed in formal parameter
+"SyntaxError [1:27-1:32]: Yield expression not allowed in formal parameter
 > 1 | function *f(){ async (x = (yield)) => {} }
-    |                                    ^^ Yield expression not allowed in formal parameter"
+    |                            ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){ async (x = yield y) => {} } 1`] = `
-"SyntaxError [1:35-1:37]: Yield expression not allowed in formal parameter
+"SyntaxError [1:26-1:31]: Yield expression not allowed in formal parameter
 > 1 | function *f(){ async (x = yield y) => {} }
-    |                                    ^^ Yield expression not allowed in formal parameter"
+    |                           ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){ async (x = yield) => {} } 1`] = `
-"SyntaxError [1:33-1:35]: Yield expression not allowed in formal parameter
+"SyntaxError [1:26-1:31]: Yield expression not allowed in formal parameter
 > 1 | function *f(){ async (x = yield) => {} }
-    |                                  ^^ Yield expression not allowed in formal parameter"
+    |                           ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){ async (x = z = yield y) => {} } 1`] = `
-"SyntaxError [1:39-1:41]: Yield expression not allowed in formal parameter
+"SyntaxError [1:30-1:35]: Yield expression not allowed in formal parameter
 > 1 | function *f(){ async (x = z = yield y) => {} }
-    |                                        ^^ Yield expression not allowed in formal parameter"
+    |                               ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){ async (x = z = yield) => {} } 1`] = `
-"SyntaxError [1:37-1:39]: Yield expression not allowed in formal parameter
+"SyntaxError [1:30-1:35]: Yield expression not allowed in formal parameter
 > 1 | function *f(){ async (x = z = yield) => {} }
-    |                                      ^^ Yield expression not allowed in formal parameter"
+    |                               ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){ return function(x = yield y){}; } 1`] = `
@@ -507,21 +507,21 @@ exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(){ yield
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(x = (yield) = f) {} 1`] = `
-"SyntaxError [1:22-1:23]: Yield expression not allowed in formal parameter
+"SyntaxError [1:17-1:22]: Yield expression not allowed in formal parameter
 > 1 | function *f(x = (yield) = f) {}
-    |                       ^ Yield expression not allowed in formal parameter"
+    |                  ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(x = delete ((yield) = f)) {} 1`] = `
-"SyntaxError [1:30-1:31]: Yield expression not allowed in formal parameter
+"SyntaxError [1:25-1:30]: Yield expression not allowed in formal parameter
 > 1 | function *f(x = delete ((yield) = f)) {}
-    |                               ^ Yield expression not allowed in formal parameter"
+    |                          ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(x=yield){ } 1`] = `
-"SyntaxError [1:19-1:20]: Yield expression not allowed in formal parameter
+"SyntaxError [1:14-1:19]: Yield expression not allowed in formal parameter
 > 1 | function *f(x=yield){ }
-    |                    ^ Yield expression not allowed in formal parameter"
+    |               ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *f(yield){ } 1`] = `
@@ -573,9 +573,9 @@ exports[`Expressions - Yield > Expressions - Yield (fail) > function *g() { (x =
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *g() { (x = y = yield z) => {}; } 1`] = `
-"SyntaxError [1:34-1:36]: Yield expression not allowed in formal parameter
+"SyntaxError [1:25-1:30]: Yield expression not allowed in formal parameter
 > 1 | function *g() { (x = y = yield z) => {}; }
-    |                                   ^^ Yield expression not allowed in formal parameter"
+    |                          ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *g() { (x = yield) = {}; } 1`] = `
@@ -585,15 +585,15 @@ exports[`Expressions - Yield > Expressions - Yield (fail) > function *g() { (x =
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *g() { (x = yield) => {}; } 1`] = `
-"SyntaxError [1:28-1:30]: Yield expression not allowed in formal parameter
+"SyntaxError [1:21-1:26]: Yield expression not allowed in formal parameter
 > 1 | function *g() { (x = yield) => {}; }
-    |                             ^^ Yield expression not allowed in formal parameter"
+    |                      ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *g() { async (x = y + foo(a, yield y)) => x; } 1`] = `
-"SyntaxError [1:48-1:50]: Yield expression not allowed in formal parameter
+"SyntaxError [1:38-1:43]: Yield expression not allowed in formal parameter
 > 1 | function *g() { async (x = y + foo(a, yield y)) => x; }
-    |                                                 ^^ Yield expression not allowed in formal parameter"
+    |                                       ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *g() { async (x = y + yield y) => x; } 1`] = `
@@ -627,9 +627,9 @@ exports[`Expressions - Yield > Expressions - Yield (fail) > function *g() { asyn
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *g() { async (x = y = yield z) => {}; } 1`] = `
-"SyntaxError [1:40-1:42]: Yield expression not allowed in formal parameter
+"SyntaxError [1:31-1:36]: Yield expression not allowed in formal parameter
 > 1 | function *g() { async (x = y = yield z) => {}; }
-    |                                         ^^ Yield expression not allowed in formal parameter"
+    |                                ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *g() { async (x = yield) = {}; } 1`] = `
@@ -639,9 +639,9 @@ exports[`Expressions - Yield > Expressions - Yield (fail) > function *g() { asyn
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *g() { async (x = yield) => {}; } 1`] = `
-"SyntaxError [1:34-1:36]: Yield expression not allowed in formal parameter
+"SyntaxError [1:27-1:32]: Yield expression not allowed in formal parameter
 > 1 | function *g() { async (x = yield) => {}; }
-    |                                   ^^ Yield expression not allowed in formal parameter"
+    |                            ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *g() { async yield = {}; } 1`] = `
@@ -699,45 +699,45 @@ exports[`Expressions - Yield > Expressions - Yield (fail) > function *g() { yiel
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *g(){ (x = {[yield y]: 1}) => z } 1`] = `
-"SyntaxError [1:36-1:38]: Yield expression not allowed in formal parameter
+"SyntaxError [1:22-1:27]: Yield expression not allowed in formal parameter
 > 1 | function *g(){ (x = {[yield y]: 1}) => z }
-    |                                     ^^ Yield expression not allowed in formal parameter"
+    |                       ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *g(){ (x = {[yield]: 1}) => z } 1`] = `
-"SyntaxError [1:34-1:36]: Yield expression not allowed in formal parameter
+"SyntaxError [1:22-1:27]: Yield expression not allowed in formal parameter
 > 1 | function *g(){ (x = {[yield]: 1}) => z }
-    |                                   ^^ Yield expression not allowed in formal parameter"
+    |                       ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *g(){ async (x = [yield y]) => z } 1`] = `
-"SyntaxError [1:37-1:39]: Yield expression not allowed in formal parameter
+"SyntaxError [1:27-1:32]: Yield expression not allowed in formal parameter
 > 1 | function *g(){ async (x = [yield y]) => z }
-    |                                      ^^ Yield expression not allowed in formal parameter"
+    |                            ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *g(){ async (x = [yield]) => z } 1`] = `
-"SyntaxError [1:35-1:37]: Yield expression not allowed in formal parameter
+"SyntaxError [1:27-1:32]: Yield expression not allowed in formal parameter
 > 1 | function *g(){ async (x = [yield]) => z }
-    |                                    ^^ Yield expression not allowed in formal parameter"
+    |                            ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *g(){ async (x = {[yield y]: 1}) => z } 1`] = `
-"SyntaxError [1:42-1:44]: Yield expression not allowed in formal parameter
+"SyntaxError [1:28-1:33]: Yield expression not allowed in formal parameter
 > 1 | function *g(){ async (x = {[yield y]: 1}) => z }
-    |                                           ^^ Yield expression not allowed in formal parameter"
+    |                             ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *g(){ async (x = {[yield]: 1}) => z } 1`] = `
-"SyntaxError [1:40-1:42]: Yield expression not allowed in formal parameter
+"SyntaxError [1:28-1:33]: Yield expression not allowed in formal parameter
 > 1 | function *g(){ async (x = {[yield]: 1}) => z }
-    |                                         ^^ Yield expression not allowed in formal parameter"
+    |                             ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *g(a, b, c, ...yield){} 1`] = `
-"SyntaxError [1:29-1:30]: Yield expression not allowed in formal parameter
+"SyntaxError [1:24-1:29]: Yield expression not allowed in formal parameter
 > 1 | function *g(a, b, c, ...yield){}
-    |                              ^ Yield expression not allowed in formal parameter"
+    |                         ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *gf() { (a = (yield) => {}) => {}; } 1`] = `
@@ -759,15 +759,15 @@ exports[`Expressions - Yield > Expressions - Yield (fail) > function *gf({yield}
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *gf(a = (10, yield, 20)) {} 1`] = `
-"SyntaxError [1:27-1:28]: Yield expression not allowed in formal parameter
+"SyntaxError [1:22-1:27]: Yield expression not allowed in formal parameter
 > 1 | function *gf(a = (10, yield, 20)) {}
-    |                            ^ Yield expression not allowed in formal parameter"
+    |                       ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *gf(b, a = 1 + yield) {} 1`] = `
-"SyntaxError [1:29-1:30]: Yield expression not allowed in formal parameter
+"SyntaxError [1:24-1:29]: Yield expression not allowed in formal parameter
 > 1 | function *gf(b, a = 1 + yield) {}
-    |                              ^ Yield expression not allowed in formal parameter"
+    |                         ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function *gf(b, yield) {} 1`] = `
@@ -777,15 +777,15 @@ exports[`Expressions - Yield > Expressions - Yield (fail) > function *gf(b, yiel
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function f(){  class x{*foo(a=yield x){}}  } 1`] = `
-"SyntaxError [1:36-1:37]: Yield expression not allowed in formal parameter
+"SyntaxError [1:30-1:35]: Yield expression not allowed in formal parameter
 > 1 | function f(){  class x{*foo(a=yield x){}}  }
-    |                                     ^ Yield expression not allowed in formal parameter"
+    |                               ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function f(){  class x{*foo(a=yield){}}  } 1`] = `
-"SyntaxError [1:35-1:36]: Yield expression not allowed in formal parameter
+"SyntaxError [1:30-1:35]: Yield expression not allowed in formal parameter
 > 1 | function f(){  class x{*foo(a=yield){}}  }
-    |                                    ^ Yield expression not allowed in formal parameter"
+    |                               ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function f(){  class x{foo(a=yield x){}}  } 1`] = `
@@ -825,27 +825,27 @@ exports[`Expressions - Yield > Expressions - Yield (fail) > function f(){  retur
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function f(){  return function*(x=yield y) {};  } 1`] = `
-"SyntaxError [1:40-1:41]: Yield expression not allowed in formal parameter
+"SyntaxError [1:34-1:39]: Yield expression not allowed in formal parameter
 > 1 | function f(){  return function*(x=yield y) {};  }
-    |                                         ^ Yield expression not allowed in formal parameter"
+    |                                   ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function f(){  return function*(x=yield) {};  } 1`] = `
-"SyntaxError [1:39-1:40]: Yield expression not allowed in formal parameter
+"SyntaxError [1:34-1:39]: Yield expression not allowed in formal parameter
 > 1 | function f(){  return function*(x=yield) {};  }
-    |                                        ^ Yield expression not allowed in formal parameter"
+    |                                   ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function f(){  x = {*foo(a=yield x){}}  } 1`] = `
-"SyntaxError [1:33-1:34]: Yield expression not allowed in formal parameter
+"SyntaxError [1:27-1:32]: Yield expression not allowed in formal parameter
 > 1 | function f(){  x = {*foo(a=yield x){}}  }
-    |                                  ^ Yield expression not allowed in formal parameter"
+    |                            ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function f(){  x = {*foo(a=yield){}}  } 1`] = `
-"SyntaxError [1:32-1:33]: Yield expression not allowed in formal parameter
+"SyntaxError [1:27-1:32]: Yield expression not allowed in formal parameter
 > 1 | function f(){  x = {*foo(a=yield){}}  }
-    |                                 ^ Yield expression not allowed in formal parameter"
+    |                            ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function f(){  x = {foo(a=yield x){}}  } 1`] = `
@@ -1017,39 +1017,39 @@ exports[`Expressions - Yield > Expressions - Yield (fail) > function* gf() { let
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function* gf() { var a = (x = yield 0) => { }; } 1`] = `
-"SyntaxError [1:39-1:41]: Yield expression not allowed in formal parameter
+"SyntaxError [1:30-1:35]: Yield expression not allowed in formal parameter
 > 1 | function* gf() { var a = (x = yield 0) => { }; }
-    |                                        ^^ Yield expression not allowed in formal parameter"
+    |                               ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function* gf() { var a = (x = yield) => { }; } 1`] = `
-"SyntaxError [1:37-1:39]: Yield expression not allowed in formal parameter
+"SyntaxError [1:30-1:35]: Yield expression not allowed in formal parameter
 > 1 | function* gf() { var a = (x = yield) => { }; }
-    |                                      ^^ Yield expression not allowed in formal parameter"
+    |                               ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function* gf() { var a = (x = yield* 0) => { }; } 1`] = `
-"SyntaxError [1:40-1:42]: Yield expression not allowed in formal parameter
+"SyntaxError [1:30-1:35]: Yield expression not allowed in formal parameter
 > 1 | function* gf() { var a = (x = yield* 0) => { }; }
-    |                                         ^^ Yield expression not allowed in formal parameter"
+    |                               ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function* gf() { var a = (x, y = yield 0, z = 0) => { }; } 1`] = `
-"SyntaxError [1:49-1:51]: Yield expression not allowed in formal parameter
+"SyntaxError [1:33-1:38]: Yield expression not allowed in formal parameter
 > 1 | function* gf() { var a = (x, y = yield 0, z = 0) => { }; }
-    |                                                  ^^ Yield expression not allowed in formal parameter"
+    |                                  ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function* gf() { var a = (x, y = yield* 0, z = 0) => { }; } 1`] = `
-"SyntaxError [1:50-1:52]: Yield expression not allowed in formal parameter
+"SyntaxError [1:33-1:38]: Yield expression not allowed in formal parameter
 > 1 | function* gf() { var a = (x, y = yield* 0, z = 0) => { }; }
-    |                                                   ^^ Yield expression not allowed in formal parameter"
+    |                                  ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function* gf() { var a = (x, y = yield, z = 0) => { }; } 1`] = `
-"SyntaxError [1:47-1:49]: Yield expression not allowed in formal parameter
+"SyntaxError [1:33-1:38]: Yield expression not allowed in formal parameter
 > 1 | function* gf() { var a = (x, y = yield, z = 0) => { }; }
-    |                                                ^^ Yield expression not allowed in formal parameter"
+    |                                  ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function* gf() { var a = (x, y, yield) => { }; } 1`] = `
@@ -1059,21 +1059,21 @@ exports[`Expressions - Yield > Expressions - Yield (fail) > function* gf() { var
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function* gf() { var a = (x, y, z = yield 0) => { }; } 1`] = `
-"SyntaxError [1:45-1:47]: Yield expression not allowed in formal parameter
+"SyntaxError [1:36-1:41]: Yield expression not allowed in formal parameter
 > 1 | function* gf() { var a = (x, y, z = yield 0) => { }; }
-    |                                              ^^ Yield expression not allowed in formal parameter"
+    |                                     ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function* gf() { var a = (x, y, z = yield) => { }; } 1`] = `
-"SyntaxError [1:43-1:45]: Yield expression not allowed in formal parameter
+"SyntaxError [1:36-1:41]: Yield expression not allowed in formal parameter
 > 1 | function* gf() { var a = (x, y, z = yield) => { }; }
-    |                                            ^^ Yield expression not allowed in formal parameter"
+    |                                     ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function* gf() { var a = (x, y, z = yield* 0) => { }; } 1`] = `
-"SyntaxError [1:46-1:48]: Yield expression not allowed in formal parameter
+"SyntaxError [1:36-1:41]: Yield expression not allowed in formal parameter
 > 1 | function* gf() { var a = (x, y, z = yield* 0) => { }; }
-    |                                               ^^ Yield expression not allowed in formal parameter"
+    |                                     ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function* gf() { var a = (x, yield, y) => { }; } 1`] = `
@@ -1263,21 +1263,21 @@ exports[`Expressions - Yield > Expressions - Yield (fail) > function*g(){ var yi
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function*g([yield]){} 1`] = `
-"SyntaxError [1:17-1:18]: Yield expression not allowed in formal parameter
+"SyntaxError [1:12-1:17]: Yield expression not allowed in formal parameter
 > 1 | function*g([yield]){}
-    |                  ^ Yield expression not allowed in formal parameter"
+    |             ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function*g([yield]){} 2`] = `
-"SyntaxError [1:17-1:18]: Yield expression not allowed in formal parameter
+"SyntaxError [1:12-1:17]: Yield expression not allowed in formal parameter
 > 1 | function*g([yield]){}
-    |                  ^ Yield expression not allowed in formal parameter"
+    |             ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function*g({a: yield}){} 1`] = `
-"SyntaxError [1:20-1:21]: Yield expression not allowed in formal parameter
+"SyntaxError [1:15-1:20]: Yield expression not allowed in formal parameter
 > 1 | function*g({a: yield}){}
-    |                     ^ Yield expression not allowed in formal parameter"
+    |                ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > function*g({yield}){} 1`] = `
@@ -1305,9 +1305,9 @@ exports[`Expressions - Yield > Expressions - Yield (fail) > function*g(yield){} 
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > gf = function* (b, a = yield) {} 1`] = `
-"SyntaxError [1:28-1:29]: Yield expression not allowed in formal parameter
+"SyntaxError [1:23-1:28]: Yield expression not allowed in formal parameter
 > 1 | gf = function* (b, a = yield) {}
-    |                             ^ Yield expression not allowed in formal parameter"
+    |                        ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > gf = function* (b, yield) {} 1`] = `
@@ -1335,9 +1335,9 @@ exports[`Expressions - Yield > Expressions - Yield (fail) > var g = function* yi
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > var obj = { *gf(b, a = yield) {} } 1`] = `
-"SyntaxError [1:28-1:29]: Yield expression not allowed in formal parameter
+"SyntaxError [1:23-1:28]: Yield expression not allowed in formal parameter
 > 1 | var obj = { *gf(b, a = yield) {} }
-    |                             ^ Yield expression not allowed in formal parameter"
+    |                        ^^^^^ Yield expression not allowed in formal parameter"
 `;
 
 exports[`Expressions - Yield > Expressions - Yield (fail) > var obj = { *gf(b, yield) {} } 1`] = `

--- a/test/parser/expressions/yield.ts
+++ b/test/parser/expressions/yield.ts
@@ -320,6 +320,24 @@ describe('Expressions - Yield', () => {
     });
   }
 
+  // The error is reported at the `yield` token, not at the `=>` or the token after it.
+  for (const { code, column } of [
+    { code: 'function* g() { async (a = yield, b = (c) => 1) => 1; }', column: 27 },
+    { code: 'function* g() { (a = yield) => 1; }', column: 21 },
+    { code: 'function* g() { async (a = 1, b = yield) => 1; }', column: 34 },
+    { code: 'function* g() { (a = (b = yield) => 1) => 1; }', column: 26 },
+    { code: 'function* g() { ([a = yield]) => 1; }', column: 22 },
+    { code: 'function* g(a = yield) {}', column: 16 },
+    { code: 'function* g([a = yield]) {}', column: 17 },
+    { code: 'class C { *g(a = yield) {} }', column: 17 },
+  ]) {
+    it(`${code} (location)`, () => {
+      t.throws(() => parseSource(code), {
+        loc: { start: { line: 1, column }, end: { line: 1, column: column + 5 } },
+      });
+    });
+  }
+
   for (const text of [
     // A generator without a body is valid.
     '',


### PR DESCRIPTION
`yield` errors in arrow parameters inside generators pointed at `=>`, and generator-parameter errors pointed at the token after `yield`.

This records `firstYieldLocation` alongside the await location and anchors the generator-parameter check at the consumed token, preserving accept/reject behavior.

The eight new location assertions fail before the fix and pass with it; 68 existing snapshots move onto `yield`, and the parser suite and test262 pass.

Some parameter lists with a nested function, method, class or async arrow after the offending `yield` still report at `=>`, matching the existing limitation on the await side.
